### PR TITLE
Update cutile kernels & other updates

### DIFF
--- a/.claude/skills/improve-cutile-kernel-perf/references/optimization-playbook.md
+++ b/.claude/skills/improve-cutile-kernel-perf/references/optimization-playbook.md
@@ -60,6 +60,21 @@ def kernel(X, block_table, Y, BLOCK: ct.Constant[int]):
 
 **Decision**: Use TMA whenever data is contiguous or block-aligned. Use gather only for truly sparse random access.
 
+**Ampere (sm80/sm86) note**: Hardware TMA is not available on this generation. `ct.load`/`ct.store` with `allow_tma=True` falls back to `cp.async` emulation, adding ~8-15% overhead. When running on Ampere, redirect to the non-TMA path and emit a `UserWarning` rather than adding TMA:
+
+```python
+if use_tma and torch.cuda.get_device_capability()[0] < 9:
+    import warnings
+    warnings.warn(
+        "use_tma=True has no effect on this GPU — TMA is emulated via cp.async. "
+        "Falling back to use_tma=False.",
+        UserWarning, stacklevel=3,
+    )
+    use_tma = False
+```
+
+> **⚠️ Ampere (sm80/sm86) correctness (silent-corruption risk)**: if you keep `allow_tma=True` on a code path that may load out-of-bounds (e.g. ragged tails, partial tiles), you **must** pass `padding_mode=ct.PaddingMode.ZERO`. Hardware TMA on SM90+ auto-zero-fills OOB addresses, but the `cp.async` emulation used on Ampere does **not** — OOB lanes read undefined memory and produce wrong results with no error. Either set `padding_mode=ct.PaddingMode.ZERO` on the load, or route Ampere through the non-TMA path as shown above.
+
 ---
 
 ## Optimization B: Add Persistent Scheduling
@@ -126,7 +141,7 @@ def _my_kernel_autotune_configs():
         tile_sizes = [64, 128, 256, 512]
         occupancies = [1, 2, 4, 8]
         num_ctas_list = [1]
-    else:                    # Ampere (A100) and earlier
+    else:                    # Ampere (sm80/sm86)
         tile_sizes = [64, 128, 256]
         occupancies = [1, 2, 4]
         num_ctas_list = [1]
@@ -242,6 +257,8 @@ ct.store(Y, index=(bid, 0), tile=result, allow_tma=False)  # +30% in rms_norm!
 
 **Impact**: +5-50% depending on mismatch
 **When**: Current tile sizes are suboptimal for the workload or GPU architecture.
+
+For per-architecture tile size constraints and recommended search spaces, see `cutile-autotuning` skill.
 
 ---
 

--- a/src/tilegym/ops/cutile/bmm.py
+++ b/src/tilegym/ops/cutile/bmm.py
@@ -283,7 +283,7 @@ def _persistent_bmm_autotune_base(stream, a, b, output, batch_size, M, N, K, tra
     # Call autotuner to find the best config and execute the kernel
     cache_key = (batch_size, M, N, K, transpose_a, transpose_b, a.dtype, str(a.device))
     if cache_key not in _bmm_tune_cache:
-        with ct.compiler_timeout(5):
+        with ct.compiler_timeout(10):
             result = exhaustive_search(
                 list(_bmm_autotune_configs()),
                 stream,

--- a/src/tilegym/ops/cutile/dropout.py
+++ b/src/tilegym/ops/cutile/dropout.py
@@ -10,6 +10,29 @@ import torch
 from tilegym.backend import register_impl
 
 
+def _mix_seed(seed: int) -> int:
+    """Pre-mix a user-provided seed into a well-spread signed int32.
+
+    The cuTile kernel's internal hash (3 rounds of XOR-shift) does not
+    amplify small seed deltas — e.g. seed=11 vs seed=99 only differ in
+    the low bits of `combined = offsets*prime + seed`, and bit 30 of the
+    final hash (which drives the p=0.5 keep decision) ends up identical
+    across all lanes, so the mask is independent of the seed.
+
+    Multiplying the seed by Knuth's constant 0x9E3779B1 (== floor(2^32 / phi))
+    spreads the bits evenly across all 32 positions. Same input seed still
+    yields the same mixed seed (reproducibility), while different seeds
+    produce bit patterns with large Hamming distance, which the kernel's
+    XOR-shift can then amplify into a proper per-lane mask difference.
+    """
+    mixed = (int(seed) * 2654435761) & 0xFFFFFFFF
+    # Convert unsigned uint32 bit pattern to signed int32 (two's complement)
+    # so it can be passed as a `ct.Constant[int]` to the int32 kernel arg.
+    if mixed >= 0x80000000:
+        mixed -= 0x100000000
+    return mixed
+
+
 @ct.kernel
 def dropout_kernel_ct(
     x,
@@ -119,8 +142,9 @@ class Dropout_CT(torch.autograd.Function):
         x_flat = x.view(-1)
         output_flat = output.view(-1)
 
-        # Convert seed to int32 to avoid overflow
-        seed_int32 = int(seed) % 2147483647  # Convert to int32 range
+        # Pre-mix seed into a well-spread int32 so small seed deltas produce
+        # large bit-level perturbations before the kernel's XOR-shift hash.
+        seed_int32 = _mix_seed(seed)
 
         ct.launch(
             torch.cuda.current_stream(),

--- a/src/tilegym/ops/cutile/moe.py
+++ b/src/tilegym/ops/cutile/moe.py
@@ -47,7 +47,6 @@ def fused_moe_kernel(
     use_int8_w8a16: ct.Constant[int],
     even_Ks: ct.Constant[int],
     a_stride_1: ct.Constant[int],  # Original A shape[1] before flatten
-    c_stride_1: ct.Constant[int],  # Original C shape[1] before flatten
 ):
     """
     Implements the fused computation for a Mixture of Experts (MOE) using
@@ -125,12 +124,19 @@ def fused_moe_kernel(
             moe_weight = ct.expand_dims(moe_weight, axis=1)
             accumulator = accumulator * moe_weight
         # -----------------------------------------------------------
-        # Write back the tile of the output
+        # Write back the tile of the output.
+        # Use 2D indexing so cuTile bounds-checks the N dimension. Otherwise,
+        # with TILE_SIZE_N > N (e.g. down-projection GEMM where N=hidden_size),
+        # out-of-range column offsets silently alias into the next row of a
+        # flattened C buffer and corrupt neighbouring outputs.
         offs_cn = bid_n * TILE_SIZE_N + ct.arange(TILE_SIZE_N, dtype=ct.int32)
-        c_offset = c_stride_1 * offs_token[:, None] + offs_cn[None, :]
-        c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
         accumulator = ct.astype(accumulator, c_ptr.dtype)
-        ct.scatter(c_ptr, c_offset, accumulator)
+        ct.scatter(
+            c_ptr,
+            (offs_token[:, None], offs_cn[None, :]),
+            accumulator,
+            check_bounds=True,
+        )
 
 
 @register_impl("invoke_fused_moe_kernel", "cutile")
@@ -179,15 +185,17 @@ def invoke_fused_moe_kernel(
     if B_scale is None:
         B_scale = torch.empty(0, device=B.device, dtype=B.dtype)
     topk_weights = topk_weights.view(-1)
+    # Keep C as 2D (M*top_k, N) so the kernel's 2D scatter can bounds-check
+    # the N dimension. Do NOT flatten -- flattening lets a scatter with
+    # TILE_SIZE_N > N silently overwrite the next row.
     C = C.view(-1, C.shape[2])
 
-    # Save original strides before flattening
+    # Save original stride of A before flattening (A is still gathered via a
+    # 1D index; out-of-range padded tokens rely on gather's padding_value=0).
     a_stride_1 = A.shape[1]
-    c_stride_1 = C.shape[1]
 
-    # Flatten tensors to 1D for gather/scatter operations
+    # Flatten A to 1D for gather operations
     A_flat = A.reshape(-1)
-    C_flat = C.reshape(-1)
 
     ct.launch(
         torch.cuda.current_stream(),
@@ -196,7 +204,7 @@ def invoke_fused_moe_kernel(
         (
             A_flat,
             B,
-            C_flat,
+            C,
             A_scale,
             B_scale,
             topk_weights,
@@ -219,6 +227,5 @@ def invoke_fused_moe_kernel(
             int(use_int8_w8a16),  # use_int8_w8a16 (convert bool to int)
             int(even_Ks),  # even_Ks (convert bool to int)
             a_stride_1,  # Original A.shape[1]
-            c_stride_1,  # Original C.shape[1]
         ),
     )

--- a/src/tilegym/ops/cutile/rms_norm.py
+++ b/src/tilegym/ops/cutile/rms_norm.py
@@ -87,18 +87,27 @@ def rms_norm_kernel_static_persistent(
     # Calculate upper bound
     upper_bound = (M + TILE_SIZE_M - 1) // TILE_SIZE_M
 
-    # Load weight vector once (shared across all tiles processed by this program)
-    w = ct.load(W, index=(0,), shape=(TILE_SIZE_N,))
+    # Load weight vector once (shared across all tiles processed by this program).
+    # padding_mode=ZERO keeps out-of-range columns (when N is not a power of two
+    # and TILE_SIZE_N = next_power_of_2(N) > N) from pulling in uninitialized
+    # memory; combined with the same mode on X, OOB contributions to y are zero
+    # and never reach the stored output columns [0, N).
+    w = ct.load(W, index=(0,), shape=(TILE_SIZE_N,), padding_mode=ct.PaddingMode.ZERO)
     w = ct.astype(w, ct.float32)
 
     # Static persistent loop: each  processes multiple tiles
     num_tile_blocks = ct.num_blocks(0)
     for current_bid in range(bid, upper_bound, num_tile_blocks):
-        # Load input tile
+        # Load input tile.
+        # padding_mode=ZERO is required when N is not a power of two so that
+        # the out-of-range columns [N, TILE_SIZE_N) contribute 0 to the
+        # sum-of-squares reduction below; otherwise uninitialized memory
+        # inflates the variance and compresses the normalized output.
         x = ct.load(
             X,
             index=(current_bid, 0),
             shape=(TILE_SIZE_M, TILE_SIZE_N),
+            padding_mode=ct.PaddingMode.ZERO,
             latency=10,  # +2% perf from this hint
         )
         x = ct.astype(x, ct.float32)

--- a/src/tilegym/ops/moe_interface.py
+++ b/src/tilegym/ops/moe_interface.py
@@ -238,7 +238,7 @@ def fused_experts_impl(
             use_int8_w8a16=use_int8_w8a16,
         )
         if topk_ids.shape[1] == 1:
-            pass  # we write directly into out_hidden_states
+            out_hidden_states[begin_chunk_idx:end_chunk_idx] = intermediate_cache3[:, 0]
         elif topk_ids.shape[1] == 2:
             torch.add(
                 intermediate_cache3[:, 0],

--- a/tests/ops/test_softmax.py
+++ b/tests/ops/test_softmax.py
@@ -40,6 +40,7 @@ class Test_Softmax(common.PyTestCase):
         else:
             pytest.skip(f"Backend {backend} is not available")
 
+        self.setUp()
         device = torch.device("cuda")
         x = torch.rand(
             m,


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->

Update codes.

This PR contains **3** new commit(s).

### Commits included:

```
4e10178 Raise bmm autotune compile timeout from 5s to 10s
b715514 refactor(skills): retire sm80-cutile-optimization; migrate arch guidance to existing skills
c34cf4d Update cutile kernels
```

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: ["ops", "benchmark"]
```

## Checklist
- [ ] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

