### PR TITLE
remove dead code in silu_and_mul kernel - creates output offsets (for 1D), expect n_elements param... but no need...

### DIFF
--- a/src/tilegym/ops/cutile/silu_and_mul.py
+++ b/src/tilegym/ops/cutile/silu_and_mul.py
@@ -90,9 +90,6 @@ def silu_and_mul(
     # Flatten input to 2D: (batch_size, 2 * hidden_size)
     input_flat = input.view(-1, original_shape[-1])
     batch_size = input_flat.shape[0]
-    n_elements = (
-        batch_size * hidden_size
-    )  # Total elements to process in output
 
     # Get final output shape
     output_shape = list(original_shape)
@@ -124,7 +121,6 @@ def silu_and_mul(
             input_flat,
             output,
             TILE_SIZE,
-            n_elements,
             hidden_size
         ),
     )


### PR DESCRIPTION
remove dead code:
~~~
out_offsets = bid * hidden_size + offsets
~~~

computes this but never used since kernel is 2D.
Similarly, the input param:
n_elements
is never used so doesn't need to be in the signature. 

Left over from 1D original work? 



