### PR TITLE
Add automatic header checks and formatting

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. 
+#
+# SPDX-License-Identifier: MIT 
+
 enabled: true
 auto_sync_draft: false
 auto_sync_ready: true

--- a/.github/infra_overview.md
+++ b/.github/infra_overview.md
@@ -1,3 +1,7 @@
+<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->
+
+<!--- SPDX-License-Identifier: MIT --->
+
 # GitHub Workflows & Infrastructure
 
 This directory contains CI/CD workflows, utility scripts, and infrastructure tests for the TileGym repository.
@@ -29,7 +33,8 @@ This directory contains CI/CD workflows, utility scripts, and infrastructure tes
 **Infrastructure validation** - Ensures code quality and validates CI scripts.
 
 **Jobs:**
-- `python-formatting` - Runs `darker` with `isort` for incremental formatting checks
+- `python-formatting` - Runs `ruff` for import sorting and format checks
+- `spdx-headers-check` - Verifies all source files have SPDX license headers
 - `utility-scripts-tests` - Runs pytest on all infrastructure tests
 
 **Triggers:** Push to `main`, push to `pull-request/*` branches
@@ -65,6 +70,7 @@ Located in `scripts/`, these Python utilities are used by workflows:
 - **`check_image_exists.py`** - Check if Docker images exist in GHCR
 - **`cleanup_stale_images.py`** - Delete stale Docker images from GHCR
 - **`format_benchmark_summary.py`** - Parse benchmark results and format as markdown tables for GitHub Actions summary
+- **`check_spdx_headers.py`** - Check and add SPDX license headers to source files
 - **`utils.py`** - Shared utilities (GitHub token, API headers, outputs)
 
 All scripts have comprehensive docstrings and are fully tested.
@@ -78,6 +84,7 @@ Located in `infra_tests/`, these pytest-based tests validate all CI scripts incl
 - PR config parsing logic
 - Image existence checks and latest tag validation
 - Image cleanup logic (verified tag preservation, untracked image detection)
+- SPDX header detection and addition
 - Shared utility functions
 
 **Run locally:**
@@ -86,6 +93,15 @@ pytest .github/infra_tests/ -v
 ```
 
 Tests are independent of the main TileGym package (no torch/CUDA dependencies).
+
+**Check SPDX headers locally:**
+```bash
+# Check all files have headers
+python3 .github/scripts/check_spdx_headers.py --action check
+
+# Add missing headers
+python3 .github/scripts/check_spdx_headers.py --action write
+```
 
 **Test results:** Available in GitHub Actions UI under "Checks" tab and as downloadable artifacts (`infra-test-results`).
 

--- a/.github/infra_tests/test_check_image_exists.py
+++ b/.github/infra_tests/test_check_image_exists.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Unit tests for check_image_exists.py"""
 
 import json

--- a/.github/infra_tests/test_check_spdx_headers.py
+++ b/.github/infra_tests/test_check_spdx_headers.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for check_spdx_headers.py script."""
+
+import sys
+import tempfile
+from pathlib import Path
+
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from check_spdx_headers import create_header
+from check_spdx_headers import get_comment_style
+from check_spdx_headers import has_spdx_header
+from check_spdx_headers import should_skip_file
+
+
+def test_has_spdx_header():
+    """Test SPDX header detection."""
+    # Content with header
+    content_with_header = """# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import sys
+"""
+    assert has_spdx_header(content_with_header)
+
+    # Content without header
+    content_without_header = """import sys
+print("hello")
+"""
+    assert not has_spdx_header(content_without_header)
+
+
+def test_create_header_python():
+    """Test header creation for Python files."""
+    header = create_header("#", "#", "")
+    assert len(header) == 4  # 3 lines + blank line
+    assert "SPDX-FileCopyrightText" in header[0]
+    assert "SPDX-License-Identifier" in header[2]
+
+
+def test_create_header_markdown():
+    """Test header creation for Markdown files."""
+    header = create_header("<!---", "", "--->")
+    assert len(header) == 4  # 3 lines + blank line
+    assert "<!---" in header[0]
+    assert "--->" in header[0]
+
+
+def test_get_comment_style():
+    """Test comment style detection."""
+    # Python file
+    py_file = Path("test.py")
+    assert get_comment_style(py_file) == ("#", "#", "")
+
+    # Markdown file
+    md_file = Path("README.md")
+    assert get_comment_style(md_file) == ("<!---", "", "--->")
+
+    # Shell script
+    sh_file = Path("script.sh")
+    assert get_comment_style(sh_file) == ("#", "#", "")
+
+    # Dockerfile
+    dockerfile = Path("Dockerfile")
+    assert get_comment_style(dockerfile) == ("#", "#", "")
+
+    # Unknown extension
+    unknown_file = Path("file.xyz")
+    assert get_comment_style(unknown_file) is None
+
+
+def test_should_skip_file():
+    """Test file skipping logic."""
+    # Should skip compiled files
+    assert should_skip_file(Path("test.pyc"))
+    assert should_skip_file(Path("__pycache__/test.py"))
+
+    # Should skip .git directory files
+    assert should_skip_file(Path(".git/config"))
+
+    # Should NOT skip .github directory files
+    assert not should_skip_file(Path(".github/workflows/ci.yml"))
+    assert not should_skip_file(Path(".github/scripts/utils.py"))
+
+    # Should not skip source files
+    assert not should_skip_file(Path("test.py"))
+    assert not should_skip_file(Path("README.md"))
+
+
+def test_integration_write_and_check():
+    """Integration test: write and check headers."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_file = Path(tmpdir) / "test.py"
+
+        # Create a file without header
+        test_file.write_text("import sys\nprint('hello')\n")
+
+        # Import the functions
+        from check_spdx_headers import add_header_to_file
+        from check_spdx_headers import check_file
+
+        # Check that it's missing header
+        assert not check_file(test_file)
+
+        # Add header
+        comment_style = get_comment_style(test_file)
+        assert add_header_to_file(test_file, comment_style)
+
+        # Check that it now has header
+        assert check_file(test_file)
+
+        # Verify content
+        content = test_file.read_text()
+        assert "SPDX-FileCopyrightText" in content
+        assert "SPDX-License-Identifier: MIT" in content
+        assert "import sys" in content  # Original content preserved
+
+
+def test_shebang_preservation():
+    """Test that shebang lines are preserved at the top."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_file = Path(tmpdir) / "test.sh"
+
+        # Create a file with shebang
+        test_file.write_text("#!/bin/bash\necho 'hello'\n")
+
+        from check_spdx_headers import add_header_to_file
+
+        # Add header
+        comment_style = ("#", "#", "")
+        add_header_to_file(test_file, comment_style)
+
+        # Verify shebang is still first line
+        content = test_file.read_text()
+        lines = content.split("\n")
+        assert lines[0] == "#!/bin/bash"
+        assert "SPDX-FileCopyrightText" in lines[1]
+
+
+if __name__ == "__main__":
+    # Run basic tests
+    test_has_spdx_header()
+    test_create_header_python()
+    test_create_header_markdown()
+    test_get_comment_style()
+    test_should_skip_file()
+    test_integration_write_and_check()
+    test_shebang_preservation()
+    print("✅ All tests passed!")

--- a/.github/infra_tests/test_cleanup_stale_images.py
+++ b/.github/infra_tests/test_cleanup_stale_images.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Unit tests for cleanup_stale_images.py"""
 
 import os

--- a/.github/infra_tests/test_format_benchmark_summary.py
+++ b/.github/infra_tests/test_format_benchmark_summary.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Unit tests for format_benchmark_summary.py"""
 
 import os

--- a/.github/infra_tests/test_parse_pr_config.py
+++ b/.github/infra_tests/test_parse_pr_config.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Unit tests for parse_pr_config.py"""
 
 import os

--- a/.github/infra_tests/test_utils.py
+++ b/.github/infra_tests/test_utils.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Unit tests for utils.py"""
 
 import os

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->
+
+<!--- SPDX-License-Identifier: MIT --->
+
 ## Description
 <!-- Describe your changes here -->
 

--- a/.github/scripts/check_image_exists.py
+++ b/.github/scripts/check_image_exists.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """
 Check if a Docker image with a specific tag exists in GHCR.
 

--- a/.github/scripts/check_spdx_headers.py
+++ b/.github/scripts/check_spdx_headers.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Script to check and add SPDX license headers to source files.
+
+Usage:
+    python check_spdx_headers.py --action check
+    python check_spdx_headers.py --action write
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+# SPDX header content
+SPDX_COPYRIGHT = "SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved."
+SPDX_LICENSE = "SPDX-License-Identifier: MIT"
+
+
+# Comment styles for different file types
+COMMENT_STYLES: Dict[str, Tuple[str, str, str]] = {
+    # Extension: (prefix, middle, suffix)
+    # For single-line comments: prefix is the comment marker, middle/suffix are empty
+    # For multi-line comments: prefix is opening, middle is for middle lines, suffix is closing
+    # Python, Shell, YAML, Makefile, etc.
+    ".py": ("#", "#", ""),
+    ".sh": ("#", "#", ""),
+    ".yml": ("#", "#", ""),
+    ".yaml": ("#", "#", ""),
+    ".mk": ("#", "#", ""),
+    # Markdown
+    ".md": ("<!---", "", "--->"),
+    # C/C++/CUDA (using C++ style comments)
+    ".c": ("//", "//", ""),
+    ".h": ("//", "//", ""),
+    ".cpp": ("//", "//", ""),
+    ".hpp": ("//", "//", ""),
+    ".cu": ("//", "//", ""),
+    ".cuh": ("//", "//", ""),
+    # JavaScript/TypeScript
+    ".js": ("//", "//", ""),
+    ".ts": ("//", "//", ""),
+    ".jsx": ("//", "//", ""),
+    ".tsx": ("//", "//", ""),
+    # CSS
+    ".css": ("/*", " *", " */"),
+    # HTML/XML
+    ".html": ("<!--", "", "-->"),
+    ".xml": ("<!--", "", "-->"),
+    # Dockerfile
+    "Dockerfile": ("#", "#", ""),
+    # TOML, INI
+    ".toml": ("#", "#", ""),
+    ".ini": ("#", "#", ""),
+}
+
+
+def should_skip_file(file_path: Path) -> bool:
+    """Check if a file should be skipped."""
+    path_str = str(file_path)
+
+    # Skip .git directory specifically (but not .github)
+    if ".git" in file_path.parts:
+        return True
+
+    # Skip files by exact name match
+    exact_match_patterns = ["LICENSE", "ATTRIBUTIONS.md", "CLA.md", ".gitignore", ".cursorignore"]
+    if file_path.name in exact_match_patterns:
+        return True
+
+    # Skip directories
+    dir_patterns = ["__pycache__", ".pytest_cache", "node_modules", "venv", "env", ".egg-info", "dist", "build"]
+    for pattern in dir_patterns:
+        if pattern in file_path.parts:
+            return True
+
+    # Skip by file extension
+    skip_extensions = [
+        ".pyc",
+        ".pyo",
+        ".so",
+        ".o",
+        ".a",
+        ".lib",
+        ".dll",
+        ".dylib",
+        ".idx",
+        ".pack",
+        ".rev",
+        ".sample",
+        ".TAG",
+    ]
+    if file_path.suffix in skip_extensions:
+        return True
+
+    # Skip files without extensions that aren't Dockerfile
+    if not file_path.suffix and file_path.name != "Dockerfile":
+        return True
+
+    return False
+
+
+def get_comment_style(file_path: Path) -> Optional[Tuple[str, str, str]]:
+    """Get the comment style for a given file."""
+    # Check for Dockerfile specifically
+    if file_path.name == "Dockerfile":
+        return COMMENT_STYLES.get("Dockerfile")
+
+    # Check by extension
+    return COMMENT_STYLES.get(file_path.suffix)
+
+
+def create_header(prefix: str, middle: str, suffix: str) -> List[str]:
+    """Create the SPDX header lines based on comment style."""
+    lines = []
+
+    if middle:
+        # Multi-line comment style (e.g., CSS, HTML)
+        lines.append(f"{prefix} {SPDX_COPYRIGHT} {suffix}\n")
+        lines.append(f"{middle}\n")
+        lines.append(f"{prefix} {SPDX_LICENSE} {suffix}\n")
+    else:
+        # Single-line comment style (e.g., Python, Shell, Markdown)
+        if prefix == "<!---":
+            # Special case for Markdown
+            lines.append(f"{prefix} {SPDX_COPYRIGHT} {suffix}\n")
+            lines.append("\n")
+            lines.append(f"{prefix} {SPDX_LICENSE} {suffix}\n")
+        else:
+            # Standard single-line comments
+            lines.append(f"{prefix} {SPDX_COPYRIGHT}\n")
+            lines.append(f"{prefix}\n")
+            lines.append(f"{prefix} {SPDX_LICENSE}\n")
+
+    lines.append("\n")
+    return lines
+
+
+def has_spdx_header(content: str) -> bool:
+    """Check if content already has SPDX headers."""
+    # Check for both required strings within the first 10 lines
+    first_lines = "\n".join(content.split("\n")[:10])
+    return SPDX_COPYRIGHT in first_lines and SPDX_LICENSE in first_lines
+
+
+def add_header_to_file(file_path: Path, comment_style: Tuple[str, str, str]) -> bool:
+    """Add SPDX header to a file if missing."""
+    try:
+        # Read existing content
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Check if header already exists
+        if has_spdx_header(content):
+            return False
+
+        # Create header
+        header_lines = create_header(*comment_style)
+
+        # Handle shebang lines (keep them at the top)
+        lines = content.split("\n")
+        if lines and lines[0].startswith("#!"):
+            # Keep shebang, add header after it
+            shebang = lines[0] + "\n"
+            rest = "\n".join(lines[1:])
+            new_content = shebang + "".join(header_lines) + rest
+        else:
+            # Add header at the beginning
+            new_content = "".join(header_lines) + content
+
+        # Write back
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(new_content)
+
+        return True
+
+    except Exception as e:
+        print(f"Error processing {file_path}: {e}", file=sys.stderr)
+        return False
+
+
+def check_file(file_path: Path) -> bool:
+    """Check if a file has the SPDX header."""
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        return has_spdx_header(content)
+    except Exception as e:
+        print(f"Error reading {file_path}: {e}", file=sys.stderr)
+        return True  # Skip files we can't read
+
+
+def find_files(root_dir: Path) -> List[Path]:
+    """Find all files that should have SPDX headers."""
+    files = []
+
+    for path in root_dir.rglob("*"):
+        if not path.is_file():
+            continue
+
+        if should_skip_file(path):
+            continue
+
+        comment_style = get_comment_style(path)
+        if comment_style is None:
+            continue
+
+        files.append(path)
+
+    return files
+
+
+def action_write(root_dir: Path) -> int:
+    """Add SPDX headers to files that are missing them."""
+    files = find_files(root_dir)
+    modified_count = 0
+
+    for file_path in files:
+        comment_style = get_comment_style(file_path)
+        if comment_style is None:
+            continue
+
+        if add_header_to_file(file_path, comment_style):
+            print(f"Added header to: {file_path.relative_to(root_dir)}")
+            modified_count += 1
+
+    print(f"\nModified {modified_count} file(s)")
+    return 0
+
+
+def action_check(root_dir: Path) -> int:
+    """Check that all files have SPDX headers."""
+    files = find_files(root_dir)
+    missing_headers = []
+
+    for file_path in files:
+        if not check_file(file_path):
+            missing_headers.append(file_path)
+
+    if missing_headers:
+        print("❌ The following files are missing SPDX headers:\n")
+        for file_path in missing_headers:
+            print(f"  {file_path.relative_to(root_dir)}")
+        print(f"\n{len(missing_headers)} file(s) missing headers")
+        print("\nRun with --action write to add headers automatically")
+        return 1
+    else:
+        print("✅ All files have SPDX headers")
+        return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check and add SPDX license headers to source files")
+    parser.add_argument(
+        "--action",
+        choices=["check", "write"],
+        required=True,
+        help="Action to perform: check (verify headers exist) or write (add missing headers)",
+    )
+    parser.add_argument(
+        "--root", type=Path, default=None, help="Root directory to search (defaults to repository root)"
+    )
+
+    args = parser.parse_args()
+
+    # Determine root directory
+    if args.root:
+        root_dir = args.root.resolve()
+    else:
+        # Find repository root (look for .git directory)
+        script_dir = Path(__file__).parent
+        root_dir = script_dir.parent.parent
+
+    if not root_dir.exists():
+        print(f"Error: Root directory does not exist: {root_dir}", file=sys.stderr)
+        return 1
+
+    print(f"Searching in: {root_dir}\n")
+
+    if args.action == "check":
+        return action_check(root_dir)
+    elif args.action == "write":
+        return action_write(root_dir)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/cleanup_stale_images.py
+++ b/.github/scripts/cleanup_stale_images.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """
 Clean up stale Docker images from GHCR.
 

--- a/.github/scripts/format_benchmark_summary.py
+++ b/.github/scripts/format_benchmark_summary.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """
 Parse benchmark results and format them as markdown for GitHub Actions summary.
 

--- a/.github/scripts/parse_pr_config.py
+++ b/.github/scripts/parse_pr_config.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """
 Parse CI configuration from PR body.
 

--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """
 Shared utilities for GitHub Actions scripts.
 """

--- a/.github/workflows/tilegym-ci-infra-tests.yml
+++ b/.github/workflows/tilegym-ci-infra-tests.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. 
+#
+# SPDX-License-Identifier: MIT 
+
 name: tilegym-ci-infra-tests
 
 on:
@@ -29,6 +33,19 @@ jobs:
       
       - name: Run ruff format check
         run: ruff format --check --diff .
+
+  spdx-headers-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      
+      - name: Check SPDX headers
+        run: python3 .github/scripts/check_spdx_headers.py --action check
 
   utility-scripts-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tilegym-ci.yml
+++ b/.github/workflows/tilegym-ci.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. 
+#
+# SPDX-License-Identifier: MIT 
+
 name: tilegym-ci
 
 on:

--- a/.github/workflows/tilegym-ghcr-cleanup.yml
+++ b/.github/workflows/tilegym-ghcr-cleanup.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. 
+#
+# SPDX-License-Identifier: MIT 
+
 name: tilegym-ghcr-cleanup
 
 on:

--- a/format.sh
+++ b/format.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. 
+#
+# SPDX-License-Identifier: MIT 
+
 # Quick formatting script for TileGym development
 # Formats code and sorts imports using ruff
 
@@ -13,6 +17,10 @@ if ! python3 -m ruff --version 2>/dev/null | grep -q "$RUFF_VERSION"; then
 fi
 
 echo ""
+echo "📝 Adding SPDX headers to files..."
+python3 .github/scripts/check_spdx_headers.py --action write
+
+echo ""
 echo "📋 Sorting imports..."
 python3 -m ruff check --select I --fix .
 
@@ -21,5 +29,5 @@ echo "✨ Formatting code..."
 python3 -m ruff format .
 
 echo ""
-echo "✅ Done! Code is formatted and imports are sorted."
+echo "✅ Done! SPDX headers added, code is formatted, and imports are sorted."
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. 
+#
+# SPDX-License-Identifier: MIT 
+
 [tool:pytest]
 testpaths = tests
 python_files = test_*.py


### PR DESCRIPTION
## Description
<!-- Describe your changes here -->

- Add new utility script to check for license headers, as well as automatically write them out if they don't exist
- Update `format.sh` to run this action in addition to ruff
- Update infra tests to run the `--check` action to confirm that headers exist

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: false
  # valid options are "ops" and "benchmark"
  test: []
```

## Checklist
- [ ] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

