### PR TITLE
[benchmark] add torch.profiler based bench utils with L2 cache flush

### DIFF
--- a/tests/benchmark/bench_rmsnorm.py
+++ b/tests/benchmark/bench_rmsnorm.py
@@ -8,6 +8,7 @@ from typing import Optional
 import torch
 import torch.nn.functional as F
 import triton
+from bench_utils import profile_with_l2flush
 
 import tilegym
 from tilegym.backend import is_backend_available
@@ -106,7 +107,7 @@ def bench_rmsnorm(N, config_idx, dtype, M, device=DEVICE):
     torch.testing.assert_close(fn(), ref(), atol=5e-2, rtol=0.0)
 
     # Benchmark the function
-    ms = triton.testing.do_bench_cudagraph(fn)
+    ms = profile_with_l2flush(fn)
 
     # Calculate memory bandwidth (GB/s)
     # RMSNorm operation: read input, read weight, write output

--- a/tests/benchmark/bench_utils.py
+++ b/tests/benchmark/bench_utils.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import torch
+from torch.profiler import ProfilerActivity
+from torch.profiler import profile
+
+
+def profile_with_l2flush(fn, warmup=20, rep=100):
+    """Measure kernel-only GPU time using torch.profiler, with L2 flush between reps."""
+    l2_size = torch.cuda.get_device_properties(0).L2_cache_size
+    l2_flush = torch.empty(l2_size // 4, dtype=torch.float32, device="cuda")
+
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    times_us = []
+    for _ in range(rep):
+        l2_flush.zero_()
+        torch.cuda.synchronize()
+        with profile(activities=[ProfilerActivity.CUDA]) as prof:
+            fn()
+            torch.cuda.synchronize()
+        kernel_us = sum(evt.device_time_total for evt in prof.key_averages() if evt.device_time_total > 0)
+        times_us.append(kernel_us)
+
+    times_us.sort()
+    median_us = times_us[len(times_us) // 2]
+    return median_us / 1000.0  # ms


### PR DESCRIPTION
Fix https://github.com/NVIDIA/TileGym/issues/82
Add `profile_with_l2flush()` to shared `bench_utils.py` — measures `kernel-only GPU time` using torch.profiler, flushing L2 cache between reps for accurate micro-benchmarking. 

Only used in bench_rmsnorm.py, we can extend to other benchmarks.

## Influence of L2

<img width="1350" height="750" alt="image" src="https://github.com/user-attachments/assets/3d91d6c3-acea-434b-98cc-ce077bca0686" />


The GB200 has a **~129 MB L2 cache**. For this kernel the working set is roughly:

```
total ≈ 2 × M × N × sizeof(float16) = 2 × 4096 × N × 2 bytes  (input + output)
```

| N     | Working Set | Fits in L2? |
|------:|------------:|:-----------:|
| 1024  | 16 MB       | Yes         |
| 2048  | 32 MB       | Yes         |
| 4096  | 64 MB       | Yes         |
| 8192  | 128 MB      | Borderline  |
| 16384 | 256 MB      | No          |

- At **N ≤ 4096**, the working set (≤ 64 MB) fits comfortably in L2, so `do_bench_cudagraph` reports inflated bandwidth — subsequent iterations hit L2 rather than HBM. The overstatement peaks at **~1.6×** for N=4096.
- At **N = 8192**, the working set (~128 MB) is right at the L2 boundary. Some caching benefit remains (1.06×).
- At **N = 16384**, the working set (~256 MB) clearly exceeds L2. Both methods converge to nearly identical HBM bandwidth (~6.4 TB/s).

## Benchmarking methods compared

| | `do_bench` | `do_bench_cudagraph` | `profile_with_l2flush` |
|---|---|---|---|
| **Timing mechanism** | CUDA events | CUDA events over a CUDA graph replay | `torch.profiler` `device_time_total` |
| **Measures** | Wall-clock GPU time (kernel + launch) | Wall-clock GPU time (kernel only, launch amortised by graph) | Kernel-only device time (no launch overhead) |
| **L2 cache flush** | Yes | No | Yes |
| **Statistic** | Mean (default) | Mean (default) | Median |
| **Best for** | Large kernel where host overhead is neglectable | Full network where L2 cache may help next layers | Micro-benchmarking ops needing cold-cache accuracy without host overhead |


<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops", "benchmark", and "sanity"
  test: ["benchmark"]
```

## Checklist
- [x] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [x] Documentation updated (if needed)
- [x] CI configuration reviewed

