### PR TITLE
fix: use relative paths for benchmark names in JSON runner and CI summary

### DIFF
--- a/.github/scripts/format_benchmark_summary.py
+++ b/.github/scripts/format_benchmark_summary.py
@@ -197,7 +197,22 @@ def format_benchmark_summary(results_dir):
         summary += gpu_section
 
     for result_file in result_files:
-        benchmark_name = result_file.stem.replace("_results", "").replace("_", " ").title()
+        if file_format == "json":
+            # For JSON files, try to read the benchmark_file field (relative path)
+            # for a more informative display name
+            try:
+                with open(result_file) as f:
+                    header_data = json.load(f)
+                rel_path = header_data.get("benchmark_file", "")
+                if rel_path:
+                    benchmark_name = rel_path.replace(".py", "")
+                else:
+                    benchmark_name = result_file.stem.replace("_results", "").replace("_", " ").title()
+            except (json.JSONDecodeError, OSError):
+                benchmark_name = result_file.stem.replace("_results", "").replace("_", " ").title()
+        else:
+            benchmark_name = result_file.stem.replace("_results", "").replace("_", " ").title()
+
         summary += f"## {benchmark_name}\n\n"
 
         if file_format == "json":

--- a/tests/benchmark/run_all_json.py
+++ b/tests/benchmark/run_all_json.py
@@ -12,6 +12,7 @@ results in JSON format for easier processing and regression detection.
 
 import json
 import logging
+import os
 import re
 import subprocess
 import sys
@@ -274,17 +275,22 @@ def run_all_benchmarks(benchmark_files: List[Path], output_dir: Path) -> Tuple[D
     }
 
     failed_benchmarks = []
+    benchmark_dir = Path(__file__).parent
 
     for bench_file in benchmark_files:
+        rel_path = bench_file.relative_to(benchmark_dir)
+        safe_name = str(rel_path).replace(os.sep, "_").replace(".py", "")
+
         logger.info("=" * 60)
-        logger.info(f"Running {bench_file.name}...")
+        logger.info(f"Running {rel_path}...")
         logger.info("=" * 60)
 
         result = run_benchmark(bench_file)
+        result["benchmark_file"] = str(rel_path)
         all_results["benchmarks"].append(result)
 
         # Save individual result file
-        output_file = output_dir / f"{bench_file.stem}_results.json"
+        output_file = output_dir / f"{safe_name}_results.json"
         with open(output_file, "w") as f:
             json.dump(result, f, indent=2)
 
@@ -293,12 +299,12 @@ def run_all_benchmarks(benchmark_files: List[Path], output_dir: Path) -> Tuple[D
 
         # Log status
         if result["status"] == "PASSED":
-            logger.info(f"✓ PASSED: {bench_file.name}")
+            logger.info(f"✓ PASSED: {rel_path}")
             logger.info(f"  Results saved to: {output_file}")
         else:
-            logger.error(f"✗ FAILED: {bench_file.name}")
+            logger.error(f"✗ FAILED: {rel_path}")
             logger.info(f"  Error details saved to: {output_file}")
-            failed_benchmarks.append(bench_file.name)
+            failed_benchmarks.append(str(rel_path))
             # Log error preview (first 5 lines)
             error_lines = result.get("error", "Unknown error").split("\n")
             for line in error_lines[:5]:


### PR DESCRIPTION
## Summary

The JSON benchmark runner (`run_all_json.py`) used bare filenames (e.g., `bench_layernorm.py`) instead of relative paths (e.g., `suites/unsloth/bench_layernorm.py`). This caused:

- Ambiguous log output in CI making it hard to identify which benchmark ran
- Output file name collisions silently overwriting results (e.g., both `bench_layernorm.py` and `suites/unsloth/bench_layernorm.py` produce `bench_layernorm_results.json`)
- CI summary page showing duplicate names without directory context

The text format runner in `run_all.sh` already handled this correctly with `rel_path`. This PR brings the JSON runner and summary formatter to parity.

### Changes

**`tests/benchmark/run_all_json.py`**
- Compute relative paths from benchmark root directory
- Use `rel_path` in log messages, JSON `benchmark_file` field, and output filenames
- Output files now use `_`-separated paths (e.g., `suites_unsloth_bench_layernorm_results.json`) to avoid collisions

**`.github/scripts/format_benchmark_summary.py`**
- For JSON results, read the `benchmark_file` field (relative path) for section display names
- Summary now shows `suites/unsloth/bench_layernorm` instead of `Bench Layernorm`
- Falls back to filename-based naming for old-format results or TXT files

### Before vs After

| | Before | After |
|---|---|---|
| CI log | `Running bench_layernorm.py...` | `Running suites/unsloth/bench_layernorm.py...` |
| Output file | `bench_layernorm_results.json` (collision!) | `suites_unsloth_bench_layernorm_results.json` |
| Summary heading | `Bench Layernorm` (ambiguous) | `suites/unsloth/bench_layernorm` |

## Test plan

- [ ] CI benchmark job logs show relative paths for `experimental/` benchmarks
- [ ] No output file collisions when combined with #100 (which adds `suites/unsloth/` benchmarks)
- [ ] Summary page shows distinct names for benchmarks in different directories

## CI Configuration

```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: ["benchmark"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)