### PR TITLE
fix(ci): render all benchmark columns in summary, not just allowlisted backends

### DIFF
--- a/.github/scripts/format_benchmark_summary.py
+++ b/.github/scripts/format_benchmark_summary.py
@@ -101,28 +101,25 @@ def json_benchmark_to_markdown(benchmark_data):
     if not configs:
         return ""
 
-    # Determine columns: parameter name + all backend names
-    param_name = None
-    backends = []
-
-    for key in configs[0].keys():
-        if key not in ["CuTile", "PyTorch", "Triton", "TorchCompile"]:
-            param_name = key
-        else:
-            backends.append(key)
-
-    if not param_name:
+    # Render every key as its own column, preserving the insertion order that
+    # run_all_json.py emits (Triton's perf_report convention: x-axis params
+    # first, then one column per backend). Avoids the previous hardcoded
+    # backend allowlist {CuTile, PyTorch, Triton, TorchCompile} that silently
+    # dropped any other backend (e.g. SDPA-Flash, SDPA-MemEff, SDPA-Math,
+    # DeepGemm, Triton+CuTile) and collapsed multiple x-axis params into a
+    # single surviving param_name.
+    columns = list(configs[0].keys())
+    if not columns:
         return ""
 
     # Build markdown table
-    headers = [param_name] + backends
-    md = "| " + " | ".join(headers) + " |\n"
-    md += "| " + " | ".join(["---"] * len(headers)) + " |\n"
+    md = "| " + " | ".join(columns) + " |\n"
+    md += "| " + " | ".join(["---"] * len(columns)) + " |\n"
 
     for config in configs:
-        row = [str(config.get(param_name, ""))]
-        for backend in backends:
-            value = config.get(backend, "")
+        row = []
+        for col in columns:
+            value = config.get(col, "")
             if isinstance(value, float):
                 row.append(f"{value:.2f}")
             else:


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description

The benchmark summary page silently dropped columns for any backend not in the hardcoded allowlist `{CuTile, PyTorch, Triton, TorchCompile}` in `.github/scripts/format_benchmark_summary.py`. Non-allowlisted keys were also overwriting `param_name`, so the x-axis column was lost in several benches.

This swap replaces the allowlist with direct iteration over `configs[0].keys()`, which `run_all_json.py` already emits in Triton's perf_report order (x-axis params first, then backends).

### Before / After (from CI run [24546853000](https://github.com/NVIDIA/TileGym/actions/runs/24546853000) artifacts)

**`bench_attention_backward`** (4 SDPA backends + N_CTX)
- Before: `| SDPA-Math | CuTile |`  *(N_CTX / SDPA-Flash / SDPA-MemEff dropped)*
- After: `| N_CTX | CuTile | SDPA-Flash | SDPA-MemEff | SDPA-Math |`

**`bench_bmm`** (multi-axis M/N/K)
- Before: `| K | CuTile | PyTorch |`  *(M / N dropped)*
- After: `| M | N | K | CuTile | PyTorch |`

**`bench_mix_triton_cutile`**
- Before: `| Triton+CuTile | PyTorch |`  *(N dropped)*
- After: `| N | PyTorch | Triton+CuTile |`

**Every bench already rendering correctly** (e.g. the ~22 single-x `CuTile + PyTorch` files): *unchanged*.

### Diff

14 insertions, 17 deletions in a single file. No schema changes, no new imports, no changes to `run_all_json.py` or `check_benchmark_regression.py`.

### Test plan

- [x] Patch rendered against real CI artifacts for `bench_attention_backward`, `bench_bmm`, `bench_mhc`, `bench_mix_triton_cutile`, and `bench_swa_attention` — all produce expected tables.
- [x] Every bench whose keys are `{x, CuTile, PyTorch}` continues to render identically to today.
- [ ] Next `tilegym-ci` run's summary page shows all backend columns for the affected benches.

### Known limitations (deliberately not addressed here)

- `run_all_json.py::parse_benchmark_output` still tokenizes the pandas header with `.split()`, so any future bench whose `line_names` entry contains whitespace would fragment into multiple columns. Hardening this parser is left to a follow-up.
- `check_benchmark_regression.py` has a similar allowlist, but uses `break`, so it already picks the correct `param_name` in practice. Leaving it alone to keep this diff focused.

### Effect
<img width="1168" height="402" alt="image" src="https://github.com/user-attachments/assets/e53051e8-e6ee-42aa-87f7-25ada87d9a5d" />

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops", "benchmark", and "sanity"
  test: ["benchmark"]
```

## Checklist
- [x] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [x] CI configuration reviewed
