### PR TITLE
Update TileGym Julia kernels to cuTile 0.2

### DIFF
--- a/.claude/skills/converting-cutile-to-julia/SKILL.md
+++ b/.claude/skills/converting-cutile-to-julia/SKILL.md
@@ -25,7 +25,7 @@ julia/                          # Self-contained Julia sub-project
 ├── Project.toml                # Dependencies: CUDA.jl, cuTile.jl, NNlib.jl, Test
 ├── kernels/                    # cuTile.jl kernel implementations
 │   ├── add.jl                  # ← Ground-truth: 1D element-wise with alpha scaling (tensor+tensor, tensor+scalar)
-│   ├── matmul.jl               # ← Ground-truth: 2D tiled MMA, column-major layout (K,M)×(N,K)→(N,M)
+│   ├── matmul.jl               # ← Ground-truth: 2D tiled MMA, standard Julia layout (M,K)×(K,N)→(M,N)
 │   └── softmax.jl              # ← Ground-truth: 3 strategies (TMA, online, chunked) using ct.load/ct.store
 └── test/                       # Julia-native tests (using Test stdlib)
     ├── runtests.jl             # Test runner entry point
@@ -55,9 +55,9 @@ The most dangerous translation errors. Full rules (17 total) in [`references/cri
 
 | # | Pitfall | One-line fix |
 |---|---------|-------------|
-| 1 | `for` loops crash the compiler | Use `while` + `Int32` counter |
+| 1 | `ct.full()` doesn't exist in Julia | Use `fill(val, shape)`, `zeros(T, dims...)`, or `ones(T, dims...)` |
 | 2 | `max(a, b)` on tiles → `IRError` | Use `max.(a, b)` (broadcast dot) |
-| 3 | `Int32(runtime_val)` → `MethodError` | Use `ct.full((N,), val, Int32)` instead |
+| 3 | `IRError` / `MethodError` mentioning `IRStructurizer` | Compiler bug — file upstream with minimal reproducer |
 | 4 | `ct.launch` arg order silently wrong | Args are positional — match kernel signature exactly |
 | 5 | `ct.load` with `order` — index positions wrong | `order` remaps BOTH shape AND index (Critical Rule 16) |
 
@@ -67,9 +67,9 @@ Side-by-side Python → Julia conversions matching the released Julia kernels in
 
 | # | Example | Key Patterns | When to Reference |
 |---|---------|-------------|-------------------|
-| 01 | [`add`](examples/01_add/) | 1D `ct.load`/`ct.store`, alpha scaling, `ct.full`, broadcast `.+`/`.*` | Starting point; basic TMA + element-wise patterns |
-| 02 | [`matmul`](examples/02_matmul/) | `muladd`, TF32 conversion, K-loop with `while`, column-major layout | MMA / tensor core operations |
-| 03 | [`softmax`](examples/03_softmax/) | Persistent scheduling, column-chunked `ct.load`/`ct.store`, multi-pass | Large-tensor reduction patterns |
+| 01 | [`add`](examples/01_add/) | 1D `ct.load`/`ct.store`, alpha scaling, scalar broadcast, `fill`/`zeros`, keyword load/store | Starting point; basic TMA + element-wise patterns |
+| 02 | [`matmul`](examples/02_matmul/) | `muladd`, TF32 conversion, K-loop with `for`, 2D swizzle, standard Julia layout, `ct.@compiler_options` | MMA / tensor core operations |
+| 03 | [`softmax`](examples/03_softmax/) | Persistent scheduling, `for` loops, `gather`/`scatter`, `padding_mode`, multi-pass | Large-tensor reduction patterns |
 
 These match the released kernels in `julia/kernels/` (`add.jl`, `matmul.jl`, `softmax.jl`). The examples are simplified teaching versions — always consult `julia/kernels/*.jl` for the canonical, tested implementations.
 

--- a/.claude/skills/converting-cutile-to-julia/examples/01_add/cutile_julia.jl
+++ b/.claude/skills/converting-cutile-to-julia/examples/01_add/cutile_julia.jl
@@ -14,107 +14,77 @@ import cuTile as ct
 
 # ── Tensor + Tensor kernel: output = x + y * alpha ──────────────────────────
 
-function _add_kernel(x::ct.TileArray{T,1}, y::ct.TileArray{T,1},
-                     output::ct.TileArray{T,1},
-                     alpha::Float32, BLOCK_SIZE::Int) where {T}
+function add_kernel(x::ct.TileArray{T,1}, y::ct.TileArray{T,1},
+                    output::ct.TileArray{T,1},
+                    alpha::Float32, BLOCK_SIZE::Int) where {T}
     bid = ct.bid(1)
 
-    x_tile = ct.load(x, bid, (BLOCK_SIZE,))
-    y_tile = ct.load(y, bid, (BLOCK_SIZE,))
+    x_tile = ct.load(x; index=bid, shape=(BLOCK_SIZE,), padding_mode=ct.PaddingMode.Zero)
+    y_tile = ct.load(y; index=bid, shape=(BLOCK_SIZE,), padding_mode=ct.PaddingMode.Zero)
 
     x_f32 = convert(ct.Tile{Float32}, x_tile)
     y_f32 = convert(ct.Tile{Float32}, y_tile)
 
-    alpha_tile = ct.full((BLOCK_SIZE,), alpha, Float32)
-    y_scaled = y_f32 .* alpha_tile
-    output_f32 = x_f32 .+ y_scaled
-
-    ct.store(output, bid, convert(ct.Tile{T}, output_f32))
-    return nothing
+    # Scalar alpha broadcasts to tile shape automatically
+    output_f32 = x_f32 .+ y_f32 .* alpha
+    ct.store(output; index=bid, tile=convert(ct.Tile{T}, output_f32))
+    return
 end
 
 # ── Tensor + Scalar kernel: output = x + scalar_val * alpha ─────────────────
 
-function _add_scalar_kernel(x::ct.TileArray{T,1}, output::ct.TileArray{T,1},
-                            scalar_val::Float32, alpha::Float32,
-                            BLOCK_SIZE::Int) where {T}
+function add_scalar_kernel(x::ct.TileArray{T,1}, output::ct.TileArray{T,1},
+                           scalar_val::Float32, alpha::Float32,
+                           BLOCK_SIZE::Int) where {T}
     bid = ct.bid(1)
 
-    x_tile = ct.load(x, bid, (BLOCK_SIZE,))
+    x_tile = ct.load(x; index=bid, shape=(BLOCK_SIZE,), padding_mode=ct.PaddingMode.Zero)
     x_f32 = convert(ct.Tile{Float32}, x_tile)
 
-    scaled_scalar = scalar_val * alpha
-    scalar_tile = ct.full((BLOCK_SIZE,), scaled_scalar, Float32)
-    output_f32 = x_f32 .+ scalar_tile
-
-    ct.store(output, bid, convert(ct.Tile{T}, output_f32))
-    return nothing
+    output_f32 = x_f32 .+ (scalar_val * alpha)
+    ct.store(output; index=bid, tile=convert(ct.Tile{T}, output_f32))
+    return
 end
 
 # ── Host functions ───────────────────────────────────────────────────────────
 
-function add!(x_ptr::Int, y_ptr::Int, out_ptr::Int,
-              n_elements::Int, alpha::Float64)
-    BLOCK_SIZE = 1024
-    padded_n = cld(n_elements, BLOCK_SIZE) * BLOCK_SIZE
-
-    x_cu = unsafe_wrap(CuArray{Float32, 1}, CUDA.CuPtr{Float32}(UInt(x_ptr)),
-                       (padded_n,); own=false)
-    y_cu = unsafe_wrap(CuArray{Float32, 1}, CUDA.CuPtr{Float32}(UInt(y_ptr)),
-                       (padded_n,); own=false)
-    out_cu = unsafe_wrap(CuArray{Float32, 1}, CUDA.CuPtr{Float32}(UInt(out_ptr)),
-                         (padded_n,); own=false)
-
-    grid = cld(padded_n, BLOCK_SIZE)
-    ct.launch(_add_kernel, grid, x_cu, y_cu, out_cu,
-              ct.Constant(Float32(alpha)), ct.Constant(BLOCK_SIZE))
-
+function add!(output::CuVector{T}, x::CuVector{T}, y::CuVector{T};
+              alpha::Float32=1.0f0, block_size::Int=1024) where {T}
+    n = length(x)
+    grid = cld(n, block_size)
+    ct.launch(add_kernel, grid, x, y, output,
+              ct.Constant(alpha), ct.Constant(block_size))
     CUDA.synchronize()
-    return nothing
+    return
 end
 
-function add_scalar!(x_ptr::Int, out_ptr::Int,
-                     n_elements::Int, scalar_val::Float64, alpha::Float64)
-    BLOCK_SIZE = 1024
-    padded_n = cld(n_elements, BLOCK_SIZE) * BLOCK_SIZE
-
-    x_cu = unsafe_wrap(CuArray{Float32, 1}, CUDA.CuPtr{Float32}(UInt(x_ptr)),
-                       (padded_n,); own=false)
-    out_cu = unsafe_wrap(CuArray{Float32, 1}, CUDA.CuPtr{Float32}(UInt(out_ptr)),
-                         (padded_n,); own=false)
-
-    grid = cld(padded_n, BLOCK_SIZE)
-    ct.launch(_add_scalar_kernel, grid, x_cu, out_cu,
-              ct.Constant(Float32(scalar_val)), ct.Constant(Float32(alpha)),
-              ct.Constant(BLOCK_SIZE))
-
+function add_scalar!(output::CuVector{T}, x::CuVector{T}, scalar_val::Float32;
+                     alpha::Float32=1.0f0, block_size::Int=1024) where {T}
+    n = length(x)
+    grid = cld(n, block_size)
+    ct.launch(add_scalar_kernel, grid, x, output,
+              ct.Constant(scalar_val), ct.Constant(alpha), ct.Constant(block_size))
     CUDA.synchronize()
-    return nothing
+    return
 end
 
 # ── Verify ───────────────────────────────────────────────────────────────────
 
 function verify()
     for n in [128, 1024, 4096, 513]
-        BLOCK_SIZE = 1024
-        padded_n = cld(n, BLOCK_SIZE) * BLOCK_SIZE
-
         x = CUDA.rand(Float32, n)
         y = CUDA.rand(Float32, n)
+        out = CUDA.zeros(Float32, n)
 
-        x_padded = CUDA.zeros(Float32, padded_n)
-        y_padded = CUDA.zeros(Float32, padded_n)
-        out = CUDA.zeros(Float32, padded_n)
-        copyto!(view(x_padded, 1:n), x)
-        copyto!(view(y_padded, 1:n), y)
+        add!(out, x, y; alpha=1.0f0)
+        @assert Array(out) ≈ Array(x) .+ Array(y) atol=1e-5
 
-        add!(Int(pointer(x_padded)), Int(pointer(y_padded)),
-             Int(pointer(out)), padded_n, 1.0)
-        @assert Array(out[1:n]) ≈ Array(x) .+ Array(y) atol=1e-5
+        add!(out, x, y; alpha=0.5f0)
+        @assert Array(out) ≈ Array(x) .+ Array(y) .* 0.5f0 atol=1e-5
 
-        add!(Int(pointer(x_padded)), Int(pointer(y_padded)),
-             Int(pointer(out)), padded_n, 0.5)
-        @assert Array(out[1:n]) ≈ Array(x) .+ Array(y) .* 0.5f0 atol=1e-5
+        out_scalar = CUDA.zeros(Float32, n)
+        add_scalar!(out_scalar, x, 3.0f0; alpha=0.5f0)
+        @assert Array(out_scalar) ≈ Array(x) .+ (3.0f0 * 0.5f0) atol=1e-5
 
         println("  n=$n: passed")
     end

--- a/.claude/skills/converting-cutile-to-julia/examples/02_matmul/cutile_julia.jl
+++ b/.claude/skills/converting-cutile-to-julia/examples/02_matmul/cutile_julia.jl
@@ -3,77 +3,86 @@
 
 # Matrix multiplication — cuTile.jl
 #
-#   C = A @ B
+#   C = A * B
 #
-# Column-major layout: A_jl(K,M), B_jl(N,K), C_jl(N,M)
-#   C_jl[n,m] = sum_k B_jl[n,k] * A_jl[k,m]
-#   acc = muladd(b_tile, a_tile, acc)
+# Standard Julia layout (column-major):
+#   A(M, K), B(K, N), C(M, N)
 #
-# Uses 2D grid, K-reduction while loop, TF32 for Float32 inputs.
+# Uses 1D grid with 2D swizzle for better L2 cache locality.
 # Matches julia/kernels/matmul.jl
 
 using CUDA
 import cuTile as ct
 
-function _matmul_kernel(A_jl::ct.TileArray{T, 2},
-                        B_jl::ct.TileArray{T, 2},
-                        C_jl::ct.TileArray{T, 2},
-                        num_k_tiles::Int,
-                        TM::Int, TN::Int, TK::Int) where {T}
-    bid_m = ct.bid(1)
-    bid_n = ct.bid(2)
+# 2D swizzle for better L2 cache locality.
+# Groups blocks to access nearby memory regions together.
+@inline function swizzle_2d(M, N, tm, tn, GROUP_SIZE_M, bid)
+    num_bid_m = cld(M, Int32(tm))
+    num_bid_n = cld(N, Int32(tn))
+    num_bid_in_group = Int32(GROUP_SIZE_M) * num_bid_n
+    group_id = fld(bid, num_bid_in_group)
+    first_bid_m = group_id * Int32(GROUP_SIZE_M)
+    group_size_m = min(num_bid_m - first_bid_m, Int32(GROUP_SIZE_M))
+    bid_m = first_bid_m + rem(bid, group_size_m)
+    bid_n = fld(rem(bid, num_bid_in_group), group_size_m)
+    return bid_m, bid_n
+end
 
-    acc = ct.full((TN, TM), zero(Float32), Float32)
+# ── Matmul Kernel: C = A * B ────────────────────────────────────────────────
+# Uses 1D grid with 2D swizzle for cache locality.
 
-    k = Int32(1)
-    while k <= num_k_tiles
-        a_tile = ct.load(A_jl, (k, bid_m), (TK, TM);
-                         padding_mode=ct.PaddingMode.Zero)
-        b_tile = ct.load(B_jl, (bid_n, k), (TN, TK);
-                         padding_mode=ct.PaddingMode.Zero)
+function matmul_kernel(A::ct.TileArray{T,2}, B::ct.TileArray{T,2},
+                       C::ct.TileArray{T,2},
+                       tm::Int, tn::Int, tk::Int) where {T}
+    ct.@compiler_options num_ctas=ct.ByTarget(v"10.0" => 2)
 
+    # 1D grid with 2D swizzle for better L2 cache locality
+    bid = ct.bid(1)
+    M = size(A, 1)
+    N = size(B, 2)
+    # swizzle_2d expects 0-indexed bid, returns 0-indexed tile coords
+    bid_m_0, bid_n_0 = swizzle_2d(M, N, tm, tn, 8, bid - Int32(1))
+    bid_m = bid_m_0 + Int32(1)
+    bid_n = bid_n_0 + Int32(1)
+
+    num_k = ct.num_tiles(A, 2, (tm, tk))
+
+    acc = zeros(Float32, tm, tn)
+
+    for k in Int32(1):num_k
+        a = ct.load(A; index=(bid_m, k), shape=(tm, tk), padding_mode=ct.PaddingMode.Zero)
+        b = ct.load(B; index=(k, bid_n), shape=(tk, tn), padding_mode=ct.PaddingMode.Zero)
+        # Convert to TF32 for tensor cores (Float32 inputs only)
         if T === Float32
-            a_tile = convert(ct.Tile{ct.TFloat32}, a_tile)
-            b_tile = convert(ct.Tile{ct.TFloat32}, b_tile)
+            a = convert(ct.Tile{ct.TFloat32}, a)
+            b = convert(ct.Tile{ct.TFloat32}, b)
         end
-
-        acc = muladd(b_tile, a_tile, acc)
-        k += Int32(1)
+        acc = muladd(a, b, acc)
     end
 
-    result = convert(ct.Tile{T}, acc)
-    ct.store(C_jl, (bid_n, bid_m), result)
-
-    return nothing
+    ct.store(C; index=(bid_m, bid_n), tile=convert(ct.Tile{T}, acc))
+    return
 end
 
 # ── Host function ────────────────────────────────────────────────────────────
 
-function matmul!(a_ptr::Int, b_ptr::Int, c_ptr::Int,
-                 K_dim::Int, M_dim::Int, N_dim::Int,
-                 tm::Int, tn::Int, tk::Int)
-    A_cu = unsafe_wrap(CuArray{Float32, 2},
-                       CUDA.CuPtr{Float32}(UInt(a_ptr)),
-                       (K_dim, M_dim); own=false)
-    B_cu = unsafe_wrap(CuArray{Float32, 2},
-                       CUDA.CuPtr{Float32}(UInt(b_ptr)),
-                       (N_dim, K_dim); own=false)
-    C_cu = unsafe_wrap(CuArray{Float32, 2},
-                       CUDA.CuPtr{Float32}(UInt(c_ptr)),
-                       (N_dim, M_dim); own=false)
+"""
+    matmul!(C, A, B; tm=128, tn=128, tk=64)
 
-    num_m_tiles = cld(M_dim, tm)
-    num_n_tiles = cld(N_dim, tn)
-    num_k_tiles = cld(K_dim, tk)
-    grid = (num_m_tiles, num_n_tiles)
+Launch matmul kernel: C = A * B.
 
-    ct.launch(_matmul_kernel, grid, A_cu, B_cu, C_cu,
-              ct.Constant(num_k_tiles),
-              ct.Constant(tm), ct.Constant(tn), ct.Constant(tk);
-              occupancy=2)
-
+Memory layout (column-major):
+  A shape: (M, K), B shape: (K, N), C shape: (M, N)
+"""
+function matmul!(C::CuMatrix{T}, A::CuMatrix{T}, B::CuMatrix{T};
+                 tm::Int=128, tn::Int=128, tk::Int=64) where {T}
+    M = size(A, 1)
+    N = size(B, 2)
+    grid = cld(M, tm) * cld(N, tn)
+    ct.launch(matmul_kernel, grid, A, B, C,
+              ct.Constant(tm), ct.Constant(tn), ct.Constant(tk))
     CUDA.synchronize()
-    return nothing
+    return
 end
 
 # ── Verify ───────────────────────────────────────────────────────────────────
@@ -87,18 +96,17 @@ function verify()
     ]
     tm, tn, tk = 128, 128, 64
     for tc in test_cases
-        A_jl = CUDA.rand(Float32, tc.K, tc.M)
-        B_jl = CUDA.rand(Float32, tc.N, tc.K)
-        C_jl = CUDA.zeros(Float32, tc.N, tc.M)
+        A = CUDA.rand(Float32, tc.M, tc.K)
+        B = CUDA.rand(Float32, tc.K, tc.N)
+        C = CUDA.zeros(Float32, tc.M, tc.N)
 
-        matmul!(Int(pointer(A_jl)), Int(pointer(B_jl)), Int(pointer(C_jl)),
-                tc.K, tc.M, tc.N, tm, tn, tk)
+        matmul!(C, A, B; tm, tn, tk)
 
-        expected = Array(B_jl) * Array(A_jl)
-        result = Array(C_jl)
+        expected = Array(A) * Array(B)
+        result = Array(C)
         @assert isapprox(result, expected; atol=1e-1, rtol=1e-2) (
-            "matmul failed ($(tc.M)x$(tc.K))@($(tc.K)x$(tc.N))")
-        println("  ($(tc.M)x$(tc.K)) @ ($(tc.K)x$(tc.N)): passed")
+            "matmul failed ($(tc.M)x$(tc.K)) * ($(tc.K)x$(tc.N))")
+        println("  ($(tc.M)x$(tc.K)) * ($(tc.K)x$(tc.N)): passed")
     end
 end
 

--- a/.claude/skills/converting-cutile-to-julia/examples/03_softmax/cutile_julia.jl
+++ b/.claude/skills/converting-cutile-to-julia/examples/03_softmax/cutile_julia.jl
@@ -6,18 +6,18 @@
 # Three strategies (forward only):
 #   1. TMA single-tile:  ct.load/ct.store, persistent scheduling, TILE_SIZE >= N
 #   2. Online 2-pass:    ct.load/ct.store, running max + sum, one block per row
-#   3. Chunked 3-pass:   ct.load/ct.store, explicit max → sum → normalize
+#   3. Chunked 3-pass:   ct.gather/ct.scatter, explicit max → sum → normalize
 #
 # Matches julia/kernels/softmax.jl
 #
 # Key translation patterns demonstrated:
-#   - while loops (for loops forbidden in cuTile.jl kernels)
 #   - Broadcast dot syntax: exp.(), .-, ./, max.()
 #   - ct.PaddingMode.NegInf  (Python: ct.PaddingMode.NEG_INF)
 #   - maximum(tile; dims=2)   (Python: ct.max(tile, 1, keepdims=True))
-#   - ct.full((1,1), -Inf32, Float32)  for scalar accumulators
+#   - fill(-Inf32, (1, 1)) for scalar accumulators
+#   - zeros(Float32, 1, 1) for zero-initialized accumulators
 #   - ct.Constant() at launch, plain ::Int in kernel signature
-#   - Host functions with unsafe_wrap for raw pointer interop
+#   - Host functions accept CuMatrix{T} directly
 
 using CUDA
 import cuTile as ct
@@ -25,33 +25,31 @@ import cuTile as ct
 #=============================================================================
  Strategy 1: TMA Single-Tile  (TILE_SIZE >= N)
  Loads entire row in one ct.load with NegInf padding.
+ Uses persistent scheduling: each block processes multiple rows.
 =============================================================================#
-function _softmax_kernel_tma(output::ct.TileArray{T, 2}, input::ct.TileArray{T, 2},
-                             n_rows::Int, n_cols::Int,
-                             TILE_SIZE::Int) where {T}
+function softmax_kernel_tma(output::ct.TileArray{T,2}, input::ct.TileArray{T,2},
+                            TILE_SIZE::Int) where {T}
+    ct.@compiler_options occupancy=2
+
     pid = ct.bid(1)
     num_programs = ct.num_blocks(1)
+    n_rows = size(input, 1)
 
     row_idx = pid
     while row_idx <= n_rows
-        row = ct.load(input, (row_idx, Int32(1)), (1, TILE_SIZE);
+        row = ct.load(input; index=(row_idx, Int32(1)), shape=(1, TILE_SIZE),
                       padding_mode=ct.PaddingMode.NegInf)
-
         row = convert(ct.Tile{Float32}, row)
 
         row_max = maximum(row; dims=2)
-        row_minus_max = row .- row_max
-
-        numerator = exp.(row_minus_max)
+        numerator = exp.(row .- row_max)
         denominator = sum(numerator; dims=2)
         softmax_output = numerator ./ denominator
 
-        softmax_output = convert(ct.Tile{T}, softmax_output)
-        ct.store(output, (row_idx, Int32(1)), softmax_output)
-
+        ct.store(output; index=(row_idx, Int32(1)),
+                 tile=convert(ct.Tile{T}, softmax_output))
         row_idx += num_programs
     end
-
     return
 end
 
@@ -60,107 +58,96 @@ end
  Pass 1: running max + sum via online algorithm (m_prev, l_prev)
  Pass 2: normalize each tile chunk
 =============================================================================#
-function _softmax_kernel_online(output::ct.TileArray{T, 2}, input::ct.TileArray{T, 2},
-                                n_cols::Int, TILE_SIZE::Int,
-                                tile_num_per_row::Int) where {T}
-    # One block per row
+function softmax_kernel_online(output::ct.TileArray{T,2}, input::ct.TileArray{T,2},
+                               TILE_SIZE::Int) where {T}
     row_idx = ct.bid(1)
+    num_col_tiles = ct.num_tiles(input, 2, (1, TILE_SIZE))
 
-    # Initialize running max and sum
-    m_prev = ct.full((1, 1), -Inf32, Float32)
-    l_prev = ct.full((1, 1), 0.0f0, Float32)
+    m_prev = fill(-Inf32, (1, 1))
+    l_prev = zeros(Float32, 1, 1)
 
     # Pass 1: compute running max and sum
-    col_idx = Int32(1)
-    while col_idx <= tile_num_per_row
-        row_tile = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
+    for col_idx in Int32(1):num_col_tiles
+        row_tile = ct.load(input; index=(row_idx, col_idx), shape=(1, TILE_SIZE),
+                          padding_mode=ct.PaddingMode.NegInf)
         row_tile = convert(ct.Tile{Float32}, row_tile)
 
         tile_max = maximum(row_tile; dims=2)
         m_curr = max.(tile_max, m_prev)
 
-        # Correct old l_prev: l_prev *= exp(m_prev - m_curr)
-        exp_diff = exp.(m_prev .- m_curr)
-        l_prev = l_prev .* exp_diff
+        # Correct old sum: l_prev *= exp(m_prev - m_curr)
+        l_prev = l_prev .* exp.(m_prev .- m_curr)
 
-        # Update with current tile: p = exp(row - m_curr)
+        # Update with current tile
         p = exp.(row_tile .- m_curr)
-        l_curr = sum(p; dims=2)
-
-        l_prev = l_curr .+ l_prev
+        l_prev = sum(p; dims=2) .+ l_prev
         m_prev = m_curr
-
-        col_idx += Int32(1)
     end
 
     # Pass 2: compute actual softmax values
-    col_idx = Int32(1)
-    while col_idx <= tile_num_per_row
-        row_tile = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
+    for col_idx in Int32(1):num_col_tiles
+        row_tile = ct.load(input; index=(row_idx, col_idx), shape=(1, TILE_SIZE),
+                          padding_mode=ct.PaddingMode.NegInf)
         row_tile = convert(ct.Tile{Float32}, row_tile)
 
-        row_minus_max = row_tile .- m_prev
-        numerator = exp.(row_minus_max)
+        numerator = exp.(row_tile .- m_prev)
         softmax_output = numerator ./ l_prev
 
-        softmax_output = convert(ct.Tile{T}, softmax_output)
-        ct.store(output, (row_idx, col_idx), softmax_output)
-
-        col_idx += Int32(1)
+        ct.store(output; index=(row_idx, col_idx),
+                 tile=convert(ct.Tile{T}, softmax_output))
     end
-
     return
 end
 
 #=============================================================================
- Strategy 3: Chunked 3-Pass  (one block per row)
+ Strategy 3: Chunked 3-Pass  (one block per row, gather/scatter)
  Pass 1: row max across all chunks
  Pass 2: sum of exp(x - max)
- Pass 3: normalize and store
+ Pass 3: normalize and scatter back
 =============================================================================#
-function _softmax_kernel_chunked(output::ct.TileArray{T, 2}, input::ct.TileArray{T, 2},
-                                 num_chunks::Int, TILE_SIZE::Int) where {T}
-    # One block per row
-    row_idx = ct.bid(1)
+function softmax_kernel_chunked(output::ct.TileArray{T,2}, input::ct.TileArray{T,2},
+                                n_cols::Int, TILE_SIZE::Int) where {T}
+    ct.@compiler_options occupancy=4
 
-    row_max = ct.full((1, 1), -Inf32, Float32)
-    denominator = ct.full((1, 1), 0.0f0, Float32)
+    row_idx = ct.bid(1)
+    num_chunks = (n_cols + TILE_SIZE - Int32(1)) ÷ Int32(TILE_SIZE)
+    col_offsets_base = ct.arange(TILE_SIZE)
+    row_tile = ct.Tile(row_idx)
+
+    row_max = fill(-Inf32, (1,))
+    denominator = zeros(Float32, TILE_SIZE)
 
     # Pass 1: Find maximum across all chunks
-    col_idx = Int32(1)
-    while col_idx <= num_chunks
-        chunk = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
+    for chunk_idx in Int32(0):num_chunks - Int32(1)
+        col_indices = ct.broadcast_to(ct.Tile(chunk_idx * Int32(TILE_SIZE)), (TILE_SIZE,)) .+ col_offsets_base
+        chunk = ct.gather(input, (row_tile, col_indices);
+                         check_bounds=true, padding_value=T(-Inf))
         chunk = convert(ct.Tile{Float32}, chunk)
-        chunk_max = maximum(chunk; dims=2)
-        row_max = max.(row_max, chunk_max)
-        col_idx += Int32(1)
+        chunk_max = maximum(chunk)
+        row_max = max.(row_max, ct.Tile(chunk_max))
     end
 
     # Pass 2: Compute denominator (sum of all exp values)
-    col_idx = Int32(1)
-    while col_idx <= num_chunks
-        chunk = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
+    for chunk_idx in Int32(0):num_chunks - Int32(1)
+        col_indices = ct.broadcast_to(ct.Tile(chunk_idx * Int32(TILE_SIZE)), (TILE_SIZE,)) .+ col_offsets_base
+        chunk = ct.gather(input, (row_tile, col_indices);
+                         check_bounds=true, padding_value=T(-Inf))
         chunk = convert(ct.Tile{Float32}, chunk)
-        row_minus_max = chunk .- row_max
-        numerator = exp.(row_minus_max)
-        exponentials_sum = sum(numerator; dims=2)
-        denominator = denominator .+ exponentials_sum
-        col_idx += Int32(1)
+        numerator = exp.(chunk .- row_max)
+        denominator = denominator .+ numerator
     end
+    denom_sum = ct.Tile(sum(denominator))
 
-    # Pass 3: Compute final softmax and store
-    col_idx = Int32(1)
-    while col_idx <= num_chunks
-        chunk = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
+    # Pass 3: Compute final softmax and scatter
+    for chunk_idx in Int32(0):num_chunks - Int32(1)
+        col_indices = ct.broadcast_to(ct.Tile(chunk_idx * Int32(TILE_SIZE)), (TILE_SIZE,)) .+ col_offsets_base
+        chunk = ct.gather(input, (row_tile, col_indices);
+                         check_bounds=true, padding_value=T(-Inf))
         chunk = convert(ct.Tile{Float32}, chunk)
-        row_minus_max = chunk .- row_max
-        numerator = exp.(row_minus_max)
-        softmax_output = numerator ./ denominator
-        softmax_output = convert(ct.Tile{T}, softmax_output)
-        ct.store(output, (row_idx, col_idx), softmax_output)
-        col_idx += Int32(1)
+        softmax_output = exp.(chunk .- row_max) ./ denom_sum
+        ct.scatter(output, (row_tile, col_indices), convert(ct.Tile{T}, softmax_output);
+                  check_bounds=true)
     end
-
     return
 end
 
@@ -169,59 +156,43 @@ end
 =============================================================================#
 
 """
-    softmax_tma!(input_ptr, output_ptr, M, N, TILE_SIZE)
+    softmax_tma!(output, input; tile_size)
 
-TMA single-tile strategy. TILE_SIZE must be >= N.
+TMA single-tile strategy. tile_size must be >= size(input, 2).
 """
-function softmax_tma!(input_ptr::Int, output_ptr::Int, M::Int, N::Int, TILE_SIZE::Int)
-    input_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(input_ptr)), (M, N); own=false)
-    output_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(output_ptr)), (M, N); own=false)
-
-    ct.launch(_softmax_kernel_tma, M, output_cu, input_cu,
-              ct.Constant(M), ct.Constant(N), ct.Constant(TILE_SIZE);
-              occupancy=2)
-
+function softmax_tma!(output::CuMatrix{T}, input::CuMatrix{T};
+                      tile_size::Int=1024) where {T}
+    M = size(input, 1)
+    ct.launch(softmax_kernel_tma, M, output, input, ct.Constant(tile_size))
     CUDA.synchronize()
-    return nothing
+    return
 end
 
 """
-    softmax_online!(input_ptr, output_ptr, M, N, TILE_SIZE, tile_num_per_row)
+    softmax_online!(output, input; tile_size)
 
-Online 2-pass strategy. Input must be padded to tile_num_per_row * TILE_SIZE columns.
+Online softmax strategy. Processes row in tile_size chunks.
 """
-function softmax_online!(input_ptr::Int, output_ptr::Int,
-                         M::Int, N::Int, TILE_SIZE::Int, tile_num_per_row::Int)
-    padded_N = tile_num_per_row * TILE_SIZE
-    input_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(input_ptr)), (M, padded_N); own=false)
-    output_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(output_ptr)), (M, padded_N); own=false)
-
-    # One block per row
-    ct.launch(_softmax_kernel_online, M, output_cu, input_cu,
-              ct.Constant(N), ct.Constant(TILE_SIZE), ct.Constant(tile_num_per_row);
-              occupancy=2)
-
+function softmax_online!(output::CuMatrix{T}, input::CuMatrix{T};
+                         tile_size::Int=1024) where {T}
+    M = size(input, 1)
+    ct.launch(softmax_kernel_online, M, output, input, ct.Constant(tile_size))
     CUDA.synchronize()
-    return nothing
+    return
 end
 
 """
-    softmax_chunked!(input_ptr, output_ptr, M, N, TILE_SIZE)
+    softmax_chunked!(output, input; tile_size)
 
-Chunked 3-pass strategy. TILE_SIZE passed as ct.Constant.
+Chunked softmax strategy (3-pass, gather/scatter).
 """
-function softmax_chunked!(input_ptr::Int, output_ptr::Int, M::Int, N::Int, TILE_SIZE::Int)
-    num_chunks = cld(N, TILE_SIZE)
-    padded_N = num_chunks * TILE_SIZE
-    input_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(input_ptr)), (M, padded_N); own=false)
-    output_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(output_ptr)), (M, padded_N); own=false)
-
-    ct.launch(_softmax_kernel_chunked, M, output_cu, input_cu,
-              ct.Constant(num_chunks), ct.Constant(TILE_SIZE);
-              occupancy=4)
-
+function softmax_chunked!(output::CuMatrix{T}, input::CuMatrix{T};
+                          tile_size::Int=1024) where {T}
+    M, N = size(input)
+    ct.launch(softmax_kernel_chunked, M, output, input,
+              ct.Constant(N), ct.Constant(tile_size))
     CUDA.synchronize()
-    return nothing
+    return
 end
 
 #=============================================================================
@@ -237,9 +208,9 @@ end
 function test_tma(M, N, TILE_SIZE)
     println("  Strategy 1: TMA single-tile ($M×$N, tile=$TILE_SIZE)")
     inp = CUDA.randn(Float32, M, N)
-    out = CuArray{Float32}(undef, M, N)
+    out = CUDA.zeros(Float32, M, N)
 
-    softmax_tma!(Int(pointer(inp)), Int(pointer(out)), M, N, TILE_SIZE)
+    softmax_tma!(out, inp; tile_size=TILE_SIZE)
 
     expected = ref_softmax(Array(inp))
     @assert isapprox(Array(out), expected; rtol=1e-3, atol=1e-3) (
@@ -250,41 +221,28 @@ end
 
 function test_online(M, N, TILE_SIZE)
     println("  Strategy 2: Online 2-pass ($M×$N, tile=$TILE_SIZE)")
-    tile_num_per_row = cld(N, TILE_SIZE)
-    padded_N = tile_num_per_row * TILE_SIZE
+    inp = CUDA.randn(Float32, M, N)
+    out = CUDA.zeros(Float32, M, N)
 
-    inp_raw = CUDA.randn(Float32, M, N)
-    inp = CUDA.fill(-Inf32, M, padded_N)
-    copyto!(view(inp, :, 1:N), inp_raw)
-    out = CuArray{Float32}(undef, M, padded_N)
+    softmax_online!(out, inp; tile_size=TILE_SIZE)
 
-    softmax_online!(Int(pointer(inp)), Int(pointer(out)),
-                    M, N, TILE_SIZE, tile_num_per_row)
-
-    expected = ref_softmax(Array(inp_raw))
-    actual = Array(out[:, 1:N])
-    @assert isapprox(actual, expected; rtol=1e-3, atol=1e-3) (
-        "Online mismatch! max diff: $(maximum(abs.(actual .- expected)))"
+    expected = ref_softmax(Array(inp))
+    @assert isapprox(Array(out), expected; rtol=1e-3, atol=1e-3) (
+        "Online mismatch! max diff: $(maximum(abs.(Array(out) .- expected)))"
     )
     println("    PASSED")
 end
 
 function test_chunked(M, N, TILE_SIZE)
     println("  Strategy 3: Chunked 3-pass ($M×$N, tile=$TILE_SIZE)")
-    num_chunks = cld(N, TILE_SIZE)
-    padded_N = num_chunks * TILE_SIZE
+    inp = CUDA.randn(Float32, M, N)
+    out = CUDA.zeros(Float32, M, N)
 
-    inp_raw = CUDA.randn(Float32, M, N)
-    inp = CUDA.fill(-Inf32, M, padded_N)
-    copyto!(view(inp, :, 1:N), inp_raw)
-    out = CuArray{Float32}(undef, M, padded_N)
+    softmax_chunked!(out, inp; tile_size=TILE_SIZE)
 
-    softmax_chunked!(Int(pointer(inp)), Int(pointer(out)), M, N, TILE_SIZE)
-
-    expected = ref_softmax(Array(inp_raw))
-    actual = Array(out[:, 1:N])
-    @assert isapprox(actual, expected; rtol=1e-3, atol=1e-3) (
-        "Chunked mismatch! max diff: $(maximum(abs.(actual .- expected)))"
+    expected = ref_softmax(Array(inp))
+    @assert isapprox(Array(out), expected; rtol=1e-3, atol=1e-3) (
+        "Chunked mismatch! max diff: $(maximum(abs.(Array(out) .- expected)))"
     )
     println("    PASSED")
 end

--- a/.claude/skills/converting-cutile-to-julia/references/api-mapping.md
+++ b/.claude/skills/converting-cutile-to-julia/references/api-mapping.md
@@ -28,6 +28,7 @@
 | Python | Julia | Notes |
 |--------|-------|-------|
 | `ct.launch(stream, grid, kernel, (a, b, c, val))` | `ct.launch(kernel, grid, a, b, c, ct.Constant(val))` | No stream; args splatted; constants wrapped |
+| `@ct.kernel(occupancy=N)` | `ct.@compiler_options occupancy=N` (in kernel body) | Replaces launch kwargs |
 | `grid = (M, N, 1)` | `grid = (M, N)` or `grid = (M, N, K)` | Trailing 1s optional |
 | `cp.cuda.get_current_stream()` | (implicit) | Julia uses task-bound stream |
 | `cp.cuda.runtime.deviceSynchronize()` | `CUDA.synchronize()` | Explicit sync |
@@ -46,10 +47,10 @@
 
 | Python | Julia | Notes |
 |--------|-------|-------|
-| `ct.load(arr, index=(i,j), shape=(m,n))` | `ct.load(arr, (i,j), (m,n))` | Positional args |
-| `ct.load(arr, index=(i,j), shape=(m,n), padding_mode=ct.PaddingMode.ZERO)` | `ct.load(arr, (i,j), (m,n); padding_mode=ct.PaddingMode.Zero)` | Semicolon kwargs; `Zero` not `ZERO` |
-| `ct.load(arr, index=(b,h,0,j), shape=(1,1,D,N), order=(0,1,3,2))` | `ct.load(arr, (b,h,j,1), (N,D,1,1); order=(2,1,3,4))` | **⚠️ `order` remaps BOTH shape AND index positions** — see Critical Rule 16 |
-| `ct.store(arr, index=(i,j), tile=t)` | `ct.store(arr, (i,j), t)` | Positional args |
+| `ct.load(arr, index=(i,j), shape=(m,n))` | `ct.load(arr; index=(i,j), shape=(m,n))` | Keyword preferred |
+| `ct.load(arr, index=(i,j), shape=(m,n), padding_mode=ct.PaddingMode.ZERO)` | `ct.load(arr; index=(i,j), shape=(m,n), padding_mode=ct.PaddingMode.Zero)` | Semicolon kwargs; `Zero` not `ZERO` |
+| `ct.load(arr, index=(b,h,0,j), shape=(1,1,D,N), order=(0,1,3,2))` | `ct.load(arr; index=(b,h,j,1), shape=(N,D,1,1), order=(2,1,3,4))` | **⚠️ `order` remaps BOTH shape AND index positions** — see Critical Rule 16 |
+| `ct.store(arr, index=(i,j), tile=t)` | `ct.store(arr; index=(i,j), tile=t)` | Keyword preferred |
 | `ct.gather(arr, indices)` | `ct.gather(arr, indices)` | Same |
 | `ct.scatter(arr, indices, tile)` | `ct.scatter(arr, indices, tile)` | Same |
 | `ct.load(arr, index=bid, shape=())` | `arr[bid]` | 0-D tile → scalar indexing |
@@ -72,10 +73,10 @@
 
 | Python | Julia | Notes |
 |--------|-------|-------|
-| `ct.full((m,n), 0, dtype=ct.float32)` | `ct.full((m,n), 0.0f0, Float32)` | Julia types |
-| `ct.zeros((m,n), dtype=ct.float32)` | `ct.zeros((m,n), Float32)` | No keyword |
-| `ct.arange(N, dtype=ct.int32)` | `ct.arange((N,), Int32)` | Tuple shape |
-| `ct.ones((m,n), dtype=ct.float32)` | (not available) | Use `ct.full((m,n), 1.0f0, Float32)` |
+| `ct.full((m,n), 0, dtype=ct.float32)` | `fill(0.0f0, (m, n))` | Base.fill overlay |
+| `ct.zeros((m,n), dtype=ct.float32)` | `zeros(Float32, m, n)` | Base.zeros overlay |
+| `ct.arange(N, dtype=ct.int32)` | `ct.arange(N)` | Returns 1-indexed [1,...,N], Int32 |
+| `ct.ones((m,n), dtype=ct.float32)` | `ones(Float32, m, n)` | Base.ones overlay |
 
 ## Type Conversion
 
@@ -211,8 +212,8 @@
 
 | Python | Julia | Notes |
 |--------|-------|-------|
-| `for k in range(n):` | `k = Int32(1); while k <= n; ...; k += Int32(1); end` | **No for loops**; use 1-based when `k` is a tile index for `ct.load`/`ct.store` |
-| `for k in range(0, n):` | `k = Int32(0); while k < n; ...; k += Int32(1); end` | Use 0-based when `k` is used in arithmetic (e.g., `k * TILE_SIZE + offset`) |
+| `for k in range(n):` | `for k in Int32(1):n` | cuTile 0.2 supports native `for` loops; use 1-based when `k` is a tile index for `ct.load`/`ct.store` |
+| `for k in range(0, n):` | `for k in Int32(0):n - Int32(1)` | Use 0-based when `k` is used in arithmetic (e.g., `k * TILE_SIZE + offset`) |
 | `if cond:` | `if cond` | Same structure |
 | `if A.dtype == ct.float32:` | `if T === Float32` | Use `===` for type check |
 
@@ -266,12 +267,12 @@ For simple 1D element-wise ops (dropout, activations), use the TMA `ct.load`/`ct
 
 ```julia
 # 1D kernel using TMA block indexing
-function _my_1d_kernel(x::ct.TileArray{T,1}, output::ct.TileArray{T,1},
-                       BLOCK_SIZE::Int) where {T}
+function my_1d_kernel(x::ct.TileArray{T,1}, output::ct.TileArray{T,1},
+                      BLOCK_SIZE::Int) where {T}
     bid = ct.bid(1)
-    x_tile = ct.load(x, bid, (BLOCK_SIZE,))
+    x_tile = ct.load(x; index=bid, shape=(BLOCK_SIZE,))
     # ... process ...
-    ct.store(output, bid, result_tile)
+    ct.store(output; index=bid, tile=result_tile)
     return nothing
 end
 ```
@@ -283,22 +284,23 @@ Host harness: flatten input, pad to `BLOCK_SIZE` multiple, launch kernel, trim o
 For row-per-block kernels with many rows, use persistent scheduling with `ct.Constant` for tile sizes:
 
 ```julia
-function _my_kernel(data::ct.TileArray{T,2}, n_rows::Int, TILE_HD::Int) where {T}
+function my_kernel(data::ct.TileArray{T,2}, TILE_HD::Int) where {T}
+    ct.@compiler_options occupancy=2
     bid = ct.bid(1)
     num_programs = ct.num_blocks(1)
+    n_rows = size(data, 2)
     row_idx = bid
     while row_idx <= n_rows
-        tile = ct.load(data, (Int32(1), row_idx), (TILE_HD, 1))
+        tile = ct.load(data; index=(Int32(1), row_idx), shape=(TILE_HD, 1))
         # ... process row ...
-        ct.store(data, (Int32(1), row_idx), result)
+        ct.store(data; index=(Int32(1), row_idx), tile=result)
         row_idx += num_programs
     end
     return
 end
 
 # Launch with ct.Constant for tile size
-ct.launch(_my_kernel, num_blocks, data_cu,
-          ct.Constant(n_rows), ct.Constant(tile_hd); occupancy=2)
+ct.launch(my_kernel, num_blocks, data_cu, ct.Constant(tile_hd))
 ```
 
 ## Kernel Patterns for Large Tensors
@@ -308,108 +310,72 @@ When a single `ct.load` of the entire data exceeds hardware limits, use one of t
 ### Pattern A: Column-loop with `ct.load`/`ct.store` (Online Algorithm)
 
 Best for TMA-based kernels where each chunk is a contiguous tile along columns.
-Supports persistent scheduling (fewer blocks than rows) with nested while loops.
+Uses `for` loops for column iteration and `ct.num_tiles` for tile count.
 
 ```julia
-# Persistent scheduling: fewer blocks than rows, outer while distributes rows
 function online_kernel(output::ct.TileArray{T, 2}, input::ct.TileArray{T, 2},
-                       n_rows::Int, TILE_SIZE::Int, tile_num_per_row::Int) where {T}
-    pid = ct.bid(1)
-    num_blocks = ct.num_blocks(1)
+                       TILE_SIZE::Int) where {T}
+    row_idx = ct.bid(1)
+    num_col_tiles = ct.num_tiles(input, 2, (1, TILE_SIZE))
 
-    row_idx = pid
-    while row_idx <= n_rows                       # outer while: persistent scheduling
-        # Pass 1: streaming max + sum
-        m_prev = ct.full((1, 1), -Inf32, Float32)
-        l_prev = ct.full((1, 1), 0.0f0, Float32)
-        col_idx = Int32(1)
-        while col_idx <= tile_num_per_row         # inner while: iterate column chunks
-            tile = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
-            tile = convert(ct.Tile{Float32}, tile)
-            tile_max = maximum(tile; dims=2)
-            m_curr = max.(tile_max, m_prev)           # broadcast max!
-            l_prev = l_prev .* exp.(m_prev .- m_curr)
-            l_prev = l_prev .+ sum(exp.(tile .- m_curr); dims=2)
-            m_prev = m_curr
-            col_idx += Int32(1)
-        end
+    m_prev = fill(-Inf32, (1, 1))
+    l_prev = zeros(Float32, 1, 1)
 
-        # Pass 2: normalize
-        col_idx = Int32(1)
-        while col_idx <= tile_num_per_row
-            tile = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
-            tile = convert(ct.Tile{Float32}, tile)
-            result = exp.(tile .- m_prev) ./ l_prev
-            ct.store(output, (row_idx, col_idx), convert(ct.Tile{T}, result))
-            col_idx += Int32(1)
-        end
+    for col_idx in Int32(1):num_col_tiles
+        tile = ct.load(input; index=(row_idx, col_idx), shape=(1, TILE_SIZE),
+                      padding_mode=ct.PaddingMode.NegInf)
+        tile = convert(ct.Tile{Float32}, tile)
+        tile_max = maximum(tile; dims=2)
+        m_curr = max.(tile_max, m_prev)
+        l_prev = l_prev .* exp.(m_prev .- m_curr)
+        l_prev = sum(exp.(tile .- m_curr); dims=2) .+ l_prev
+        m_prev = m_curr
+    end
 
-        row_idx += num_blocks                     # advance to next row for this block
+    for col_idx in Int32(1):num_col_tiles
+        tile = ct.load(input; index=(row_idx, col_idx), shape=(1, TILE_SIZE),
+                      padding_mode=ct.PaddingMode.NegInf)
+        tile = convert(ct.Tile{Float32}, tile)
+        result = exp.(tile .- m_prev) ./ l_prev
+        ct.store(output; index=(row_idx, col_idx), tile=convert(ct.Tile{T}, result))
     end
     return
 end
 ```
 
-### Pattern B: Chunked with `ct.load`/`ct.store` and `ct.Constant` (Preferred)
+### Pattern B: Chunked with `ct.gather`/`ct.scatter` and `ct.Constant` (Preferred)
 
 Use when you need multiple passes over column chunks. Pass tile sizes as
 `ct.Constant` at launch — no `@eval` needed.
 
 ```julia
-function _chunked_kernel(output::ct.TileArray{T, 2}, input::ct.TileArray{T, 2},
-                         n_rows::Int, num_chunks::Int, TILE_SIZE::Int) where {T}
-    pid = ct.bid(1)
-    num_blocks = ct.num_blocks(1)
+function chunked_kernel(output::ct.TileArray{T, 2}, input::ct.TileArray{T, 2},
+                        n_cols::Int, TILE_SIZE::Int) where {T}
+    ct.@compiler_options occupancy=4
+    row_idx = ct.bid(1)
+    num_chunks = (n_cols + TILE_SIZE - Int32(1)) ÷ Int32(TILE_SIZE)
+    col_offsets_base = ct.arange(TILE_SIZE)
+    row_tile = ct.Tile(row_idx)
 
-    row_idx = pid
-    while row_idx <= n_rows                   # outer while: persistent scheduling
-        row_max = ct.full((1, 1), -Inf32, Float32)
-        denom = ct.full((1, 1), 0.0f0, Float32)
+    row_max = fill(-Inf32, (1,))
+    denominator = zeros(Float32, TILE_SIZE)
 
-        # Pass 1: max
-        col_idx = Int32(1)
-        while col_idx <= num_chunks
-            chunk = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
-            chunk = convert(ct.Tile{Float32}, chunk)
-            row_max = max.(row_max, maximum(chunk; dims=2))
-            col_idx += Int32(1)
-        end
-
-        # Pass 2: sum of exp
-        col_idx = Int32(1)
-        while col_idx <= num_chunks
-            chunk = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
-            chunk = convert(ct.Tile{Float32}, chunk)
-            denom = denom .+ sum(exp.(chunk .- row_max); dims=2)
-            col_idx += Int32(1)
-        end
-
-        # Pass 3: normalize and store
-        col_idx = Int32(1)
-        while col_idx <= num_chunks
-            chunk = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
-            chunk = convert(ct.Tile{Float32}, chunk)
-            result = exp.(chunk .- row_max) ./ denom
-            ct.store(output, (row_idx, col_idx), convert(ct.Tile{T}, result))
-            col_idx += Int32(1)
-        end
-
-        row_idx += num_blocks                 # advance to next row
+    for chunk_idx in Int32(0):num_chunks - Int32(1)
+        col_indices = ct.broadcast_to(ct.Tile(chunk_idx * Int32(TILE_SIZE)), (TILE_SIZE,)) .+ col_offsets_base
+        chunk = ct.gather(input, (row_tile, col_indices); check_bounds=true, padding_value=T(-Inf))
+        chunk = convert(ct.Tile{Float32}, chunk)
+        row_max = max.(row_max, ct.Tile(maximum(chunk)))
     end
-
+    # ... pass 2 and 3 similarly ...
     return
 end
 
-function julia_chunked_softmax(input_ptr::Int, output_ptr::Int, M::Int, N::Int, TILE_SIZE::Int)
-    num_chunks = cld(N, TILE_SIZE)
-    padded_N = num_chunks * TILE_SIZE
-    input_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(input_ptr)), (M, padded_N); own=false)
-    output_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(output_ptr)), (M, padded_N); own=false)
-    num_blocks = min(M, 128)
-    ct.launch(_chunked_kernel, num_blocks, output_cu, input_cu,
-              ct.Constant(M), ct.Constant(num_chunks), ct.Constant(TILE_SIZE); occupancy=4)
+function julia_chunked_softmax(output::CuMatrix{T}, input::CuMatrix{T};
+                               tile_size::Int=1024) where {T}
+    M, N = size(input)
+    ct.launch(chunked_kernel, M, output, input, ct.Constant(N), ct.Constant(tile_size))
     CUDA.synchronize()
-    return nothing
+    return
 end
 ```
 
@@ -422,8 +388,8 @@ end
 | `ct.num_blocks(0)` | `ct.num_blocks(1)` |
 | `ct.num_tiles(A, axis=1, shape=s)` | `ct.num_tiles(A, 2, s)` |
 | `A.shape[0]` | `size(A, 1)` |
-| `ct.load(arr, index=i, shape=s)` | `ct.load(arr, i, s)` |
-| `ct.store(arr, index=i, tile=t)` | `ct.store(arr, i, t)` |
+| `ct.load(arr, index=i, shape=s)` | `ct.load(arr; index=i, shape=s)` |
+| `ct.store(arr, index=i, tile=t)` | `ct.store(arr; index=i, tile=t)` |
 | `.astype(ct.float32)` | `convert(ct.Tile{Float32}, tile)` |
 | `ct.mma(a, b, acc=acc)` | `muladd(a, b, acc)` |
 | `ct.where(m, x, y)` | `ifelse.(m, x, y)` |
@@ -431,7 +397,7 @@ end
 | `ct.maximum(a, b)` | `max.(a, b)` |
 | `ct.exp(t)` | `exp.(t)` |
 | `ct.rsqrt(t)` | `rsqrt.(t)` (cuTile.jl exports `rsqrt`; `map(ct.rsqrt, t)` also works) |
-| `for k in range(n):` | `k=Int32(1); while k<=n; ...; k+=Int32(1); end` |
+| `for k in range(n):` | `for k in Int32(1):n` |
 | `ct.launch(stream, grid, kernel, (args))` | `ct.launch(kernel, grid, args...)` |
 | `ct.Constant[int]` in sig | `::Int` in sig, `ct.Constant(val)` at launch |
 | `ct.cdiv(a, b)` | `cld(a, b)` |

--- a/.claude/skills/converting-cutile-to-julia/references/critical-rules.md
+++ b/.claude/skills/converting-cutile-to-julia/references/critical-rules.md
@@ -6,7 +6,7 @@
 
 1. **1-based indexing everywhere**: `ct.bid`, `ct.num_tiles` axis, `dims` for reductions, `permutedims` axes, `ct.extract` indices, `ct.cat` axis — ALL shifted +1 from Python.
 
-2. **No `for` loops in kernels**: Julia's iterator-based `for` generates complex IR the cuTile compiler doesn't support. Use `while` loops with explicit `Int32` counter and increment.
+2. **`for` loops work in kernels (cuTile 0.2+)**: `for k in Int32(1):n` and `for k in Int32(0):n - Int32(1)` are fully supported. Step ranges also work: `for i in start:step:stop`. The `while` pattern still works but `for` is preferred for simple iteration.
 
 3. **Explicit broadcasting**: Python cuTile auto-broadcasts `+`, `-`, `*`, `/` between different shapes. Julia requires `.+`, `.-`, `.*`, `./` for shape-mismatched tiles. Same-shape `+`/`-` and scalar `*`/`/` work without dots.
 
@@ -22,27 +22,27 @@
 
 9. **Type names**: `ct.float32` → `Float32`, `ct.float16` → `Float16`, `ct.int32` → `Int32`, `ct.bfloat16` → `BFloat16`, `ct.tfloat32` → `ct.TFloat32`.
 
-10. **Integer types in loops**: Loop counters and increments must have matching types. Use `Int32` consistently: `k = Int32(1); while k <= n; ...; k += Int32(1); end`.
+10. **Integer types in loops**: Loop counters and increments must have matching types. Use `Int32` consistently. Preferred: `for k in Int32(1):n` (handles types automatically). The `while` pattern also works: `k = Int32(1); while k <= n; ...; k += Int32(1); end`.
 
 11. **`ct.launch` arg order is positional**: Kernel args after the grid in `ct.launch(kernel, grid, arg1, arg2, ...)` map 1:1 to the kernel's parameter list. If the kernel signature is `(output, input, ...)`, you MUST pass `output` first. Swapping arguments silently produces wrong results (the kernel reads from the output buffer and writes to the input buffer).
 
 12. **Element-wise `max`/`min` between tiles**: Use `max.(a, b)` (broadcast syntax), NOT `max(a, b)`. The non-broadcast `max(a, b)` on two tiles is not supported in kernel IR and will fail with `IRError: Unsupported function call: max`. Similarly `min(a, b)` → `min.(a, b)`.
 
-13. **No `Int32()`/`Float32()` casts on runtime kernel values**: The cuTile.jl compiler cannot convert runtime computed values with `Int32(expr)`. This fails with `MethodError: no method matching Int32(::IRStructurizer.BlockArg)`. Instead, keep all arithmetic in a consistent type from the start, or use `ct.full((N,), val, Int32)` to create a tile from a runtime value.
+13. **IRStructurizer / compiler errors should be reported**: If you encounter `IRError`, `MethodError` mentioning `IRStructurizer.BlockArg`, or other internal compiler errors, these are bugs in the cuTile.jl compiler pipeline — do not work around them. Write a minimal reproducer and file it upstream.
 
 14. **Tile-size limits for `ct.load`**: TMA-based `ct.load` has hardware limits on how much data can be loaded at once (~16K elements). For large tensors, use chunked or online algorithms that iterate over the data in fixed-size tiles, using either `ct.load`/`ct.store` with column indices or `ct.gather`/`ct.scatter` with index tiles.
 
- 15. **`ct.Constant` parameters work as shape arguments**: The shape tuple in `ct.arange((N,), Int32)` and `ct.full((N,), val, T)` can use `ct.Constant` kernel parameters — cuTile.jl's const-seeded inference pipeline resolves them at compile time. Pass tile sizes as `ct.Constant(val)` at the `ct.launch` call site and use the corresponding `::Int` parameter directly in shape tuples. No `@eval` metaprogramming needed.
+ 15. **`ct.Constant` parameters work as shape arguments**: The shape tuple in `ct.arange(N)` and `fill(val, (N,))` can use `ct.Constant` kernel parameters — cuTile.jl's const-seeded inference pipeline resolves them at compile time. Pass tile sizes as `ct.Constant(val)` at the `ct.launch` call site and use the corresponding `::Int` parameter directly in shape tuples. No `@eval` metaprogramming needed.
      ```julia
      function my_kernel(output::ct.TileArray{T, 2}, input::ct.TileArray{T, 2},
                         TILE_SIZE::Int) where {T}
+         ct.@compiler_options occupancy=2
          bid = ct.bid(1)
-         tile = ct.load(input, (bid, Int32(1)), (1, TILE_SIZE))  # TILE_SIZE from ct.Constant
+         tile = ct.load(input; index=(bid, Int32(1)), shape=(1, TILE_SIZE))  # TILE_SIZE from ct.Constant
          # ...
      end
 
-     ct.launch(my_kernel, grid, output_cu, input_cu,
-               ct.Constant(tile_size); occupancy=2)
+     ct.launch(my_kernel, grid, output_cu, input_cu, ct.Constant(tile_size))
      ```
 
  16. **`ct.load` `order` parameter remaps BOTH shape AND index positions**: When using `order=(2,1,...)`, the `order` defines a logical-to-physical dimension mapping that applies to **both** the shape tuple and the index tuple. If `order=(2,1,3,4)`, then index position 0 → physical array dim 1, index position 1 → physical array dim 0. **You must place tile iterators at the index position that maps to the correct physical dimension.**

--- a/.claude/skills/converting-cutile-to-julia/references/debugging.md
+++ b/.claude/skills/converting-cutile-to-julia/references/debugging.md
@@ -12,10 +12,9 @@
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `MethodError: no method matching Int32(::IRStructurizer.BlockArg)` | `Int32(runtime_val)` cast on a computed kernel value | Keep types consistent from the start; use `ct.full((N,), val, Int32)` to create a tile |
-| `IRError: Unsupported function call: max` | `max(a, b)` on two tiles (non-broadcast) | Use `max.(a, b)` — broadcast dot syntax |
+| `IRError: Unsupported function call: max` | `max(a, b)` on two tiles (non-broadcast) | Use `max.(a, b)` — broadcast dot syntax (same as regular Julia arrays) |
 | `IRError: Unsupported function call: min` | Same as above for `min` | Use `min.(a, b)` |
-| `IRError: Unsupported function call: for` | `for` loop in kernel body | Replace with `while` + explicit `Int32` counter |
+| `IRError` or `MethodError` mentioning `IRStructurizer` | Internal compiler bug | Do not work around — write a minimal reproducer and file upstream |
 | `TypeError: in typeassert, expected Tile{...}, got Tile{...}` | Type mismatch in tile operation | Check `convert(ct.Tile{T}, tile)` calls |
 | `BoundsError` at launch | Wrong number of args to `ct.launch` | Verify arg count matches kernel signature exactly |
 | `UndefVarError: X not defined` | Variable only defined in one `if` branch | Pre-define variable before the `if/else` |

--- a/.claude/skills/converting-cutile-to-julia/references/testing.md
+++ b/.claude/skills/converting-cutile-to-julia/references/testing.md
@@ -55,26 +55,16 @@ const KERNEL_DIR = joinpath(@__DIR__, "..", "kernels")
 include(joinpath(KERNEL_DIR, "<op>.jl"))
 
 @testset "<Op> Kernel" begin
-
     @testset "basic correctness" begin
         M, N = 128, 256
         x_gpu = CUDA.rand(Float32, M, N)
+        out_gpu = similar(x_gpu)
 
-        out_gpu = CUDA.zeros(Float32, M, N)
+        my_op!(out_gpu, x_gpu)
 
-        # Call bridge function
-        julia_<op>(
-            Int(pointer(x_gpu)),
-            Int(pointer(out_gpu)),
-            M, N
-        )
-
-        # Compare against reference
         expected = reference_impl(Array(x_gpu))
-        result = Array(out_gpu)
-        @test result ≈ expected atol=1e-5
+        @test Array(out_gpu) ≈ expected atol=1e-5
     end
-
 end
 ```
 
@@ -129,8 +119,8 @@ For complex ops (attention, softmax), prefer NNlib.jl.
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `MethodError: no method matching Int32(::IRStructurizer.BlockArg)` | `Int32()` cast on runtime value | Use `ct.full((N,), val, Int32)` |
 | `IRError: Unsupported function call: max` | `max(a, b)` on tiles | Use `max.(a, b)` (broadcast dot) |
+| `IRError` or `MethodError` mentioning `IRStructurizer` | Internal compiler bug | Do not work around — file upstream with minimal reproducer |
 | All zeros in output | `ct.launch` arg order wrong | Verify args map positionally to kernel params |
 | Slight numerical drift | Reduction order differs | Increase tolerance to 2x default |
 | Transposed results | Column-major layout mismatch | Verify data is created in col-major for Julia |
@@ -143,7 +133,7 @@ For complex ops (attention, softmax), prefer NNlib.jl.
 Before marking a Julia kernel conversion complete:
 
 - [ ] `julia --project=julia/ julia/test/runtests.jl` passes
-- [ ] `validate_cutile_jl.py` passes on the `.jl` kernel file
+- [ ] `validate_cutile_jl.py` passes on the `.jl` kernel file (no longer flags `for` loops)
 - [ ] No NaN/Inf in output
 - [ ] Tested at least one non-power-of-2 shape
 - [ ] Tested at least one non-tile-aligned dimension

--- a/.claude/skills/converting-cutile-to-julia/scripts/validate_cutile_jl.py
+++ b/.claude/skills/converting-cutile-to-julia/scripts/validate_cutile_jl.py
@@ -93,10 +93,6 @@ def validate(filepath: str) -> list[str]:
 
         # --- Checks that apply inside kernel bodies ---
         if in_kernel:
-            # for loop (forbidden in kernels)
-            if re.match(r"^\s*for\s+\w+\s+(in|=)\s+", line):
-                errors.append(f"ERROR (line {i}): 'for' loop in kernel — use 'while' with Int32 counter")
-
             # 0-based ct.bid / ct.num_blocks
             if re.search(r"ct\.bid\(0\)", line):
                 errors.append(f"ERROR (line {i}): ct.bid(0) — Julia is 1-indexed, use ct.bid(1)")
@@ -154,13 +150,6 @@ def validate(filepath: str) -> list[str]:
         if re.search(r"ct\.Constant\[", line):
             errors.append(f"ERROR (line {i}): ct.Constant[...] in signature — use ::Int and ct.Constant(val) at launch")
 
-        # Keyword args with = instead of ;
-        # ct.load with keyword index= or shape=
-        if re.search(r"ct\.load\([^)]*index\s*=", line):
-            errors.append(f"WARNING (line {i}): ct.load with index= keyword — use positional args in Julia")
-        if re.search(r"ct\.store\([^)]*tile\s*=", line):
-            errors.append(f"WARNING (line {i}): ct.store with tile= keyword — use positional args in Julia")
-
         # PaddingMode case
         if re.search(r"ct\.PaddingMode\.ZERO\b", line):
             errors.append(f"ERROR (line {i}): ct.PaddingMode.ZERO — use ct.PaddingMode.Zero")
@@ -180,9 +169,17 @@ def validate(filepath: str) -> list[str]:
         if re.search(r"ct\.launch\([^,]+,\s*stream", line) or re.search(r"ct\.launch\(\s*stream", line):
             errors.append(f"ERROR (line {i}): ct.launch(stream, ...) — Julia ct.launch does not take a stream argument")
 
-        # ct.ones (not available in cuTile.jl)
+        # ct.ones (wrong namespace — use Base overlay ones(T, dims...))
         if re.search(r"\bct\.ones\(", line):
-            errors.append(f"ERROR (line {i}): ct.ones() not available — use ct.full(shape, 1.0f0, Float32)")
+            errors.append(f"ERROR (line {i}): ct.ones() not available — use ones(T, dims...)")
+
+        # ct.full (not available in cuTile.jl)
+        if re.search(r"\bct\.full\(", line):
+            errors.append(f"ERROR (line {i}): ct.full() not available — use fill(val, shape), zeros(T, dims...), or ones(T, dims...)")
+
+        # ct.zeros (wrong namespace — use Base overlay zeros(T, dims...))
+        if re.search(r"\bct\.zeros\(", line):
+            errors.append(f"ERROR (line {i}): ct.zeros() not available — use zeros(T, dims...)")
 
     return errors
 

--- a/.claude/skills/converting-cutile-to-julia/scripts/validate_cutile_jl.py
+++ b/.claude/skills/converting-cutile-to-julia/scripts/validate_cutile_jl.py
@@ -175,7 +175,9 @@ def validate(filepath: str) -> list[str]:
 
         # ct.full (not available in cuTile.jl)
         if re.search(r"\bct\.full\(", line):
-            errors.append(f"ERROR (line {i}): ct.full() not available — use fill(val, shape), zeros(T, dims...), or ones(T, dims...)")
+            errors.append(
+                f"ERROR (line {i}): ct.full() not available — use fill(val, shape), zeros(T, dims...), or ones(T, dims...)"
+            )
 
         # ct.zeros (wrong namespace — use Base overlay zeros(T, dims...))
         if re.search(r"\bct\.zeros\(", line):

--- a/.claude/skills/converting-cutile-to-julia/translations/workflow.md
+++ b/.claude/skills/converting-cutile-to-julia/translations/workflow.md
@@ -97,7 +97,7 @@ todowrite([
 
 ### Static Validation (run BEFORE testing)
 ```bash
-# Checks for common anti-patterns (for loops, 0-based indexing, Python API leftovers)
+# Checks for common anti-patterns (0-based indexing, Python API leftovers)
 # The script is bundled with this skill at scripts/validate_cutile_jl.py
 python <skill-dir>/scripts/validate_cutile_jl.py <path_to_julia_file.jl>
 ```
@@ -130,7 +130,7 @@ grep "ct.permute\|ct.transpose" source.py     # → permutedims/transpose
 grep "ct.where" source.py                      # → ifelse.(cond, x, y)
 grep "\.astype(" source.py                     # → convert(ct.Tile{T}, tile)
 grep "ct.mma\|ct.matmul" source.py             # → muladd(a, b, acc) or a * b
-grep "for .* in range" source.py               # → while loop (for not supported)
+grep "for .* in range" source.py               # → for k in Int32(1):n (native for loops supported)
 grep "ct.sum\|ct.max\|ct.min" source.py        # → sum/maximum/minimum with dims+1
 grep "ct.maximum\|ct.minimum" source.py        # → max.(a, b) / min.(a, b)
 grep "ct.atomic" source.py                     # → ct.atomic_cas/xchg/add (kwarg syntax changes)
@@ -147,7 +147,7 @@ grep "ct.bitwise" source.py                    # → a .⊻ b, a .>> n, a .& mas
 | Finding | Action |
 |---------|--------|
 | `@ct.kernel` count | Each becomes a `function ... end` |
-| `for ... in range(...)` | Replace with `while` + `Int32` counter |
+| `for ... in range(...)` | Use `for k in Int32(1):n` (native for loops supported in 0.2) |
 | `ct.where` | Use `ifelse.(cond, x, y)` |
 | `.astype(ct.X)` | Use `convert(ct.Tile{X}, tile)` |
 | `ct.mma(a, b, acc=acc)` | Use `muladd(a, b, acc)` |
@@ -192,8 +192,9 @@ import cuTile as ct
 end
 
 # Kernel (typed TileArray parameters)
-function _my_kernel(output::ct.TileArray{T, 2}, input::ct.TileArray{T, 2},
-                    param::Int) where {T}
+function my_kernel(output::ct.TileArray{T, 2}, input::ct.TileArray{T, 2},
+                   param::Int) where {T}
+    ct.@compiler_options occupancy=2
     bid = ct.bid(1)
     # ... body ...
     return
@@ -205,8 +206,7 @@ function my_op(input::CuArray{T, 2}, output::CuArray{T, 2}) where {T}
     M, N = size(input)
 
     grid_size = M  # one block per row (example)
-    ct.launch(_my_kernel, grid_size, output, input,
-              ct.Constant(N); occupancy=2)
+    ct.launch(my_kernel, grid_size, output, input, ct.Constant(N))
 
     CUDA.synchronize()
     return nothing
@@ -256,12 +256,12 @@ Full critical rules (17) → [`references/critical-rules.md`](../references/crit
 | 2 | `ct.num_blocks(0)` | `ct.num_blocks(1)` | ☐ |
 | 3 | `ct.num_tiles(A, axis=1, shape=(...))` | `ct.num_tiles(A, 2, (...))` | ☐ |
 | 4 | `A.shape[0]` | `size(A, 1)` | ☐ |
-| 5 | `ct.arange(N, dtype=ct.int32)` | `ct.arange((N,), Int32)` | ☐ |
-| 6 | `ct.full((m,n), v, dtype=ct.float32)` | `ct.full((m,n), v, Float32)` | ☐ |
-| 7 | `ct.zeros((m,n), dtype=ct.float32)` | `ct.zeros((m,n), Float32)` | ☐ |
-| 8 | `ct.load(arr, index=(...), shape=(...))` | `ct.load(arr, (...), (...))` | ☐ |
+| 5 | `ct.arange(N, dtype=ct.int32)` | `ct.arange(N)` | ☐ |
+| 6 | `ct.full((m,n), v, dtype=ct.float32)` | `fill(v, (m, n))` — ct.full doesn't exist | ☐ |
+| 7 | `ct.zeros((m,n), dtype=ct.float32)` | `zeros(Float32, m, n)` — Base.zeros overlay | ☐ |
+| 8 | `ct.load(arr, index=(...), shape=(...))` | `ct.load(arr; index=(...), shape=(...))` — keyword preferred | ☐ |
 | 8b | `ct.load(... order=(...))` | `ct.load(... ; order=(...))` — **index positions must follow remapped dims** (Rule 16) | ☐ |
-| 9 | `ct.store(arr, index=(...), tile=t)` | `ct.store(arr, (...), t)` | ☐ |
+| 9 | `ct.store(arr, index=(...), tile=t)` | `ct.store(arr; index=(...), tile=t)` — keyword preferred | ☐ |
 | 10 | `ct.load(arr, index=bid, shape=())` (0-D tile) | `arr[bid]` | ☐ |
 | 11 | `tile.astype(ct.float32)` | `convert(ct.Tile{Float32}, tile)` | ☐ |
 | 12 | `ct.mma(a, b, acc=acc)` | `muladd(a, b, acc)` | ☐ |
@@ -280,7 +280,7 @@ Full critical rules (17) → [`references/critical-rules.md`](../references/crit
 | 25 | `ct.reshape(t, shape)` | `reshape(t, shape)` | ☐ |
 | 26 | `ct.extract(t, index=(...), shape=(...))` | `ct.extract(t, (...), (...))` | ☐ |
 | 27 | `ct.cat((a,b), axis=0)` | `ct.cat((a,b), 1)` | ☐ |
-| 28 | `for k in range(n):` | `k=Int32(1); while k<=n; ...; k+=Int32(1); end` | ☐ |
+| 28 | `for k in range(n):` | `for k in Int32(1):n` — native for loops supported | ☐ |
 | 29 | `a + b` (different shapes) | `a .+ b` | ☐ |
 | 30 | `a * b` (element-wise) | `a .* b` | ☐ |
 | 31 | `a / b` (element-wise) | `a ./ b` | ☐ |
@@ -314,7 +314,7 @@ python <skill-dir>/scripts/validate_cutile_jl.py <path_to_julia_file.jl>
 ```
 
 This checks for common anti-patterns:
-- `for` loops in kernel functions
+- `ct.full()` usage (doesn't exist — use fill/zeros/ones)
 - `.astype(` or `ct.where(` instead of Julia equivalents
 - Missing `return` at end of kernel
 - 0-based indexing in `ct.bid(0)`, `ct.num_blocks(0)`
@@ -323,7 +323,6 @@ This checks for common anti-patterns:
 - Lambda grids
 - `ct.cdiv(` instead of `cld(`
 - `ct.launch(stream, ...)` with Python-style stream argument
-- `ct.ones()` (not available in cuTile.jl)
 
 Fix any reported errors before proceeding.
 
@@ -347,15 +346,12 @@ include(joinpath(KERNEL_DIR, "<op>.jl"))
     @testset "basic correctness" begin
         M, N = 128, 256
         x_gpu = CUDA.rand(Float32, M, N)
-        out_gpu = CUDA.zeros(Float32, M, N)
+        out_gpu = similar(x_gpu)
 
-        # Call bridge function
-        julia_<op>(Int(pointer(x_gpu)), Int(pointer(out_gpu)), M, N)
+        my_op!(out_gpu, x_gpu)
 
-        # Compare against reference
         expected = reference_impl(Array(x_gpu))
-        result = Array(out_gpu)
-        @test result ≈ expected atol=1e-5
+        @test Array(out_gpu) ≈ expected atol=1e-5
     end
 end
 ```
@@ -391,7 +387,7 @@ If test fails → fix → re-validate → re-test (loop until green, max 5 attem
 Julia Kernel (julia/kernels/<op>.jl):
  [ ] File exists in correct location
  [ ] All indices converted from 0-based to 1-based
- [ ] for loops replaced with while loops
+ [ ] for loops use Int32 ranges (for k in Int32(1):n)
  [ ] Broadcasting uses .+ .* etc. for different-shape tiles
  [ ] cuTile-specific math (rsqrt) uses rsqrt.(tile) — cuTile.jl exports rsqrt
  [ ] ct.Constant parameters wrapped at launch site (not in signature)
@@ -399,14 +395,14 @@ Julia Kernel (julia/kernels/<op>.jl):
  [ ] ct.mma → muladd, ct.matmul → *
  [ ] .astype() → convert(ct.Tile{T}, tile)
  [ ] ct.where → ifelse.(cond, x, y)
- [ ] ct.full/ct.zeros use Julia types (Float32 not ct.float32)
+ [ ] fill/zeros/ones use Julia types (ct.full doesn't exist; use fill, zeros, ones)
  [ ] Kernel returns nothing
  [ ] Column-major layout considered
  [ ] ct.launch arg order matches kernel signature
  [ ] Element-wise max/min uses max.(a,b) not max(a,b)
  [ ] No Int32()/Float32() casts on runtime kernel values
  [ ] ct.arange/ct.full shape args use ct.Constant parameters (no @eval needed)
- [ ] Host harness uses unsafe_wrap(CuArray, ptr, shape; own=false) if bridging
+ [ ] Host harness accepts CuArray directly
  [ ] Host harness calls CUDA.synchronize() after launch
  [ ] validate_cutile_jl.py passes
 

--- a/julia/Manifest.toml
+++ b/julia/Manifest.toml
@@ -6,7 +6,7 @@
 
 julia_version = "1.12.5"
 manifest_format = "2.0"
-project_hash = "22e2947d98422eaeedf506d1cd70e53c882fe86c"
+project_hash = "566febac560058b9e63ffa9e4b7d917fc9fd4913"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]
@@ -39,21 +39,15 @@ weakdeps = ["SparseArrays", "StaticArrays"]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 version = "1.1.2"
 
-[[deps.ArnoldiMethod]]
-deps = ["LinearAlgebra", "Random", "StaticArrays"]
-git-tree-sha1 = "d57bd3762d308bded22c3b82d033bff85f6195c6"
-uuid = "ec485272-7323-5ecc-a04f-4719b315124d"
-version = "0.4.0"
-
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 version = "1.11.0"
 
 [[deps.Atomix]]
 deps = ["UnsafeAtomics"]
-git-tree-sha1 = "29bb0eb6f578a587a49da16564705968667f5fa8"
+git-tree-sha1 = "b8651b2eb5796a386b0398a20b519a6a6150f75c"
 uuid = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
-version = "1.1.2"
+version = "1.1.3"
 
     [deps.Atomix.extensions]
     AtomixCUDAExt = "CUDA"
@@ -126,15 +120,15 @@ version = "0.21.0+0"
 
 [[deps.CUDA_Tile_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "177a579593feeaa86632c422aad2f9c305a77824"
+git-tree-sha1 = "cb997051ff44db3ce652a0b115838945fb06f6da"
 uuid = "2068806d-a867-5dbd-af0e-42c2eb5d895d"
-version = "13.1.6+0"
+version = "13.2.0+0"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra"]
-git-tree-sha1 = "e4c6a16e77171a5f5e25e9646617ab1c276c5607"
+git-tree-sha1 = "12177ad6b3cad7fd50c8b3825ce24a99ad61c18f"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.26.0"
+version = "1.26.1"
 weakdeps = ["SparseArrays"]
 
     [deps.ChainRulesCore.extensions]
@@ -151,9 +145,9 @@ weakdeps = ["Dates", "LinearAlgebra"]
     CompatLinearAlgebraExt = "LinearAlgebra"
 
 [[deps.CompilerCaching]]
-git-tree-sha1 = "b5c5ec2858307c363db87008daf704bb8c834ec7"
+git-tree-sha1 = "896d45723256948e3bef892c4881188701a2e71a"
 uuid = "9db33cc3-5358-4881-8759-fa4194144afd"
-version = "0.1.2"
+version = "0.2.2"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -170,12 +164,6 @@ git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 version = "1.16.0"
 
-[[deps.DataStructures]]
-deps = ["OrderedCollections"]
-git-tree-sha1 = "e357641bb3e0638d353c4b29ea0e40ea644066a6"
-uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.19.3"
-
 [[deps.DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
 uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
@@ -190,6 +178,11 @@ version = "1.11.0"
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 version = "1.7.0"
+
+[[deps.EnumX]]
+git-tree-sha1 = "c49898e8438c828577f04b92fc9368c388ac783c"
+uuid = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
+version = "1.0.7"
 
 [[deps.ExprTools]]
 git-tree-sha1 = "27415f162e6028e81c72b82ef756bf321213b6ec"
@@ -220,28 +213,15 @@ version = "0.2.0"
 
 [[deps.GPUCompiler]]
 deps = ["ExprTools", "InteractiveUtils", "LLVM", "Libdl", "Logging", "PrecompileTools", "Preferences", "Scratch", "Serialization", "TOML", "Tracy", "UUIDs"]
-git-tree-sha1 = "966946d226e8b676ca6409454718accb18c34c54"
+git-tree-sha1 = "fedfe5e7db7035271c3f58359007f971da1dde87"
 uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
-version = "1.8.2"
+version = "1.9.1"
 
 [[deps.GPUToolbox]]
 deps = ["LLVM"]
-git-tree-sha1 = "9e9186b09a13b7f094f87d1a9bb266d8780e1b1c"
+git-tree-sha1 = "a589b6c1a0eff953571f5d8b0474f5020831114d"
 uuid = "096a3bc2-3ced-46d0-87f4-dd12716f4bfc"
-version = "1.0.0"
-
-[[deps.Graphs]]
-deps = ["ArnoldiMethod", "DataStructures", "Inflate", "LinearAlgebra", "Random", "SimpleTraits", "SparseArrays", "Statistics"]
-git-tree-sha1 = "7eb45fe833a5b7c51cf6d89c5a841d5967e44be3"
-uuid = "86223c79-3864-5bf0-83f7-82e725a168b6"
-version = "1.14.0"
-
-    [deps.Graphs.extensions]
-    GraphsSharedArraysExt = "SharedArrays"
-
-    [deps.Graphs.weakdeps]
-    Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-    SharedArrays = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+version = "1.1.1"
 
 [[deps.HashArrayMappedTries]]
 git-tree-sha1 = "2eaa69a7cab70a52b9687c8bf950a5a93ec895ae"
@@ -249,15 +229,10 @@ uuid = "076d061b-32b6-4027-95e0-9a2c6f6d7e74"
 version = "0.2.0"
 
 [[deps.IRStructurizer]]
-deps = ["AbstractTrees", "Graphs", "MLStyle", "PrecompileTools"]
-git-tree-sha1 = "1c27fc3a1d19a0b00bf82d17f66134034ce950b1"
+deps = ["AbstractTrees", "MLStyle", "PrecompileTools"]
+git-tree-sha1 = "f0ca2686771554ad3f6d2604b0d58040844dba5c"
 uuid = "93e32bba-5bb8-402b-805d-ffb066edee93"
-version = "0.1.2"
-
-[[deps.Inflate]]
-git-tree-sha1 = "d1b1b796e47d94588b3757fe84fbf65a5ec4a80d"
-uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
-version = "0.1.5"
+version = "0.5.3"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
@@ -288,9 +263,9 @@ version = "1.12.0"
 
 [[deps.KernelAbstractions]]
 deps = ["Adapt", "Atomix", "InteractiveUtils", "MacroTools", "PrecompileTools", "Requires", "StaticArrays", "UUIDs"]
-git-tree-sha1 = "fb14a863240d62fbf5922bf9f8803d7df6c62dc8"
+git-tree-sha1 = "f2e76d3ced51a2a9e185abc0b97494c7273f649f"
 uuid = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
-version = "0.9.40"
+version = "0.9.41"
 
     [deps.KernelAbstractions.extensions]
     EnzymeExt = "EnzymeCore"
@@ -482,9 +457,9 @@ version = "1.5.2"
 
 [[deps.PrettyTables]]
 deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "REPL", "Reexport", "StringManipulation", "Tables"]
-git-tree-sha1 = "211530a7dc76ab59087f4d4d1fc3f086fbe87594"
+git-tree-sha1 = "624de6279ab7d94fc9f672f0068107eb6619732c"
 uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
-version = "3.2.3"
+version = "3.3.2"
 
     [deps.PrettyTables.extensions]
     PrettyTablesTypstryExt = "Typstry"
@@ -549,12 +524,6 @@ version = "1.3.0"
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 version = "1.11.0"
-
-[[deps.SimpleTraits]]
-deps = ["InteractiveUtils", "MacroTools"]
-git-tree-sha1 = "be8eeac05ec97d379347584fa9fe2f5f76795bcb"
-uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
-version = "0.9.5"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
@@ -655,9 +624,9 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 version = "1.11.0"
 
 [[deps.UnsafeAtomics]]
-git-tree-sha1 = "b13c4edda90890e5b04ba24e20a310fbe6f249ff"
+git-tree-sha1 = "0f30765c32d66d58e41f4cb5624d4fc8a82ec13b"
 uuid = "013be700-e6cd-48c3-b4a1-df204f14c38f"
-version = "0.3.0"
+version = "0.3.1"
 weakdeps = ["LLVM"]
 
     [deps.UnsafeAtomics.extensions]
@@ -669,10 +638,10 @@ uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 version = "1.3.1+2"
 
 [[deps.cuTile]]
-deps = ["BFloat16s", "CUDA_Compiler_jll", "CUDA_Tile_jll", "CompilerCaching", "IRStructurizer"]
-git-tree-sha1 = "477b1b65f2c7e0f69c938cae33077e1091ef2343"
+deps = ["BFloat16s", "CUDA_Compiler_jll", "CUDA_Tile_jll", "CompilerCaching", "EnumX", "GPUArrays", "IRStructurizer"]
+path = "../../.."
 uuid = "0dea8319-8c4a-4662-a73d-20234d115b9a"
-version = "0.1.1"
+version = "0.2.0"
 
     [deps.cuTile.extensions]
     CUDAExt = "CUDA"

--- a/julia/Project.toml
+++ b/julia/Project.toml
@@ -18,5 +18,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 CUDA = "5.9"
+cuTile = "0.2"
 NNlib = "0.9"
 julia = "1.12"

--- a/julia/kernels/add.jl
+++ b/julia/kernels/add.jl
@@ -16,91 +16,60 @@ import cuTile as ct
  Add Kernel (tensor + tensor): output = x + y * alpha
 =============================================================================#
 
-function _add_kernel(x::ct.TileArray{T,1}, y::ct.TileArray{T,1},
-                     output::ct.TileArray{T,1},
-                     alpha::Float32, BLOCK_SIZE::Int) where {T}
+function add_kernel(x::ct.TileArray{T,1}, y::ct.TileArray{T,1},
+                    output::ct.TileArray{T,1},
+                    alpha::Float32, BLOCK_SIZE::Int) where {T}
     bid = ct.bid(1)
 
-    # Load input tiles at block index
-    x_tile = ct.load(x, bid, (BLOCK_SIZE,))
-    y_tile = ct.load(y, bid, (BLOCK_SIZE,))
+    x_tile = ct.load(x; index=bid, shape=(BLOCK_SIZE,), padding_mode=ct.PaddingMode.Zero)
+    y_tile = ct.load(y; index=bid, shape=(BLOCK_SIZE,), padding_mode=ct.PaddingMode.Zero)
 
     x_f32 = convert(ct.Tile{Float32}, x_tile)
     y_f32 = convert(ct.Tile{Float32}, y_tile)
 
-    # Compute: x + y * alpha
-    alpha_tile = ct.full((BLOCK_SIZE,), alpha, Float32)
-    y_scaled = y_f32 .* alpha_tile
-    output_f32 = x_f32 .+ y_scaled
-
-    ct.store(output, bid, convert(ct.Tile{T}, output_f32))
-    return nothing
+    # Scalar alpha broadcasts to tile shape automatically
+    output_f32 = x_f32 .+ y_f32 .* alpha
+    ct.store(output; index=bid, tile=convert(ct.Tile{T}, output_f32))
+    return
 end
 
 #=============================================================================
  Add Scalar Kernel (tensor + scalar): output = x + scalar_val * alpha
 =============================================================================#
 
-function _add_scalar_kernel(x::ct.TileArray{T,1}, output::ct.TileArray{T,1},
-                            scalar_val::Float32, alpha::Float32,
-                            BLOCK_SIZE::Int) where {T}
+function add_scalar_kernel(x::ct.TileArray{T,1}, output::ct.TileArray{T,1},
+                           scalar_val::Float32, alpha::Float32,
+                           BLOCK_SIZE::Int) where {T}
     bid = ct.bid(1)
 
-    # Load input tile at block index
-    x_tile = ct.load(x, bid, (BLOCK_SIZE,))
+    x_tile = ct.load(x; index=bid, shape=(BLOCK_SIZE,), padding_mode=ct.PaddingMode.Zero)
     x_f32 = convert(ct.Tile{Float32}, x_tile)
 
-    # Compute: x + scalar * alpha
-    scaled_scalar = scalar_val * alpha
-    scalar_tile = ct.full((BLOCK_SIZE,), scaled_scalar, Float32)
-    output_f32 = x_f32 .+ scalar_tile
-
-    ct.store(output, bid, convert(ct.Tile{T}, output_f32))
-    return nothing
+    output_f32 = x_f32 .+ (scalar_val * alpha)
+    ct.store(output; index=bid, tile=convert(ct.Tile{T}, output_f32))
+    return
 end
 
 #=============================================================================
  Host Functions
- Accept raw GPU pointers, wrap as CuArray, launch kernel.
 =============================================================================#
 
-function add!(x_ptr::Int, y_ptr::Int, out_ptr::Int,
-              n_elements::Int, alpha::Float64)
-    BLOCK_SIZE = 1024
-    # Pad n_elements to multiple of BLOCK_SIZE
-    padded_n = cld(n_elements, BLOCK_SIZE) * BLOCK_SIZE
-
-    x_cu = unsafe_wrap(CuArray{Float32, 1}, CUDA.CuPtr{Float32}(UInt(x_ptr)),
-                       (padded_n,); own=false)
-    y_cu = unsafe_wrap(CuArray{Float32, 1}, CUDA.CuPtr{Float32}(UInt(y_ptr)),
-                       (padded_n,); own=false)
-    out_cu = unsafe_wrap(CuArray{Float32, 1}, CUDA.CuPtr{Float32}(UInt(out_ptr)),
-                         (padded_n,); own=false)
-
-    grid = cld(padded_n, BLOCK_SIZE)
-    ct.launch(_add_kernel, grid, x_cu, y_cu, out_cu,
-              ct.Constant(Float32(alpha)), ct.Constant(BLOCK_SIZE))
-
+function add!(output::CuVector{T}, x::CuVector{T}, y::CuVector{T};
+              alpha::Float32=1.0f0, block_size::Int=1024) where {T}
+    n = length(x)
+    grid = cld(n, block_size)
+    ct.launch(add_kernel, grid, x, y, output,
+              ct.Constant(alpha), ct.Constant(block_size))
     CUDA.synchronize()
-    return nothing
+    return
 end
 
-function add_scalar!(x_ptr::Int, out_ptr::Int,
-                     n_elements::Int, scalar_val::Float64, alpha::Float64)
-    BLOCK_SIZE = 1024
-    # Pad n_elements to multiple of BLOCK_SIZE
-    padded_n = cld(n_elements, BLOCK_SIZE) * BLOCK_SIZE
-
-    x_cu = unsafe_wrap(CuArray{Float32, 1}, CUDA.CuPtr{Float32}(UInt(x_ptr)),
-                       (padded_n,); own=false)
-    out_cu = unsafe_wrap(CuArray{Float32, 1}, CUDA.CuPtr{Float32}(UInt(out_ptr)),
-                         (padded_n,); own=false)
-
-    grid = cld(padded_n, BLOCK_SIZE)
-    ct.launch(_add_scalar_kernel, grid, x_cu, out_cu,
-              ct.Constant(Float32(scalar_val)), ct.Constant(Float32(alpha)),
-              ct.Constant(BLOCK_SIZE))
-
+function add_scalar!(output::CuVector{T}, x::CuVector{T}, scalar_val::Float32;
+                     alpha::Float32=1.0f0, block_size::Int=1024) where {T}
+    n = length(x)
+    grid = cld(n, block_size)
+    ct.launch(add_scalar_kernel, grid, x, output,
+              ct.Constant(scalar_val), ct.Constant(alpha), ct.Constant(block_size))
     CUDA.synchronize()
-    return nothing
+    return
 end

--- a/julia/kernels/matmul.jl
+++ b/julia/kernels/matmul.jl
@@ -4,63 +4,63 @@
 
 # cuTile.jl matrix multiplication kernel
 #
-# Tile sizes passed as ct.Constant at launch (no @eval needed).
-#
-# Memory layout (column-major):
-#   A(K, M), B(N, K), C(N, M)
-#   C[n,m] = sum_k B[n,k] * A[k,m]
-#   acc = muladd(b_tile, a_tile, acc) where b_tile is (tn, tk), a_tile is (tk, tm)
+# Standard Julia layout (column-major):
+#   A(M, K), B(K, N), C(M, N)
+#   C = A * B
 
 using CUDA
 import cuTile as ct
 
+# 2D swizzle for better L2 cache locality.
+# Groups blocks to access nearby memory regions together.
+@inline function swizzle_2d(M, N, tm, tn, GROUP_SIZE_M, bid)
+    num_bid_m = cld(M, Int32(tm))
+    num_bid_n = cld(N, Int32(tn))
+    num_bid_in_group = Int32(GROUP_SIZE_M) * num_bid_n
+    group_id = fld(bid, num_bid_in_group)
+    first_bid_m = group_id * Int32(GROUP_SIZE_M)
+    group_size_m = min(num_bid_m - first_bid_m, Int32(GROUP_SIZE_M))
+    bid_m = first_bid_m + rem(bid, group_size_m)
+    bid_n = fld(rem(bid, num_bid_in_group), group_size_m)
+    return bid_m, bid_n
+end
+
 #=============================================================================
- Matmul Kernel with ct.Constant tile sizes
- Grid: (num_m_tiles, num_n_tiles)
-   bid(1) -> M tile index
-   bid(2) -> N tile index
+ Matmul Kernel: C = A * B
+ Uses 1D grid with 2D swizzle for cache locality.
 =============================================================================#
 
-function _matmul_kernel(A_jl::ct.TileArray{T, 2},
-                        B_jl::ct.TileArray{T, 2},
-                        C_jl::ct.TileArray{T, 2},
-                        num_k_tiles::Int,
-                        TM::Int, TN::Int, TK::Int) where {T}
-    # Grid dimensions (1-indexed)
-    # A_jl is (K, M), B_jl is (N, K), C_jl is (N, M)
-    bid_m = ct.bid(1)      # M tile index
-    bid_n = ct.bid(2)      # N tile index
+function matmul_kernel(A::ct.TileArray{T,2}, B::ct.TileArray{T,2},
+                       C::ct.TileArray{T,2},
+                       tm::Int, tn::Int, tk::Int) where {T}
+    ct.@compiler_options num_ctas=ct.ByTarget(v"10.0" => 2)
 
-    # Initialize accumulator with Float32 for precision
-    acc = ct.full((TN, TM), zero(Float32), Float32)
+    # 1D grid with 2D swizzle for better L2 cache locality
+    bid = ct.bid(1)
+    M = size(A, 1)
+    N = size(B, 2)
+    # swizzle_2d expects 0-indexed bid, returns 0-indexed tile coords
+    bid_m_0, bid_n_0 = swizzle_2d(M, N, tm, tn, 8, bid - Int32(1))
+    bid_m = bid_m_0 + Int32(1)
+    bid_n = bid_n_0 + Int32(1)
 
-    # K reduction loop (while, not for)
-    k = Int32(1)
-    while k <= num_k_tiles
-        # Load A_jl tile: shape (K, M), load (tk, tm) at (k, bid_m)
-        a_tile = ct.load(A_jl, (k, bid_m), (TK, TM);
-                         padding_mode=ct.PaddingMode.Zero)
+    num_k = ct.num_tiles(A, 2, (tm, tk))
 
-        # Load B_jl tile: shape (N, K), load (tn, tk) at (bid_n, k)
-        b_tile = ct.load(B_jl, (bid_n, k), (TN, TK);
-                         padding_mode=ct.PaddingMode.Zero)
+    acc = zeros(Float32, tm, tn)
 
+    for k in Int32(1):num_k
+        a = ct.load(A; index=(bid_m, k), shape=(tm, tk), padding_mode=ct.PaddingMode.Zero)
+        b = ct.load(B; index=(k, bid_n), shape=(tk, tn), padding_mode=ct.PaddingMode.Zero)
         # Convert to TF32 for tensor cores (Float32 inputs only)
         if T === Float32
-            a_tile = convert(ct.Tile{ct.TFloat32}, a_tile)
-            b_tile = convert(ct.Tile{ct.TFloat32}, b_tile)
+            a = convert(ct.Tile{ct.TFloat32}, a)
+            b = convert(ct.Tile{ct.TFloat32}, b)
         end
-
-        # C_jl[n,m] = sum_k B_jl[n,k] * A_jl[k,m] => muladd(b_tile, a_tile, acc)
-        acc = muladd(b_tile, a_tile, acc)
-        k += Int32(1)
+        acc = muladd(a, b, acc)
     end
 
-    # Convert to output type and store
-    result = convert(ct.Tile{T}, acc)
-    ct.store(C_jl, (bid_n, bid_m), result)
-
-    return nothing
+    ct.store(C; index=(bid_m, bid_n), tile=convert(ct.Tile{T}, acc))
+    return
 end
 
 #=============================================================================
@@ -68,37 +68,20 @@ end
 =============================================================================#
 
 """
-    matmul!(a_ptr, b_ptr, c_ptr, K_dim, M_dim, N_dim, tm, tn, tk)
+    matmul!(C, A, B; tm=128, tn=128, tk=64)
 
-Launch matmul kernel. Tile sizes are passed as ct.Constant.
+Launch matmul kernel: C = A * B.
 
 Memory layout (column-major):
-  A shape: (K, M), B shape: (N, K), C shape: (N, M)
+  A shape: (M, K), B shape: (K, N), C shape: (M, N)
 """
-function matmul!(a_ptr::Int, b_ptr::Int, c_ptr::Int,
-                 K_dim::Int, M_dim::Int, N_dim::Int,
-                 tm::Int, tn::Int, tk::Int)
-    # A_jl shape: (K, M), B_jl shape: (N, K), C_jl shape: (N, M)
-    A_cu = unsafe_wrap(CuArray{Float32, 2},
-                       CUDA.CuPtr{Float32}(UInt(a_ptr)),
-                       (K_dim, M_dim); own=false)
-    B_cu = unsafe_wrap(CuArray{Float32, 2},
-                       CUDA.CuPtr{Float32}(UInt(b_ptr)),
-                       (N_dim, K_dim); own=false)
-    C_cu = unsafe_wrap(CuArray{Float32, 2},
-                       CUDA.CuPtr{Float32}(UInt(c_ptr)),
-                       (N_dim, M_dim); own=false)
-
-    num_m_tiles = cld(M_dim, tm)
-    num_n_tiles = cld(N_dim, tn)
-    num_k_tiles = cld(K_dim, tk)
-    grid = (num_m_tiles, num_n_tiles)
-
-    ct.launch(_matmul_kernel, grid, A_cu, B_cu, C_cu,
-              ct.Constant(num_k_tiles),
-              ct.Constant(tm), ct.Constant(tn), ct.Constant(tk);
-              occupancy=2)
-
+function matmul!(C::CuMatrix{T}, A::CuMatrix{T}, B::CuMatrix{T};
+                 tm::Int=128, tn::Int=128, tk::Int=64) where {T}
+    M = size(A, 1)
+    N = size(B, 2)
+    grid = cld(M, tm) * cld(N, tn)
+    ct.launch(matmul_kernel, grid, A, B, C,
+              ct.Constant(tm), ct.Constant(tn), ct.Constant(tk))
     CUDA.synchronize()
-    return nothing
+    return
 end

--- a/julia/kernels/softmax.jl
+++ b/julia/kernels/softmax.jl
@@ -7,7 +7,7 @@
 # Three strategies:
 # 1. TMA single-tile: loads entire row in one ct.load (small N)
 # 2. Online softmax: 2-pass column-loop with running max/sum (large N)
-# 3. Chunked softmax: 3-pass with gather/scatter (explicit chunking)
+# 3. Chunked softmax: 3-pass with explicit chunking (large N)
 
 using CUDA
 import cuTile as ct
@@ -15,33 +15,31 @@ import cuTile as ct
 #=============================================================================
  Strategy 1: TMA Single-Tile (for small N where TILE_SIZE >= N)
  Loads entire row in one ct.load call with NegInf padding.
+ Uses persistent scheduling: each block processes multiple rows.
 =============================================================================#
-function _softmax_kernel_tma(output::ct.TileArray{T, 2}, input::ct.TileArray{T, 2},
-                             n_rows::Int, n_cols::Int,
-                             TILE_SIZE::Int) where {T}
+function softmax_kernel_tma(output::ct.TileArray{T,2}, input::ct.TileArray{T,2},
+                            TILE_SIZE::Int) where {T}
+    ct.@compiler_options occupancy=2
+
     pid = ct.bid(1)
     num_programs = ct.num_blocks(1)
+    n_rows = size(input, 1)
 
     row_idx = pid
     while row_idx <= n_rows
-        row = ct.load(input, (row_idx, Int32(1)), (1, TILE_SIZE);
+        row = ct.load(input; index=(row_idx, Int32(1)), shape=(1, TILE_SIZE),
                       padding_mode=ct.PaddingMode.NegInf)
-
         row = convert(ct.Tile{Float32}, row)
 
         row_max = maximum(row; dims=2)
-        row_minus_max = row .- row_max
-
-        numerator = exp.(row_minus_max)
+        numerator = exp.(row .- row_max)
         denominator = sum(numerator; dims=2)
         softmax_output = numerator ./ denominator
 
-        softmax_output = convert(ct.Tile{T}, softmax_output)
-        ct.store(output, (row_idx, Int32(1)), softmax_output)
-
+        ct.store(output; index=(row_idx, Int32(1)),
+                 tile=convert(ct.Tile{T}, softmax_output))
         row_idx += num_programs
     end
-
     return
 end
 
@@ -50,110 +48,97 @@ end
  Pass 1: streaming max + sum via numerically stable online algorithm
  Pass 2: normalize each tile chunk using final max and sum
 =============================================================================#
-function _softmax_kernel_online(output::ct.TileArray{T, 2}, input::ct.TileArray{T, 2},
-                                n_cols::Int, TILE_SIZE::Int,
-                                tile_num_per_row::Int) where {T}
-    # One block per row
+function softmax_kernel_online(output::ct.TileArray{T,2}, input::ct.TileArray{T,2},
+                               TILE_SIZE::Int) where {T}
     row_idx = ct.bid(1)
+    num_col_tiles = ct.num_tiles(input, 2, (1, TILE_SIZE))
 
-    # Initialize running max and sum
-    m_prev = ct.full((1, 1), -Inf32, Float32)
-    l_prev = ct.full((1, 1), 0.0f0, Float32)
+    m_prev = fill(-Inf32, (1, 1))
+    l_prev = zeros(Float32, 1, 1)
 
     # Pass 1: compute running max and sum
-    col_idx = Int32(1)
-    while col_idx <= tile_num_per_row
-        row_tile = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
+    for col_idx in Int32(1):num_col_tiles
+        row_tile = ct.load(input; index=(row_idx, col_idx), shape=(1, TILE_SIZE),
+                          padding_mode=ct.PaddingMode.NegInf)
         row_tile = convert(ct.Tile{Float32}, row_tile)
 
         tile_max = maximum(row_tile; dims=2)
         m_curr = max.(tile_max, m_prev)
 
-        # Correct old l_prev: l_prev *= exp(m_prev - m_curr)
-        exp_diff = exp.(m_prev .- m_curr)
-        l_prev = l_prev .* exp_diff
+        # Correct old sum: l_prev *= exp(m_prev - m_curr)
+        l_prev = l_prev .* exp.(m_prev .- m_curr)
 
-        # Update with current tile: p = exp(row - m_curr)
+        # Update with current tile
         p = exp.(row_tile .- m_curr)
-        l_curr = sum(p; dims=2)
-
-        l_prev = l_curr .+ l_prev
+        l_prev = sum(p; dims=2) .+ l_prev
         m_prev = m_curr
-
-        col_idx += Int32(1)
     end
 
     # Pass 2: compute actual softmax values
-    col_idx = Int32(1)
-    while col_idx <= tile_num_per_row
-        row_tile = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
+    for col_idx in Int32(1):num_col_tiles
+        row_tile = ct.load(input; index=(row_idx, col_idx), shape=(1, TILE_SIZE),
+                          padding_mode=ct.PaddingMode.NegInf)
         row_tile = convert(ct.Tile{Float32}, row_tile)
 
-        row_minus_max = row_tile .- m_prev
-        numerator = exp.(row_minus_max)
+        numerator = exp.(row_tile .- m_prev)
         softmax_output = numerator ./ l_prev
 
-        softmax_output = convert(ct.Tile{T}, softmax_output)
-        ct.store(output, (row_idx, col_idx), softmax_output)
-
-        col_idx += Int32(1)
+        ct.store(output; index=(row_idx, col_idx),
+                 tile=convert(ct.Tile{T}, softmax_output))
     end
-
     return
 end
 
 #=============================================================================
- Strategy 3: Chunked Softmax (3-pass with ct.load/ct.store)
+ Strategy 3: Chunked Softmax (3-pass with gather/scatter)
+ Uses index-based access with bounds checking (matches Python TileGym).
  Pass 1: find row maximum across all chunks
  Pass 2: compute sum of exp(x - max) across all chunks
- Pass 3: compute final softmax = exp(x - max) / sum and store back
-
- Tile size passed as ct.Constant (no @eval needed).
+ Pass 3: compute final softmax = exp(x - max) / sum and scatter back
 =============================================================================#
+function softmax_kernel_chunked(output::ct.TileArray{T,2}, input::ct.TileArray{T,2},
+                                n_cols::Int, TILE_SIZE::Int) where {T}
+    ct.@compiler_options occupancy=4
 
-function _softmax_kernel_chunked(output::ct.TileArray{T, 2}, input::ct.TileArray{T, 2},
-                                 num_chunks::Int, TILE_SIZE::Int) where {T}
-    # One block per row
     row_idx = ct.bid(1)
+    num_chunks = (n_cols + TILE_SIZE - Int32(1)) ÷ Int32(TILE_SIZE)
+    col_offsets_base = ct.arange(TILE_SIZE)
+    row_tile = ct.Tile(row_idx)
 
-    row_max = ct.full((1, 1), -Inf32, Float32)
-    denominator = ct.full((1, 1), 0.0f0, Float32)
+    row_max = fill(-Inf32, (1,))
+    denominator = zeros(Float32, TILE_SIZE)
 
     # Pass 1: Find maximum across all chunks
-    col_idx = Int32(1)
-    while col_idx <= num_chunks
-        chunk = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
+    for chunk_idx in Int32(0):num_chunks - Int32(1)
+        col_indices = ct.broadcast_to(ct.Tile(chunk_idx * Int32(TILE_SIZE)), (TILE_SIZE,)) .+ col_offsets_base
+        chunk = ct.gather(input, (row_tile, col_indices);
+                         check_bounds=true, padding_value=T(-Inf))
         chunk = convert(ct.Tile{Float32}, chunk)
-        chunk_max = maximum(chunk; dims=2)
-        row_max = max.(row_max, chunk_max)
-        col_idx += Int32(1)
+        chunk_max = maximum(chunk)
+        row_max = max.(row_max, ct.Tile(chunk_max))
     end
 
     # Pass 2: Compute denominator (sum of all exp values)
-    col_idx = Int32(1)
-    while col_idx <= num_chunks
-        chunk = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
+    for chunk_idx in Int32(0):num_chunks - Int32(1)
+        col_indices = ct.broadcast_to(ct.Tile(chunk_idx * Int32(TILE_SIZE)), (TILE_SIZE,)) .+ col_offsets_base
+        chunk = ct.gather(input, (row_tile, col_indices);
+                         check_bounds=true, padding_value=T(-Inf))
         chunk = convert(ct.Tile{Float32}, chunk)
-        row_minus_max = chunk .- row_max
-        numerator = exp.(row_minus_max)
-        exponentials_sum = sum(numerator; dims=2)
-        denominator = denominator .+ exponentials_sum
-        col_idx += Int32(1)
+        numerator = exp.(chunk .- row_max)
+        denominator = denominator .+ numerator
     end
+    denom_sum = ct.Tile(sum(denominator))
 
-    # Pass 3: Compute final softmax and store
-    col_idx = Int32(1)
-    while col_idx <= num_chunks
-        chunk = ct.load(input, (row_idx, col_idx), (1, TILE_SIZE))
+    # Pass 3: Compute final softmax and scatter
+    for chunk_idx in Int32(0):num_chunks - Int32(1)
+        col_indices = ct.broadcast_to(ct.Tile(chunk_idx * Int32(TILE_SIZE)), (TILE_SIZE,)) .+ col_offsets_base
+        chunk = ct.gather(input, (row_tile, col_indices);
+                         check_bounds=true, padding_value=T(-Inf))
         chunk = convert(ct.Tile{Float32}, chunk)
-        row_minus_max = chunk .- row_max
-        numerator = exp.(row_minus_max)
-        softmax_output = numerator ./ denominator
-        softmax_output = convert(ct.Tile{T}, softmax_output)
-        ct.store(output, (row_idx, col_idx), softmax_output)
-        col_idx += Int32(1)
+        softmax_output = exp.(chunk .- row_max) ./ denom_sum
+        ct.scatter(output, (row_tile, col_indices), convert(ct.Tile{T}, softmax_output);
+                  check_bounds=true)
     end
-
     return
 end
 
@@ -162,62 +147,43 @@ end
 =============================================================================#
 
 """
-    softmax_tma!(input_ptr, output_ptr, M, N, TILE_SIZE)
+    softmax_tma!(output, input; tile_size)
 
-TMA single-tile strategy. TILE_SIZE must be >= N.
+TMA single-tile strategy. tile_size must be >= size(input, 2).
 """
-function softmax_tma!(input_ptr::Int, output_ptr::Int, M::Int, N::Int, TILE_SIZE::Int)
-    input_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(input_ptr)), (M, N); own=false)
-    output_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(output_ptr)), (M, N); own=false)
-
-    ct.launch(_softmax_kernel_tma, M, output_cu, input_cu,
-              ct.Constant(M), ct.Constant(N), ct.Constant(TILE_SIZE);
-              occupancy=2)
-
+function softmax_tma!(output::CuMatrix{T}, input::CuMatrix{T};
+                      tile_size::Int=1024) where {T}
+    M = size(input, 1)
+    ct.launch(softmax_kernel_tma, M, output, input, ct.Constant(tile_size))
     CUDA.synchronize()
-    return nothing
+    return
 end
 
 """
-    softmax_online!(input_ptr, output_ptr, M, N, TILE_SIZE, tile_num_per_row)
+    softmax_online!(output, input; tile_size)
 
-Online softmax strategy. Processes row in TILE_SIZE chunks.
-Input must be padded to tile_num_per_row * TILE_SIZE columns.
+Online softmax strategy. Processes row in tile_size chunks.
 """
-function softmax_online!(input_ptr::Int, output_ptr::Int,
-                         M::Int, N::Int, TILE_SIZE::Int, tile_num_per_row::Int)
-    # N here is the padded column count (tile_num_per_row * TILE_SIZE)
-    padded_N = tile_num_per_row * TILE_SIZE
-    input_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(input_ptr)), (M, padded_N); own=false)
-    output_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(output_ptr)), (M, padded_N); own=false)
-
-    # One block per row for online variant
-    ct.launch(_softmax_kernel_online, M, output_cu, input_cu,
-              ct.Constant(N), ct.Constant(TILE_SIZE), ct.Constant(tile_num_per_row);
-              occupancy=2)
-
+function softmax_online!(output::CuMatrix{T}, input::CuMatrix{T};
+                         tile_size::Int=1024) where {T}
+    M = size(input, 1)
+    ct.launch(softmax_kernel_online, M, output, input, ct.Constant(tile_size))
     CUDA.synchronize()
-    return nothing
+    return
 end
 
 """
-    softmax_chunked!(input_ptr, output_ptr, M, N, TILE_SIZE)
+    softmax_chunked!(output, input; tile_size)
 
-Chunked softmax strategy. TILE_SIZE is passed as ct.Constant.
+Chunked softmax strategy (3-pass, gather/scatter).
 """
-function softmax_chunked!(input_ptr::Int, output_ptr::Int, M::Int, N::Int, TILE_SIZE::Int)
-    num_chunks = cld(N, TILE_SIZE)
-    # Pad N to multiple of TILE_SIZE for ct.load alignment
-    padded_N = num_chunks * TILE_SIZE
-    input_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(input_ptr)), (M, padded_N); own=false)
-    output_cu = unsafe_wrap(CuArray{Float32, 2}, CUDA.CuPtr{Float32}(UInt(output_ptr)), (M, padded_N); own=false)
-
-    ct.launch(_softmax_kernel_chunked, M, output_cu, input_cu,
-              ct.Constant(num_chunks), ct.Constant(TILE_SIZE);
-              occupancy=4)
-
+function softmax_chunked!(output::CuMatrix{T}, input::CuMatrix{T};
+                          tile_size::Int=1024) where {T}
+    M, N = size(input)
+    ct.launch(softmax_kernel_chunked, M, output, input,
+              ct.Constant(N), ct.Constant(tile_size))
     CUDA.synchronize()
-    return nothing
+    return
 end
 
 const softmax! = softmax_tma!

--- a/julia/test/test_add.jl
+++ b/julia/test/test_add.jl
@@ -3,13 +3,10 @@
 # SPDX-License-Identifier: MIT
 
 # Tests for cuTile.jl add kernel
-#
-# Directly tests the host functions (add!, add_scalar!).
 
 using Test
 using CUDA
 
-# Load kernel from julia/kernels/
 const KERNEL_DIR = joinpath(@__DIR__, "..", "kernels")
 include(joinpath(KERNEL_DIR, "add.jl"))
 
@@ -19,26 +16,12 @@ include(joinpath(KERNEL_DIR, "add.jl"))
         for n in [128, 1024, 4096, 513]
             x = CUDA.rand(Float32, n)
             y = CUDA.rand(Float32, n)
-            out = CUDA.zeros(Float32, cld(n, 1024) * 1024)
+            out = similar(x)
 
-            # Pad inputs to block-aligned size
-            padded_n = cld(n, 1024) * 1024
-            x_padded = CUDA.zeros(Float32, padded_n)
-            y_padded = CUDA.zeros(Float32, padded_n)
-            copyto!(view(x_padded, 1:n), x)
-            copyto!(view(y_padded, 1:n), y)
-
-            add!(
-                Int(pointer(x_padded)),
-                Int(pointer(y_padded)),
-                Int(pointer(out)),
-                padded_n,
-                1.0
-            )
+            add!(out, x, y)
 
             expected = Array(x) .+ Array(y)
-            result = Array(out[1:n])
-            @test result ≈ expected atol=1e-5
+            @test Array(out) ≈ expected atol=1e-5
         end
     end
 
@@ -46,65 +29,35 @@ include(joinpath(KERNEL_DIR, "add.jl"))
         n = 1024
         x = CUDA.rand(Float32, n)
         y = CUDA.rand(Float32, n)
-        out = CUDA.zeros(Float32, n)
+        out = similar(x)
 
-        add!(
-            Int(pointer(x)),
-            Int(pointer(y)),
-            Int(pointer(out)),
-            n,
-            0.5
-        )
+        add!(out, x, y; alpha=0.5f0)
 
         expected = Array(x) .+ Array(y) .* 0.5f0
-        result = Array(out)
-        @test result ≈ expected atol=1e-5
+        @test Array(out) ≈ expected atol=1e-5
     end
 
     @testset "tensor + scalar" begin
         for n in [128, 1024, 4096]
             x = CUDA.rand(Float32, n)
-            scalar_val = 3.14
-            alpha = 1.0
+            out = similar(x)
 
-            padded_n = cld(n, 1024) * 1024
-            x_padded = CUDA.zeros(Float32, padded_n)
-            out = CUDA.zeros(Float32, padded_n)
-            copyto!(view(x_padded, 1:n), x)
+            add_scalar!(out, x, 3.14f0)
 
-            add_scalar!(
-                Int(pointer(x_padded)),
-                Int(pointer(out)),
-                padded_n,
-                scalar_val,
-                alpha
-            )
-
-            expected = Array(x) .+ Float32(scalar_val * alpha)
-            result = Array(out[1:n])
-            @test result ≈ expected atol=1e-5
+            expected = Array(x) .+ 3.14f0
+            @test Array(out) ≈ expected atol=1e-5
         end
     end
 
     @testset "tensor + scalar with alpha" begin
         n = 1024
         x = CUDA.rand(Float32, n)
-        scalar_val = 2.0
-        alpha = 0.5
+        out = similar(x)
 
-        out = CUDA.zeros(Float32, n)
+        add_scalar!(out, x, 2.0f0; alpha=0.5f0)
 
-        add_scalar!(
-            Int(pointer(x)),
-            Int(pointer(out)),
-            n,
-            scalar_val,
-            alpha
-        )
-
-        expected = Array(x) .+ Float32(scalar_val * alpha)
-        result = Array(out)
-        @test result ≈ expected atol=1e-5
+        expected = Array(x) .+ 1.0f0
+        @test Array(out) ≈ expected atol=1e-5
     end
 
 end

--- a/julia/test/test_matmul.jl
+++ b/julia/test/test_matmul.jl
@@ -4,10 +4,9 @@
 
 # Tests for cuTile.jl matmul kernel
 #
-# Memory layout (column-major):
-#   A shape: (K, M), B shape: (N, K), C shape: (N, M)
-#
-#   matmul!(a_ptr, b_ptr, c_ptr, K_dim, M_dim, N_dim, tm, tn, tk)
+# Standard Julia layout (column-major):
+#   A shape: (M, K), B shape: (K, N), C shape: (M, N)
+#   C = A * B
 
 using Test
 using CUDA
@@ -19,30 +18,15 @@ include(joinpath(KERNEL_DIR, "matmul.jl"))
 
     @testset "square matrices" begin
         for n in [64, 128, 256]
-            # Col-major layout: A(K,M), B(N,K), C(N,M)
             M, K, N = n, n, n
+            A = CUDA.rand(Float32, M, K)
+            B = CUDA.rand(Float32, K, N)
+            C = CUDA.zeros(Float32, M, N)
 
-            # Create the matrices as Julia would see them (col-major interpretation of row-major data)
-            # A_jl has shape (K, M), B_jl has shape (N, K), C_jl has shape (N, M)
-            A_jl = CUDA.rand(Float32, K, M)
-            B_jl = CUDA.rand(Float32, N, K)
-            C_jl = CUDA.zeros(Float32, N, M)
+            matmul!(C, A, B)
 
-            tm, tn, tk = 128, 128, 64
-
-            matmul!(
-                Int(pointer(A_jl)),
-                Int(pointer(B_jl)),
-                Int(pointer(C_jl)),
-                K, M, N,
-                tm, tn, tk
-            )
-
-            # Expected: C_jl[n,m] = sum_k B_jl[n,k] * A_jl[k,m]
-            # This is just B_jl * A_jl in matrix notation
-            expected = Array(B_jl) * Array(A_jl)
-            result = Array(C_jl)
-            @test result ≈ expected atol=1e-1 rtol=1e-2
+            expected = Array(A) * Array(B)
+            @test Array(C) ≈ expected atol=1e-1 rtol=1e-2
         end
     end
 
@@ -53,74 +37,42 @@ include(joinpath(KERNEL_DIR, "matmul.jl"))
             (M=128, K=256, N=64),
         ]
         for tc in test_cases
-            A_jl = CUDA.rand(Float32, tc.K, tc.M)
-            B_jl = CUDA.rand(Float32, tc.N, tc.K)
-            C_jl = CUDA.zeros(Float32, tc.N, tc.M)
+            A = CUDA.rand(Float32, tc.M, tc.K)
+            B = CUDA.rand(Float32, tc.K, tc.N)
+            C = CUDA.zeros(Float32, tc.M, tc.N)
 
-            tm, tn, tk = 128, 128, 64
+            matmul!(C, A, B)
 
-            matmul!(
-                Int(pointer(A_jl)),
-                Int(pointer(B_jl)),
-                Int(pointer(C_jl)),
-                tc.K, tc.M, tc.N,
-                tm, tn, tk
-            )
-
-            expected = Array(B_jl) * Array(A_jl)
-            result = Array(C_jl)
-            @test result ≈ expected atol=1e-1 rtol=1e-2
+            expected = Array(A) * Array(B)
+            @test Array(C) ≈ expected atol=1e-1 rtol=1e-2
         end
     end
 
     @testset "non-tile-aligned dimensions" begin
-        # Dimensions that don't divide evenly by tile size
         M, K, N = 100, 200, 150
+        A = CUDA.rand(Float32, M, K)
+        B = CUDA.rand(Float32, K, N)
+        C = CUDA.zeros(Float32, M, N)
 
-        A_jl = CUDA.rand(Float32, K, M)
-        B_jl = CUDA.rand(Float32, N, K)
-        C_jl = CUDA.zeros(Float32, N, M)
+        matmul!(C, A, B)
 
-        tm, tn, tk = 128, 128, 64
-
-        matmul!(
-            Int(pointer(A_jl)),
-            Int(pointer(B_jl)),
-            Int(pointer(C_jl)),
-            K, M, N,
-            tm, tn, tk
-        )
-
-        expected = Array(B_jl) * Array(A_jl)
-        result = Array(C_jl)
-        @test result ≈ expected atol=1e-1 rtol=1e-2
+        expected = Array(A) * Array(B)
+        @test Array(C) ≈ expected atol=1e-1 rtol=1e-2
     end
 
     @testset "identity multiplication" begin
-        # A_jl = I (identity), so C_jl = B_jl * I = B_jl
-        M = 128
-        K = 128
-        N = 128
+        M, K, N = 128, 128, 128
 
-        # Identity as col-major (K, M)
-        A_jl = CuArray(Float32[i == j ? 1.0f0 : 0.0f0 for i in 1:K, j in 1:M])
-        B_jl = CUDA.rand(Float32, N, K)
-        C_jl = CUDA.zeros(Float32, N, M)
+        # Identity matrix as (M, K)
+        A = CuArray(Float32[i == j ? 1.0f0 : 0.0f0 for i in 1:M, j in 1:K])
+        B = CUDA.rand(Float32, K, N)
+        C = CUDA.zeros(Float32, M, N)
 
-        tm, tn, tk = 128, 128, 64
+        matmul!(C, A, B)
 
-        matmul!(
-            Int(pointer(A_jl)),
-            Int(pointer(B_jl)),
-            Int(pointer(C_jl)),
-            K, M, N,
-            tm, tn, tk
-        )
-
-        expected = Array(B_jl) * Array(A_jl)
-        result = Array(C_jl)
+        expected = Array(A) * Array(B)
         # TF32 tensor cores have ~1e-3 relative precision
-        @test result ≈ expected atol=1e-1 rtol=1e-2
+        @test Array(C) ≈ expected atol=1e-1 rtol=1e-2
     end
 
 end

--- a/julia/test/test_softmax.jl
+++ b/julia/test/test_softmax.jl
@@ -2,9 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-# Tests for cuTile.jl softmax kernels (softmax_tma!, softmax_online!, softmax_chunked!).
-#
-# Tests create column-major data directly.
+# Tests for cuTile.jl softmax kernels
 
 using Test
 using CUDA
@@ -13,12 +11,9 @@ const KERNEL_DIR = joinpath(@__DIR__, "..", "kernels")
 include(joinpath(KERNEL_DIR, "softmax.jl"))
 
 """
-    reference_softmax(x::Matrix{Float32}) -> Matrix{Float32}
-
-CPU reference softmax. Input is (M, N) col-major; softmax is computed over dim 2 (columns).
+CPU reference softmax. Input is (M, N) col-major; softmax over dim 2 (columns).
 """
 function reference_softmax(x::Matrix{Float32})
-    # x is (M, N) — softmax over N (dim 2)
     M, N = size(x)
     out = similar(x)
     for i in 1:M
@@ -28,16 +23,6 @@ function reference_softmax(x::Matrix{Float32})
         out[i, :] = exps ./ sum(exps)
     end
     return out
-end
-
-"""
-Helper to create col-major test data on GPU and return both CPU & GPU versions.
-The bridge functions expect col-major (M, N) CuArrays.
-"""
-function make_test_data(M::Int, N::Int)
-    x_cpu = randn(Float32, M, N)
-    x_gpu = CuArray(x_cpu)
-    return x_cpu, x_gpu
 end
 
 function next_power_of_2(n::Int)
@@ -62,20 +47,14 @@ end
         ]
         for (M, N) in test_cases
             TILE_SIZE = next_power_of_2(N)
-            x_cpu, x_gpu = make_test_data(M, N)
+            x_cpu = randn(Float32, M, N)
+            x_gpu = CuArray(x_cpu)
+            out_gpu = similar(x_gpu)
 
-            # Pad to TILE_SIZE columns if needed (NegInf padding is handled by kernel)
-            out_gpu = CUDA.zeros(Float32, M, N)
-
-            softmax_tma!(
-                Int(pointer(x_gpu)),
-                Int(pointer(out_gpu)),
-                M, N, TILE_SIZE
-            )
+            softmax_tma!(out_gpu, x_gpu; tile_size=TILE_SIZE)
 
             expected = reference_softmax(x_cpu)
-            result = Array(out_gpu)
-            @test result ≈ expected atol=1e-5 rtol=1e-4
+            @test Array(out_gpu) ≈ expected atol=1e-5 rtol=1e-4
         end
     end
 
@@ -86,25 +65,14 @@ end
             (M=2,  N=8192,  TILE_SIZE=1024),
         ]
         for (M, N, TILE_SIZE) in test_cases
-            tile_num_per_row = cld(N, TILE_SIZE)
-            padded_N = tile_num_per_row * TILE_SIZE
-
             x_cpu = randn(Float32, M, N)
-            # Pad with -Inf for unused columns
-            x_padded_cpu = fill(-Inf32, M, padded_N)
-            x_padded_cpu[:, 1:N] .= x_cpu
-            x_padded_gpu = CuArray(x_padded_cpu)
-            out_padded_gpu = CUDA.zeros(Float32, M, padded_N)
+            x_gpu = CuArray(x_cpu)
+            out_gpu = similar(x_gpu)
 
-            softmax_online!(
-                Int(pointer(x_padded_gpu)),
-                Int(pointer(out_padded_gpu)),
-                M, N, TILE_SIZE, tile_num_per_row
-            )
+            softmax_online!(out_gpu, x_gpu; tile_size=TILE_SIZE)
 
             expected = reference_softmax(x_cpu)
-            result = Array(out_padded_gpu[:, 1:N])
-            @test result ≈ expected atol=1e-4 rtol=1e-3
+            @test Array(out_gpu) ≈ expected atol=1e-4 rtol=1e-3
         end
     end
 
@@ -115,47 +83,29 @@ end
             (M=2,  N=1000,  TILE_SIZE=512),
         ]
         for (M, N, TILE_SIZE) in test_cases
-            num_chunks = cld(N, TILE_SIZE)
-            padded_N = num_chunks * TILE_SIZE
-
             x_cpu = randn(Float32, M, N)
-            x_padded_cpu = fill(-Inf32, M, padded_N)
-            x_padded_cpu[:, 1:N] .= x_cpu
-            x_padded_gpu = CuArray(x_padded_cpu)
-            out_padded_gpu = CUDA.zeros(Float32, M, padded_N)
+            x_gpu = CuArray(x_cpu)
+            out_gpu = similar(x_gpu)
 
-            softmax_chunked!(
-                Int(pointer(x_padded_gpu)),
-                Int(pointer(out_padded_gpu)),
-                M, N, TILE_SIZE
-            )
+            softmax_chunked!(out_gpu, x_gpu; tile_size=TILE_SIZE)
 
             expected = reference_softmax(x_cpu)
-            result = Array(out_padded_gpu[:, 1:N])
-            @test result ≈ expected atol=1e-4 rtol=1e-3
+            @test Array(out_gpu) ≈ expected atol=1e-4 rtol=1e-3
         end
     end
 
     @testset "Numerical stability (large values)" begin
         M, N = 4, 128
         TILE_SIZE = 128
-        # Large values that would overflow naive exp()
         x_cpu = randn(Float32, M, N) .* 100f0
         x_gpu = CuArray(x_cpu)
-        out_gpu = CUDA.zeros(Float32, M, N)
+        out_gpu = similar(x_gpu)
 
-        softmax_tma!(
-            Int(pointer(x_gpu)),
-            Int(pointer(out_gpu)),
-            M, N, TILE_SIZE
-        )
+        softmax_tma!(out_gpu, x_gpu; tile_size=TILE_SIZE)
 
         result = Array(out_gpu)
-
-        # Softmax output must be valid probabilities
         @test all(isfinite, result)
         @test all(x -> x >= 0, result)
-        # Each row should sum to ~1
         for i in 1:M
             @test sum(result[i, :]) ≈ 1.0f0 atol=1e-4
         end
@@ -167,19 +117,14 @@ end
     @testset "Single row" begin
         M, N = 1, 512
         TILE_SIZE = 512
+        x_cpu = randn(Float32, M, N)
+        x_gpu = CuArray(x_cpu)
+        out_gpu = similar(x_gpu)
 
-        x_cpu, x_gpu = make_test_data(M, N)
-        out_gpu = CUDA.zeros(Float32, M, N)
-
-        softmax_tma!(
-            Int(pointer(x_gpu)),
-            Int(pointer(out_gpu)),
-            M, N, TILE_SIZE
-        )
+        softmax_tma!(out_gpu, x_gpu; tile_size=TILE_SIZE)
 
         expected = reference_softmax(x_cpu)
-        result = Array(out_gpu)
-        @test result ≈ expected atol=1e-5
+        @test Array(out_gpu) ≈ expected atol=1e-5
     end
 
 end


### PR DESCRIPTION
## Description

Also align with both the cuTile.jl examples and the Python TileGym implementations, and update the skills accordingly.

**cuTile 0.2 API changes:**
- `ct.full()` (which doesn't exist in the Julia API) → `zeros()`, `fill()` — standard Julia constructors now work in kernels via overlays
- Keyword argument `ct.load`/`ct.store` style, matching all cuTile.jl examples
- `while` loops → native `for` loops where applicable
- `ct.num_tiles()` and `size(arr, dim)` inside kernels instead of passing pre-computed values as arguments
- Scalar-tile broadcasting (`y .* alpha`) instead of creating full tiles for scalar operations
- `ct.@compiler_options` for kernel-level hints (occupancy, num_ctas) instead of launch kwargs

**Alignment with Python TileGym:**
- Matmul: added 2D swizzle with 1D grid, matching `swizzle_2d` in the Python matmul
- Softmax chunked: rewritten from `ct.load`/`ct.store` to `ct.gather`/`ct.scatter` with `check_bounds=true` and `padding_value=-Inf`, matching the Python chunked softmax
- Softmax TMA/online: `padding_mode=NegInf` on loads, matching Python's `padding_mode=NEG_INF` / `padding_value=-math.inf`
- Compiler options match Python decorators (`@ct.kernel(occupancy=4)` → `ct.@compiler_options occupancy=4`)

**Julia idioms:**
- Matmul layout changed from `A(K,M), B(N,K), C(N,M)` to standard `A(M,K), B(K,N), C(M,N)` — tests now verify `A * B` instead of `B * A`
- Host functions accept `CuArray`s with output-first convention (`matmul!(C, A, B)`) instead of raw `Int` pointers with `unsafe_wrap`
- Removed underscore prefixes on kernel function names
- Tests simplified: no manual padding, no pointer arithmetic

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops", "benchmark", and "sanity"
  test: []
```

## Checklist
- [ ] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

cc @0xtaruhi

