### PR TITLE
Standardize softmax.py to avoid numpy dependency

### DIFF
--- a/src/tilegym/ops/cutile/softmax.py
+++ b/src/tilegym/ops/cutile/softmax.py
@@ -27,7 +27,7 @@ def softmax_kernel(
     # Static persistent scheduling: each block processes multiple rows
     pid = ct.bid(0)
     num_programs = ct.num_blocks(0)
-    offsets = ct.arange(TILE_SIZE, dtype=torch.int32)
+    offsets = ct.arange(TILE_SIZE, dtype=ct.int32)
 
     for row_idx in range(pid, n_rows, num_programs):
         # Load the row tile using index-based access


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
Updates softmax.py to be internally consistent with other tilegym kernels ala attention.py by removing the numpy import dependency and use -math.inf and ct.float32. (vs -np.inf and np.float32).
This also updates to use the ct dtypes (ct.float32 and ct.int32) to replace torch.int32 and torch.float32 to further standardize dtypes. 

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: ["ops"]
```

## Checklist
- [ X ] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

