### PR TITLE
perf(rmsnorm): skip bounds checking in gather kernel when tile evenly divides N

### DIFF
--- a/src/tilegym/ops/cutile/rms_norm.py
+++ b/src/tilegym/ops/cutile/rms_norm.py
@@ -34,9 +34,11 @@ def rms_norm_kernel_gather(
     num_tiles = ct.cdiv(N, TILE_SIZE)
     offsets = ct.arange(TILE_SIZE, dtype=ct.int32)
 
+    check_bound = num_tiles * TILE_SIZE != N
+
     for j in range(0, num_tiles):
         offs = j * TILE_SIZE + offsets
-        xj = ct.gather(x, (row, offs), latency=1)
+        xj = ct.gather(x, (row, offs), check_bounds=check_bound, latency=1)
         xj = ct.astype(xj, ct.float32)
         _rms += xj * xj
 
@@ -46,9 +48,9 @@ def rms_norm_kernel_gather(
 
     for j in range(0, num_tiles):
         offs = j * TILE_SIZE + offsets
-        wj = ct.gather(w, offs, latency=1)
+        wj = ct.gather(w, offs, check_bounds=check_bound, latency=1)
         wj = ct.astype(wj, ct.float32)
-        xj = ct.gather(x, (row, offs), latency=1)
+        xj = ct.gather(x, (row, offs), check_bounds=check_bound, latency=1)
         xj = ct.astype(xj, ct.float32)
         # Apply offset: y = x_normalized * (offset + w)
         yj = xj * rms * (offset + wj)

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -54,6 +54,11 @@ class Test_RMSNorm(common.PyTestCase):
         else:
             pytest.skip(f"Backend {backend} is not available")
 
+        # skip static_persistent tests when n > 16384 to avoid excessive memory usage
+        # Avoid tileiras hangs on RTX PRO 6000 which has 100 KB shared memory per SM
+        if static_persistent and n > 16384:
+            pytest.skip("Skipping static_persistent test for large n to avoid excessive memory usage")
+
         self.setUp()
         device = torch.device("cuda")
         eps = 1e-5

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -35,6 +35,8 @@ class Test_RMSNorm(common.PyTestCase):
         "m, n, dtype",
         [
             (256, 256, torch.float16),
+            (256, 768, torch.float16),  # non-pow2
+            (256, 18432, torch.float16),  # non-pow2
             (4096, 2**8, torch.bfloat16),
             (31072, 4096, torch.bfloat16),
             (256, 256, torch.float32),


### PR DESCRIPTION
Pass explicit `check_bounds` to `ct.gather` so the compiler can elide boundary checks when TILE_SIZE evenly divides N, reducing SASS instruction count and improving bandwidth by ~3-13%.
  ## Performance (M=4096, GB200)                                                                                           
                                                                                                                           
  | dtype | N | Before (GB/s) | After (GB/s) | Delta |                                                                     
  |-------|------|--------------|-------------|-------|                                                                  
  | fp16 | 1024 | 4064 | 4295 | +5.7% |                                                                                    
  | fp16 | 2048 | 6088 | 6342 | +4.2% |                                                                                    
  | fp16 | 4096 | 7193 | 8033 | +11.7% |                                                                                   
  | fp16 | 8192 | 5270 | 5920 | +12.3% |                                                                                   
  | fp16 | 16384 | 5872 | 6199 | +5.6% |                                                                                   
  | bf16 | 1024 | 4034 | 4376 | +8.5% |                                                                                    
  | bf16 | 2048 | 6184 | 6342 | +2.6% |                                                                                    
  | bf16 | 4096 | 7169 | 8096 | +12.9% |                                                                                   
  | bf16 | 8192 | 5386 | 5877 | +9.1% |                                                                                    
  | bf16 | 16384 | 6000 | 6025 | +0.4% |

<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops", "benchmark", and "sanity"
  test: ["ops", "benchmark"]
```

## Checklist
- [x] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [x] Documentation updated (if needed)
- [x] CI configuration reviewed

