### PR TITLE
[fix] Update benchmark sparse checkout

### DIFF
--- a/.github/workflows/tilegym-ci.yml
+++ b/.github/workflows/tilegym-ci.yml
@@ -292,9 +292,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
-            .github/scripts/format_benchmark_summary.py
-            .github/scripts/check_benchmark_regression.py
-            .github/scripts/merge_baseline_selective.py
+            .github/scripts
             tests/benchmark
           sparse-checkout-cone-mode: false
 


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->
Add github scripts to benchmark sparse checkout

Fixes error from https://github.com/NVIDIA/TileGym/actions/runs/20780943983/job/59678464400

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: false
  # valid options are "ops" and "benchmark"
  test: []
```

## Checklist
- [x] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [x] Documentation updated (if needed)
- [x] CI configuration reviewed

