### PR TITLE
fix: remove deadcode adding bias since it's not supported

### DIFF
--- a/src/tilegym/ops/cutile/rms_norm.py
+++ b/src/tilegym/ops/cutile/rms_norm.py
@@ -109,11 +109,9 @@ def rms_norm_kernel_static_persistent(
         # Step 6: Apply linear transformation
         # Broadcast weight to match input shape
         w_broadcasted = ct.reshape(w, (1, TILE_SIZE_N))
-        b_broadcasted = ct.full((1, TILE_SIZE_N), 0.0, dtype=ct.float32)
 
-        # Apply linear transformation: y = x_normalized * w + b
+        # Apply linear transformation: y = x_normalized * w
         y = ct.mul(x_normalized, w_broadcasted)
-        y = ct.add(y, b_broadcasted)
 
         # Convert back to original dtype
         y = ct.astype(y, X.dtype)


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->

This PR removes a piece of dead code that was adding a tile of float32 zeros, followed by an immediate cast back to the original dtype. This operation is a no-op and unnecessary.

In addition, this kernel does not support a bias term, so performing an extra addition provides no functional benefit and only adds overhead/confusion on why it exists.

I ran the benchmark and the performance is basically identical before and after. Ran on B200 GPU


## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: []
```

## Checklist
- [x] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

