### PR TITLE
add `multi_wave_cached` rms norm

### DIFF
--- a/src/tilegym/ops/cutile/rms_norm.py
+++ b/src/tilegym/ops/cutile/rms_norm.py
@@ -13,6 +13,46 @@ from .utils import next_power_of_2
 
 
 @ct.kernel
+def rms_norm_kernel_multi_wave_cached(
+    x,
+    w,
+    out,
+    Rstd,
+    N: ct.Constant[int],
+    eps: ct.Constant[float],
+    offset: ct.Constant[float],
+    TILE_SIZE: ct.Constant[int],
+):
+    """
+    Multi-wave RMSNorm kernel that caches inputs in registers (single tile).
+
+    Formula: y = norm(x) * (offset + w)
+    For Llama: offset=0.0, For Gemma3: offset=1.0
+    """
+    row = ct.bid(0)
+    _rms = ct.full((TILE_SIZE,), 0.0, dtype=ct.float32)
+    offsets = ct.arange(TILE_SIZE, dtype=ct.int32)
+    check_bound = TILE_SIZE != N
+
+    # cache inputs in registers
+    xj = ct.gather(x, (row, offsets), check_bounds=check_bound, latency=1)
+    xj = ct.astype(xj, ct.float32)
+    _rms += xj * xj
+
+    # Calculate RMS Norm
+    rms = ct.rsqrt(ct.sum(_rms, axis=0, keepdims=False) / N + eps)
+    ct.scatter(Rstd, row, rms)
+
+    wj = ct.gather(w, offsets, check_bounds=check_bound, latency=1)
+    wj = ct.astype(wj, ct.float32)
+
+    # Apply offset: y = x_normalized * (offset + w)
+    yj = xj * rms * (offset + wj)
+    yj = ct.astype(yj, x.dtype)
+    ct.scatter(out, (row, offsets), yj, latency=1)
+
+
+@ct.kernel
 def rms_norm_kernel_gather(
     x,
     w,
@@ -256,7 +296,7 @@ class RMSNorm(torch.autograd.Function):
         weight,
         eps,
         bias=None,
-        static_persistent=None,
+        mode=None,
         offset=0.0,
     ):
         """
@@ -268,7 +308,7 @@ class RMSNorm(torch.autograd.Function):
             weight: Weight tensor of shape [N]
             eps: Epsilon value for numerical stability
             bias: Bias tensor of shape [N], default is None
-            static_persistent: Whether to use static persistent kernel, default is False
+            mode: Kernel selection mode (None, "static_persistent", "multi_wave_reload", "multi_wave_cached")
             offset: Offset to add to weight (default 0.0 for Llama, 1.0 for Gemma3)
 
         Returns:
@@ -294,17 +334,17 @@ class RMSNorm(torch.autograd.Function):
 
         NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
 
-        if static_persistent is None:
+        if mode is None:
             if M > NUM_SMS * 2:
                 # Heuristic for static persistent mode: if we need run over 2 waves, use static persistent mode
-                static_persistent = True
+                mode = "static_persistent"
             else:
-                static_persistent = False
+                mode = "multi_wave_reload"
 
         # Allocate rstd for backward (both paths now store it)
         rstd = torch.empty((M,), dtype=torch.float32, device=x.device)
 
-        if static_persistent:
+        if mode == "static_persistent":
             # Static persistent mode
             if bias is not None:
                 raise NotImplementedError("Bias is not supported in static persistent CuTile RMSNorm")
@@ -349,8 +389,21 @@ class RMSNorm(torch.autograd.Function):
                 rms_norm_kernel_static_persistent,
                 (x_arg, y, weight, rstd, TILE_SIZE_M, TILE_SIZE_N, eps, offset),
             )
-        else:
-            # Standard mode
+        elif mode == "multi_wave_cached":
+            # Multi-wave cached mode (single tile, inputs cached in registers)
+            if bias is not None:
+                raise NotImplementedError("Bias is not supported in multi_wave_cached CuTile RMSNorm")
+
+            TILE_SIZE = next_power_of_2(N)
+            grid = (M,)
+            ct.launch(
+                torch.cuda.current_stream(),
+                grid,
+                rms_norm_kernel_multi_wave_cached,
+                (x_arg, weight, y, rstd, N, eps, offset, TILE_SIZE),
+            )
+        elif mode == "multi_wave_reload":
+            # Standard multi-wave reload mode
             if bias is not None:
                 raise NotImplementedError("Bias is not supported in standard CuTile RMSNorm")
 
@@ -371,6 +424,11 @@ class RMSNorm(torch.autograd.Function):
                     offset,
                     TILE_SIZE,
                 ),
+            )
+        else:
+            raise ValueError(
+                f"Unknown mode '{mode}'. Supported modes: None, 'static_persistent', "
+                f"'multi_wave_reload', 'multi_wave_cached'"
             )
 
         # Always save for backward (both paths now produce rstd)
@@ -396,12 +454,12 @@ class RMSNorm(torch.autograd.Function):
         x, weight, rstd = ctx.saved_tensors
         dx, dw = rms_norm_backward(x, dy, weight, rstd)
 
-        # Gradients: (x, normalized_shape, weight, eps, bias, static_persistent, offset)
+        # Gradients: (x, normalized_shape, weight, eps, bias, mode, offset)
         return dx, None, dw, None, None, None, None
 
 
 @register_impl("rms_norm", backend="cutile")
-def rms_norm(input, normalized_shape, weight, eps, bias=None, static_persistent=None, offset=0.0, **kwargs):
+def rms_norm(input, normalized_shape, weight, eps, bias=None, mode=None, offset=0.0, **kwargs):
     """
     Root mean square normalization implemented using CUDA Tile
 
@@ -411,14 +469,14 @@ def rms_norm(input, normalized_shape, weight, eps, bias=None, static_persistent=
         weight: Tensor of shape (N,)
         eps: Small constant added to variance calculation
         bias: Bias tensor of shape (N,), default is None (not supported in cutile)
-        static_persistent: Whether to use static persistent kernel, default is False
+        mode: Kernel selection mode (None, "static_persistent", "multi_wave_reload", "multi_wave_cached")
         offset: Offset to add to weight (default 0.0 for Llama, 1.0 for Gemma3)
         **kwargs: Additional arguments for backend-specific configurations
 
     Returns:
         Normalized tensor with same shape as input
     """
-    return RMSNorm.apply(input, normalized_shape, weight, eps, bias, static_persistent, offset)
+    return RMSNorm.apply(input, normalized_shape, weight, eps, bias, mode, offset)
 
 
 class TileRMSNorm(nn.Module):
@@ -437,21 +495,21 @@ class TileRMSNorm(nn.Module):
         self.hidden_size = hidden_size
         self.offset = offset
 
-    def forward(self, hidden_states, static_persistent=None):
+    def forward(self, hidden_states, mode=None):
         """
-        Forward pass with optional static_persistent override
+        Forward pass with optional mode override
 
         Args:
             hidden_states: Input tensor
-            static_persistent: Default is None, which means use heuristic to
-                               decide whether to use static persistent mode for better performance
+            mode: Default is None, which means use heuristic to
+                               decide which kernel mode to use for better performance
         """
         return rms_norm(
             hidden_states,
             None,
             self.weight,
             self.variance_epsilon,
-            static_persistent=static_persistent,
+            mode=mode,
             offset=self.offset,
         )
 

--- a/src/tilegym/ops/ops.py
+++ b/src/tilegym/ops/ops.py
@@ -138,7 +138,7 @@ def rms_norm(
     weight: torch.Tensor,
     eps: float,
     bias: Optional[torch.Tensor] = None,
-    static_persistent: bool = False,
+    mode: Optional[str] = None,
     **kwargs: Any,
 ):
     """
@@ -150,7 +150,7 @@ def rms_norm(
         weight: Tensor of shape (N,)
         eps: small scaler to be added to variance calculation prior to division.
         bias: Bias tensor of shape (N,), default is None
-        static_persistent: Whether to use static persistent kernel, default is False
+        mode: Kernel selection mode (None, "static_persistent", "multi_wave_reload", "multi_wave_cached")
         **kwargs: Additional arguments for backend-specific configurations
     """
     raise NotImplementedError(f"rms_norm is not implemented for {get_current_backend()}")

--- a/tests/benchmark/bench_mix_triton_cutile.py
+++ b/tests/benchmark/bench_mix_triton_cutile.py
@@ -131,7 +131,7 @@ def bench_mix_triton_cutile(N, backend, dtype, M, device=DEVICE):
             # Step 1: Triton vector add
             added = triton_vector_add(x, y)
             # Step 2: CuTile rmsnorm
-            return tilegym.ops.cutile.rms_norm(added, w_shape, weight, eps, static_persistent=True)
+            return tilegym.ops.cutile.rms_norm(added, w_shape, weight, eps, mode="static_persistent")
 
         fn = mixed_fn
 

--- a/tests/benchmark/bench_rmsnorm.py
+++ b/tests/benchmark/bench_rmsnorm.py
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: MIT
 
+from typing import Any
+from typing import Optional
+
 import torch
 import torch.nn.functional as F
 import triton
@@ -15,11 +18,12 @@ DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 def reference_rms_norm(
     input: torch.Tensor,
-    normalized_shape: tuple,
+    normalized_shape: Any,
     weight: torch.Tensor,
     eps: float,
-    bias: torch.Tensor = None,  # Unused - kept for interface compatibility
-    **kwargs,  # Unused - kept for interface compatibility
+    bias: Optional[torch.Tensor] = None,
+    mode: Optional[str] = None,
+    **kwargs: Any,
 ):
     """Fused PyTorch RMSNorm baseline using F.rms_norm.
 

--- a/tests/benchmark/bench_rmsnorm.py
+++ b/tests/benchmark/bench_rmsnorm.py
@@ -19,7 +19,7 @@ def reference_rms_norm(
     weight: torch.Tensor,
     eps: float,
     bias: torch.Tensor = None,  # Unused - kept for interface compatibility
-    static_persistent: bool = False,  # Unused - kept for interface compatibility
+    **kwargs,  # Unused - kept for interface compatibility
 ):
     """Fused PyTorch RMSNorm baseline using F.rms_norm.
 
@@ -36,52 +36,55 @@ def reference_rms_norm(
 register_impl("rms_norm", "torch")(reference_rms_norm)
 
 
-# Available backends with their display names and plot styles
-ALL_BACKENDS = [
-    ("cutile", "CuTile", ("blue", "-")) if is_backend_available("cutile") else None,
-    ("torch", "PyTorch", ("green", "-")),
+# Available configs with their display names and plot styles
+# (backend, mode, display label, plot style)
+ALL_CONFIGS = [
+    ("cutile", "static_persistent", "CuTile static persistent", ("purple", "-")),
+    ("cutile", "multi_wave_reload", "CuTile multi wave reload", ("blue", "-")),
+    ("cutile", "multi_wave_cached", "CuTile multi wave cached", ("red", "--")),
+    ("torch", None, "PyTorch", ("green", "-")),
 ]
 
 
-def get_supported_backends():
-    """Filter backends based on availability"""
-    return [p for p in ALL_BACKENDS if p is not None]
+def get_supported_configs():
+    cutile_available = is_backend_available("cutile")
+    if cutile_available:
+        return ALL_CONFIGS
+    return [c for c in ALL_CONFIGS if c[0] == "torch"]
 
 
-def create_benchmark_config(dtype, static_persistent=True):
+M_DEFAULT = 4096
+
+
+def create_benchmark_config(dtype):
     """Create a benchmark configuration for given parameters"""
-    available_backends = get_supported_backends()
-    if not available_backends:
+    supported = get_supported_configs()
+    if not supported:
         return None
 
-    backends, names, styles = zip(*available_backends)
+    # Use index as line_val key to pass both backend and mode
+    labels = [c[2] for c in supported]
+    styles = [c[3] for c in supported]
     dtype_name = str(dtype).split(".")[-1]  # e.g., 'float16' from 'torch.float16'
 
     return triton.testing.Benchmark(
         x_names=["N"],
         x_vals=[2**i for i in range(10, 15)],  # Hidden size from 1024 to 16384
-        line_arg="backend",
-        line_vals=list(backends),
-        line_names=list(names),
-        styles=list(styles),
+        line_arg="config_idx",
+        line_vals=list(range(len(supported))),
+        line_names=labels,
+        styles=styles,
         ylabel="GB/s",
-        plot_name=f"rmsnorm-performance-{dtype_name}-persistent-{static_persistent}-GBps",
+        plot_name=f"rmsnorm-{dtype_name}-M{M_DEFAULT}",
         args={
             "dtype": dtype,
-            "static_persistent": static_persistent,
-            "M": 4096,
+            "M": M_DEFAULT,
         },  # Fixed batch*seq_len
     )
 
 
-@triton.testing.perf_report(
-    [
-        create_benchmark_config(dtype, static_persistent)
-        for dtype in [torch.float16, torch.bfloat16]
-        for static_persistent in [True, False]
-    ]
-)
-def bench_rmsnorm(N, backend, dtype, static_persistent, M, device=DEVICE):
+@triton.testing.perf_report([create_benchmark_config(dtype) for dtype in [torch.float16, torch.bfloat16]])
+def bench_rmsnorm(N, config_idx, dtype, M, device=DEVICE):
     eps = 1e-5
 
     # Create input tensors
@@ -91,7 +94,10 @@ def bench_rmsnorm(N, backend, dtype, static_persistent, M, device=DEVICE):
     x = torch.rand(x_shape, dtype=dtype, device=device, requires_grad=False).mul_(0.5).add_(-2.3)
     weight = torch.randn(w_shape, dtype=dtype, device=device, requires_grad=False)
 
-    fn = lambda: tilegym.ops.rms_norm(x, w_shape, weight, eps, static_persistent=static_persistent, backend=backend)
+    supported = get_supported_configs()
+    backend, mode, _, _ = supported[config_idx]
+
+    fn = lambda: tilegym.ops.rms_norm(x, w_shape, weight, eps, mode=mode, backend=backend)
     ref = lambda: reference_rms_norm(x, w_shape, weight, eps)
     torch.testing.assert_close(fn(), ref(), atol=5e-2, rtol=0.0)
 

--- a/tests/ops/experimental/test_rmsnorm_backward.py
+++ b/tests/ops/experimental/test_rmsnorm_backward.py
@@ -91,9 +91,9 @@ class Test_RMSNormAutogradBackward(common.PyTestCase):
             (256, 256, torch.float32),
         ],
     )
-    @pytest.mark.parametrize("static_persistent", [True, False])
+    @pytest.mark.parametrize("mode", [None, "static_persistent", "multi_wave_reload", "multi_wave_cached"])
     @pytest.mark.parametrize("backend", _backends)
-    def test_op(self, m, n, dtype, static_persistent, backend, arch):
+    def test_op(self, m, n, dtype, mode, backend, arch):
         if tilegym.is_backend_available(backend):
             tilegym.set_backend(backend)
         else:
@@ -114,7 +114,7 @@ class Test_RMSNormAutogradBackward(common.PyTestCase):
             (n,),
             w_cutile,
             eps,
-            static_persistent=static_persistent,
+            mode=mode,
         )
         y_cutile.backward(dy)
 

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -42,13 +42,13 @@ class Test_RMSNorm(common.PyTestCase):
             (256, 256, torch.float32),
         ],
     )
-    @pytest.mark.parametrize("static_persistent", [True, False])
+    @pytest.mark.parametrize("mode", [None, "static_persistent", "multi_wave_reload", "multi_wave_cached"])
     @pytest.mark.parametrize("backend", _backends)
     @markif(
         lambda arch, m, n: arch in ["sm120", "sm121"] and m == 31072 and n == 4096,
         mark=pytest.mark.slow,
     )
-    def test_op(self, m, n, dtype, static_persistent, backend, arch):
+    def test_op(self, m, n, dtype, mode, backend, arch):
         if tilegym.is_backend_available(backend):
             tilegym.set_backend(backend)
         else:
@@ -56,7 +56,8 @@ class Test_RMSNorm(common.PyTestCase):
 
         # skip static_persistent tests when n > 16384 to avoid excessive memory usage
         # Avoid tileiras hangs on RTX PRO 6000 which has 100 KB shared memory per SM
-        if static_persistent and n > 16384:
+        # mode=None can also select static_persistent via heuristic when M > NUM_SMS * 2
+        if mode in ("static_persistent", None) and n > 16384:
             pytest.skip("Skipping static_persistent test for large n to avoid excessive memory usage")
 
         self.setUp()
@@ -81,7 +82,7 @@ class Test_RMSNorm(common.PyTestCase):
                     "eps": eps,
                 },
                 extra_test_kwargs={
-                    "static_persistent": static_persistent,
+                    "mode": mode,
                 },
                 rtol=0.0,
                 atol=5e-2,


### PR DESCRIPTION
Add `rms_norm_kernel_multi_wave_cached`, a single-tile RMSNorm kernel that caches inputs in registers to avoid reloading from memory.

Replace the boolean `static_persistent parameter` with a `mode` parameter for explicit kernel selection:
- None: heuristic selection based on tensor shape (default)
- "static_persistent": `rms_norm_kernel_static_persistent`
- "multi_wave_reload": `rms_norm_kernel_multi_wave_reload`
- "multi_wave_cached": `rms_norm_kernel_multi_wave_cached`

Rename kernels for consistency:
- rms_norm_kernel_gather -> rms_norm_kernel_multi_wave_reload
- rms_norm_kernel_gather_regs_cached -> rms_norm_kernel_multi_wave_cached

Update benchmark to compare all kernel modes side-by-side per dtype.


## Performance on GB200 with M = 4096

Current `do_bench_cudagraph` based performance is not reliable see https://github.com/NVIDIA/TileGym/issues/82, so I doubled checked with `torch.profiler`, see https://github.com/NVIDIA/TileGym/commit/3c8de12b0bbd3cc5fa025573dde39bd690e3134b

| dtype | N | Reload do_bench_cudagraph (GB/s) | Cached do_bench_cudagraph (GB/s) | Speedup do_bench_cudagraph | Reload profiler (GB/s) | Cached profiler (GB/s) | Speedup profiler |
|-------|---:|---:|---:|---:|---:|---:|---:|
| float16 | 1024 | 4314.1 | 4428.8 | 1.03x | 3084.4 | 3139.8 | 1.02x |
| float16 | 2048 | 6253.6 | 6252.2 | 1.00x | 4128.8 | 4128.8 | 1.00x |
| float16 | 4096 | 8152.3 | 8241.5 | 1.01x | 5128.1 | 5204.1 | 1.01x |
| float16 | 8192 | 5916.0 | 6317.6 | **1.07x** | 5645.5 | 5949.8 | **1.05x** |
| float16 | 16384 | 6197.5 | 6404.7 | **1.03x** | 5967.0 | 6365.4 | **1.07x** |
| bfloat16 | 1024 | 4364.3 | 4374.6 | 1.00x | 3066.4 | 3102.7 | 1.01x |
| bfloat16 | 2048 | 6319.6 | 6328.8 | 1.00x | 4049.5 | 4033.5 | 1.00x |
| bfloat16 | 4096 | 8027.3 | 7560.4 | **0.94x** | 4958.8 | 5103.2 | 1.03x |
| bfloat16 | 8192 | 5984.2 | 6400.0 | **1.07x** | 5563.6 | 5908.2 | **1.06x** |
| bfloat16 | 16384 | 6017.0 | 6385.3 | **1.06x** | 5742.3 | 6341.7 | **1.10x** |

<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops", "benchmark", and "sanity"
  test: ["ops", "benchmark"]
```

## Checklist
- [x] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [x] Documentation updated (if needed)
- [x] CI configuration reviewed

