### PR TITLE
Move benchmark tests to json output

### DIFF
--- a/.github/infra_overview.md
+++ b/.github/infra_overview.md
@@ -19,7 +19,7 @@ This directory contains CI/CD workflows, utility scripts, and infrastructure tes
 
 **Test Results:**
 - **ops-test-results:** JUnit XML + HTML report with test pass/fail status (visible in "Checks" tab)
-- **benchmark-results:** Individual `*_results.txt` files containing performance tables with TFLOPS/GBps metrics for each benchmark (downloadable artifacts)
+- **benchmark-results:** Individual `*_results.json` files containing structured performance data with TFLOPS/GBps metrics for each benchmark (downloadable artifacts)
 - **Benchmark summary:** Formatted markdown tables visible in the workflow "Summary" tab
 
 ---

--- a/.github/workflows/tilegym-ci.yml
+++ b/.github/workflows/tilegym-ci.yml
@@ -316,8 +316,8 @@ jobs:
           echo "Contents of test-results directory:"
           ls -lah ${{ github.workspace }}/test-results/ || echo "Directory does not exist"
           echo ""
-          echo "Files matching *_results.txt:"
-          ls -lh ${{ github.workspace }}/test-results/*_results.txt 2>/dev/null || echo "No matching files found"
+          echo "Files matching *_results.json:"
+          ls -lh ${{ github.workspace }}/test-results/*_results.json 2>/dev/null || echo "No matching files found"
 
       - name: Format benchmark summary
         if: always()
@@ -328,7 +328,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
-          path: test-results/*_results.txt
+          path: test-results/*_results.json
           retention-days: 30
 
   promote-to-latest:

--- a/tests/benchmark/run_all.sh
+++ b/tests/benchmark/run_all.sh
@@ -32,21 +32,18 @@ for file in bench_*.py; do
     fi
     
     benchmark_name=$(basename "$file" .py)
-    output_file="$OUTPUT_DIR/${benchmark_name}_results.txt"
+    output_json="$OUTPUT_DIR/${benchmark_name}_results.json"
     
     echo "=========================================="
     echo "Running $file..."
     echo "=========================================="
     
-    # Ensure output file is created even if benchmark produces no output
-    touch "$output_file"
-    
-    if python "$file" 2>&1 | tee "$output_file"; then
+    # Run benchmark and capture output as JSON
+    if python "$(dirname "$0")/run_with_json.py" "$file" "$output_json"; then
         echo "✓ PASSED: $file"
-        echo "  Results saved to: $output_file"
+        echo "  Results saved to: $output_json"
     else
         echo "✗ FAILED: $file"
-        echo "FAILED" > "$output_file"
         exit 1  # Exit with error if any benchmark fails
     fi
     echo ""
@@ -56,5 +53,5 @@ echo "=========================================="
 echo "All benchmarks complete!"
 echo "Results directory: $OUTPUT_DIR"
 echo "Files created:"
-ls -lh "$OUTPUT_DIR"/*_results.txt 2>/dev/null || echo "  No result files found"
+ls -lh "$OUTPUT_DIR"/*_results.json 2>/dev/null || echo "  No result files found"
 echo "=========================================="

--- a/tests/benchmark/run_with_json.py
+++ b/tests/benchmark/run_with_json.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""Wrapper to run benchmark and save output as JSON"""
+
+import json
+import re
+import subprocess
+import sys
+
+
+def parse_triton_table(output):
+    """Parse Triton benchmark table output into structured JSON"""
+    results = []
+    
+    # Split into sections by benchmark name (lines ending with unit like -TFLOPS: or -GBps:)
+    sections = re.split(r'\n(?=[a-zA-Z][\w-]+-(?:TFLOPS|GBps|GB/s):)', output)
+    
+    for section in sections:
+        if not section.strip():
+            continue
+            
+        lines = section.strip().split('\n')
+        if len(lines) < 2:
+            continue
+        
+        # First line is benchmark name and unit
+        header_match = re.match(r'([\w-]+)-(TFLOPS|GBps|GB/s):', lines[0])
+        if not header_match:
+            continue
+            
+        benchmark_name = header_match.group(1)
+        unit = header_match.group(2)
+        
+        # Second line is column headers
+        if len(lines) < 2:
+            continue
+        headers = lines[1].split()
+        
+        # Remaining lines are data
+        data_rows = []
+        for line in lines[2:]:
+            if not line.strip() or line.strip().startswith('-'):
+                continue
+            values = line.split()
+            if len(values) >= len(headers):
+                row = {headers[i]: float(values[i]) if i > 0 else values[i] 
+                       for i in range(len(headers))}
+                data_rows.append(row)
+        
+        if data_rows:
+            results.append({
+                "benchmark": benchmark_name,
+                "unit": unit,
+                "columns": headers,
+                "data": data_rows
+            })
+    
+    return results
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: run_with_json.py <benchmark_file.py> <output.json>")
+        sys.exit(1)
+    
+    benchmark_file = sys.argv[1]
+    output_json = sys.argv[2]
+    
+    # Run the benchmark
+    try:
+        result = subprocess.run(
+            [sys.executable, benchmark_file],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        stdout = result.stdout
+        
+        # Print stdout for debugging (visible in CI logs)
+        print(stdout)
+        
+        # Parse into JSON
+        parsed = parse_triton_table(stdout)
+        
+        # Save JSON
+        with open(output_json, 'w') as f:
+            json.dump(parsed, f, indent=2)
+        
+        sys.exit(0)
+        
+    except subprocess.CalledProcessError as e:
+        print(f"Benchmark failed: {e}", file=sys.stderr)
+        print(e.stdout, file=sys.stderr)
+        print(e.stderr, file=sys.stderr)
+        
+        # Save error as JSON
+        with open(output_json, 'w') as f:
+            json.dump({"error": str(e), "stderr": e.stderr}, f, indent=2)
+        
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->

Use json artifacts for ease of parsing rather than .txt files for benchmark outputs

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: ["ops", "benchmark"]
```

## Checklist
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

