### PR TITLE
Update improve-cutile-kernel-perf skill & Add liger kernels & other updates

### DIFF
--- a/.agents/skills/improve-cutile-kernel-perf/SKILL.md
+++ b/.agents/skills/improve-cutile-kernel-perf/SKILL.md
@@ -35,13 +35,14 @@ Work with user to prepare optimization environment:
    - cuTile kernels live under `src/tilegym/suites/<suite>/cutile/` or `src/tilegym/ops/cutile/`
    - Read the kernel file and identify: the `@ct.kernel` decorated function(s), the launch wrapper (`ct.launch()` or `ct_experimental.autotune_launch()`), the `@register_impl` registration, and current autotune configs (if any)
 3. Classify the kernel:
-   - Arithmetic Intensity < 10 -> Memory-bound (primary metric: GB/s)
-   - Arithmetic Intensity 10-50 -> Balanced (track both GB/s and TFLOPS)
-   - Arithmetic Intensity > 50 -> Compute-bound (primary metric: TFLOPS)
+   - Arithmetic Intensity < 10 -> Memory-bound
+   - Arithmetic Intensity 10-50 -> Balanced
+   - Arithmetic Intensity > 50 -> Compute-bound
+
+   Note: classification is only used to pick the optimization priority order in the experiment loop. The **core metric** is always `latency (ms)`.
 4. Check GPU environment:
    - Ensure a GPU node (B200/H100/H200) is available
    - All subsequent benchmark commands should run on the GPU node
-   - Check `ncu` CLI available for deep profiling
 5. Study related references:
    - `references/optimization-playbook.md`: Step-by-step recipes for each optimization (A through J) with before/after code examples
    - `references/perf-knobs-catalog.md`: Complete catalog of all tunable parameters (TMA, persistent scheduling, occupancy, tile sizes, latency hints, etc.)
@@ -56,8 +57,8 @@ Work with user to prepare optimization environment:
 Every experiment iteration applies ONE optimization to the target kernel, verifies correctness, re-benchmarks, and records results. Each iteration should be enforced to finish within 10 minutes.
 
 ### The goal
-- Improve the **core metric**: reduce `SM Active Cycles`
-- Subject to the **core constraint**: Correctness shall not regress — every optimization MUST preserve numerical correctness. `SM Active Cycles` shall not regress > 2% compared to baseline.
+- Improve the **core metric**: reduce `latency (ms)`
+- Subject to the **core constraint**: Correctness shall not regress — every optimization MUST preserve numerical correctness. `latency (ms)` shall not regress > 2% compared to baseline.
 
 ### What you can change
 - The target kernel file under `src/tilegym/suites/<suite>/cutile/` or `src/tilegym/ops/cutile/`: kernel body, tile sizes, occupancy, num_ctas, TMA usage, latency hints, flush_to_zero, autotune configs, persistent scheduling, and other cuTile-specific parameters
@@ -79,8 +80,7 @@ python -m pytest tests/suites/.../test_<kernel_name>.py -k "test_ and cutile and
 #### Performance benchmark:
 For each iteration:
 1. Run pytest benchmark: `python -m pytest ... --print-record` → extract latency (ms)
-2. Run ncu profiling: `ncu [command]` → extract GB/s (memory-bound), TFLOPS (compute-bound) and `SM Active Cycles`.
-3. Record both metrics in perf_results.md
+2. Record latency in perf_results.md
 
 Benchmark cmdlines:
 ```bash
@@ -93,22 +93,20 @@ Cutile: {'forward': {'mean': 3.7903138461538455, 'std': 0.0016941310873207053, '
 ```
 
 ### Track experiment progress
-Use @sandbox/perf_results.md to record each iteration's results. It should only contain a Markdown table with 7 columns:
+Use @sandbox/perf_results.md to record each iteration's results. It should only contain a Markdown table with 5 columns:
 - `iteration`: iteration number, starting from 0 (baseline)
 - `optimization`: what was applied (e.g., "baseline", "TMA replace gather", "persistent scheduling")
-- `metric`: primary metric value (GB/s or TFLOPS)
 - `latency_ms`: kernel latency in milliseconds, six decimal points
-- `SM Active Cycles`: cuTile backend `SM Active Cycles`
 - `correctness`: PASS or FAIL
 - `status`: Whether this iteration was `keep`, `revert`, or `crash`
 
 Example content:
 
 ```markdown
-| iteration | optimization | metric | latency_ms | SM Active Cycles | correctness | status |
-|----------:|:-------------|-------:|-----------:|------------------:|:------------|-------:|
-| 0 | baseline | 245.30 | 0.82 |  1,342,117        | PASS | keep |
-| 1 | TMA replace gather | 512.60 | 0.39 | 1,161,237         | PASS | keep |
+| iteration | optimization       | latency_ms | correctness | status |
+|----------:|:-------------------|-----------:|:------------|-------:|
+| 0         | baseline           |   0.820000 | PASS        | keep   |
+| 1         | TMA replace gather |   0.390000 | PASS        | keep   |
 ```
 
 Create the tabular header if the file was empty. Append one line for each iteration.
@@ -145,7 +143,7 @@ LOOP:
 
    | Outcome | Action |
    |---------|--------|
-   | Improvement(`SM Active Cycles`) >= 5% | Accept as new baseline, continue |
+   | Improvement(`latency (ms)`) >= 5% | Accept as new baseline, continue |
    | Improvement 2-5% | Accept, lower priority for next iteration |
    | Improvement < 2% | Accept but stop unless user wants more |
    | Regression on any config | Revert immediately, try next optimization |

--- a/src/tilegym/ops/cutile/__init__.py
+++ b/src/tilegym/ops/cutile/__init__.py
@@ -47,6 +47,7 @@ if is_backend_available("cutile"):
     from .experimental.mhc import mhc_apply_residual
     from .experimental.mhc import mhc_gemm_rms_scale
     from .experimental.mhc import mhc_sinkhorn
+    from .experimental.nvfp4_quantize import tile_nvfp4_quantize
     from .experimental.sparse_mla import tile_sparse_mla
     from .experimental.swa_attention import tile_swa_attention
     from .flash_decode import fmha_decode
@@ -103,6 +104,7 @@ if is_backend_available("cutile"):
         "sparse_mla",
         "swa_attention",
         "tile_swa_attention",
+        "tile_nvfp4_quantize",
     ]
 else:
     __all__ = []

--- a/src/tilegym/ops/cutile/experimental/nvfp4_quantize.py
+++ b/src/tilegym/ops/cutile/experimental/nvfp4_quantize.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+from functools import lru_cache
+from typing import Optional
+
+import cuda.tile as ct
+import numpy as np
+import torch
+from cuda.tile._datatype import float4_e2m1fn
+from cuda.tile._datatype import float8_e4m3fn
+from cuda.tile._stub import pack_to_bytes
+
+from tilegym.backend import register_impl
+from tilegym.experimental import experimental_kernel
+
+ct.pack_to_bytes = pack_to_bytes
+
+FP4_MAX = 6.0
+E4M3_EPS = 1.5258789e-05
+
+ConstInt = ct.Constant[int]
+ConstBool = ct.Constant[bool]
+
+
+# Currently uses a fixed 128x64 tile (128 rows x 64 cols per CTA).
+# Future work: support additional tile sizes (e.g. 64x64, 256x64) to enable
+# auto-tuning across tile configurations for different matrix shapes.
+@lru_cache(maxsize=None)
+def _make_nvfp4_kernel(occupancy: int):
+    @experimental_kernel
+    @ct.kernel(occupancy=occupancy)
+    def _nvfp4_quant_kernel(
+        x,  # bf16/fp16/fp32 [rows, cols]
+        scales_out,  # uint8 [num_tiles * 512]  — swizzled fp8 e4m3fn
+        packed_out,  # uint8 [rows, cols//2]  — packed fp4
+        s_enc,  # float32 [1]  — global encoding scale (runtime)
+        NUM_N_BLOCKS: ConstInt,
+        NUM_M_BLOCKS: ConstInt,
+        NUM_COLS: ConstInt,  # actual unpadded col count
+        NUM_ROWS: ConstInt,  # actual unpadded row count
+        USE_COL_MASK: ConstBool,  # True when cols % 64 != 0
+        USE_ROW_MASK: ConstBool,  # True when rows % 128 != 0
+    ):
+        blk_n = ct.bid(0)
+        blk_m = ct.bid(1)
+
+        # TMA zero-pads OOB rows and cols in hardware, so ct.load works for all
+        # blocks including partial last row/col blocks.
+        block = ct.load(x, index=(blk_m, blk_n), shape=(128, 64))  # 128x64 tile
+        block_3d = ct.reshape(ct.astype(block, ct.float32), (128, 4, 16))
+        block_max = ct.max(ct.abs(block_3d), axis=2, keepdims=True)
+
+        s_enc_3d = ct.reshape(ct.load(s_enc, index=(0,), shape=(1,)), (1, 1, 1))
+        scale_pre = ct.maximum((block_max / FP4_MAX) * s_enc_3d, E4M3_EPS)
+
+        # Zero scales for OOB col groups in the last partial col block
+        if USE_COL_MASK and blk_n == NUM_N_BLOCKS - 1:
+            valid_col_grps = (NUM_COLS % 64) // 16
+            grp_idx = ct.reshape(ct.arange(4, dtype=ct.int32), (1, 4, 1))
+            scale_pre = ct.where(grp_idx < valid_col_grps, scale_pre, 0.0)
+
+        # Zero scales for OOB rows in the last partial row block
+        if USE_ROW_MASK and blk_m == NUM_M_BLOCKS - 1:
+            valid_rows = NUM_ROWS % 128
+            row_idx = ct.reshape(ct.arange(128, dtype=ct.int32), (128, 1, 1))
+            scale_pre = ct.where(row_idx < valid_rows, scale_pre, 0.0)
+
+        scale_e4m3 = ct.astype(scale_pre, float8_e4m3fn)
+        scale_u8 = ct.bitcast(scale_e4m3, np.uint8)
+
+        # Swizzle the 128x4 logical scale grid into a 512-byte block.
+        #
+        # Step 1 — split the 128 rows into four 32-row groups:
+        #
+        #    group 0        group 1        group 2        group 3
+        #   (rows 0-31)   (rows 32-63)  (rows 64-95)  (rows 96-127)
+        #   +---------+   +---------+   +---------+   +---------+
+        #   |r0  c0-3 |   |r32 c0-3 |   |r64 c0-3 |   |r96 c0-3 |
+        #   |r1  c0-3 |   |r33 c0-3 |   |r65 c0-3 |   |r97 c0-3 |
+        #   |   ...   |   |   ...   |   |   ...   |   |   ...   |
+        #   |r31 c0-3 |   |r63 c0-3 |   |r95 c0-3 |   |r127 c0-3|
+        #   +---------+   +---------+   +---------+   +---------+
+        #
+        # Step 2 — interleave: sub-row s takes row index s from each group,
+        # yielding 32 sub-rows of 16 bytes (4 groups x 4 bytes):
+        #
+        #     s= 0: [r0 c0-3 | r32 c0-3 | r64 c0-3 | r96 c0-3]  <- bytes   0-15
+        #     s= 1: [r1 c0-3 | r33 c0-3 | r65 c0-3 | r97 c0-3]  <- bytes  16-31
+        #      ...
+        #     s=31: [r31 c0-3| r63 c0-3 | r95 c0-3 |r127 c0-3]  <- bytes 496-511
+        #           ^-4 bytes^
+        #
+        # Expanded, each sub-row s (s = 0..31) holds one scale per col-group for the
+        # same relative row index from each group:
+        #
+        #                group 0          group 1          group 2          group 3
+        #               (rows 0-31)      (rows 32-63)     (rows 64-95)    (rows 96-127)
+        #     byte:   0   1   2   3  |  4   5   6   7  |  8   9  10  11  | 12  13  14  15
+        #            +---------------+----------------+----------------+----------------+
+        #     s= 0   | r0  c0 c1 c2 c3| r32 c0 c1 c2 c3| r64 c0 c1 c2 c3| r96 c0 c1 c2 c3|
+        #     s= 1   | r1  c0 c1 c2 c3| r33 c0 c1 c2 c3| r65 c0 c1 c2 c3| r97 c0 c1 c2 c3|
+        #     s= 2   | r2  c0 c1 c2 c3| r34 c0 c1 c2 c3| r66 c0 c1 c2 c3| r98 c0 c1 c2 c3|
+        #      ...   |      ...       |      ...       |      ...       |      ...       |
+        #     s=31   |r31  c0 c1 c2 c3| r63 c0 c1 c2 c3| r95 c0 c1 c2 c3|r127 c0 c1 c2 c3|
+        #            +---------------+----------------+----------------+----------------+
+        #
+        # Each byte is one fp8 e4m3fn scale. Col-groups cover the input columns:
+        #     c0 = cols  0-15    c1 = cols 16-31    c2 = cols 32-47    c3 = cols 48-63
+        #
+        # byte offset of scale[r, c]:  (r % 32) * 16  +  (r // 32) * 4  +  c
+        #
+        # Implemented as: [128, 4, 1] -> reshape [4, 32, 1, 4] -> permute(2,1,0,3) -> [1, 32, 4, 4] -> reshape [512]
+        scale_4d = ct.reshape(scale_u8, (4, 32, 1, 4))
+        scale_swizzled = ct.reshape(ct.permute(scale_4d, (2, 1, 0, 3)), (512,))
+
+        # Store 512-byte swizzle block to its slot in the 1D scales buffer
+        tile_idx = blk_m * NUM_N_BLOCKS + blk_n
+        ct.store(scales_out, index=(tile_idx,), tile=scale_swizzled)
+
+        enc_scale = s_enc_3d / ct.astype(scale_e4m3, ct.float32)
+        fp4 = ct.astype(block_3d * enc_scale, float4_e2m1fn)
+        packed = ct.reshape(ct.pack_to_bytes(fp4), (128, 32))
+
+        ct.store(packed_out, index=(blk_m, blk_n), tile=packed)
+
+    return _nvfp4_quant_kernel
+
+
+def tile_nvfp4_quantize(
+    x: torch.Tensor,
+    s_enc: float = 1.0,
+    occupancy: Optional[int] = None,
+    **kwargs,
+):
+    """
+    Host launcher for NVFP4 quantization (cuTile backend).
+
+    Args:
+        x:          bf16, fp16, or fp32 input tensor, shape (rows, cols).
+                    cols must be divisible by 16.
+        s_enc:      Global encoding scale (float, default 1.0).
+        occupancy:  CTA occupancy hint for the kernel (default: None, uses ct.kernel default).
+                    Different values compile to separate kernel variants.
+
+    Returns:
+        packed_out: uint8 tensor of shape (rows, cols // 2) -- two fp4 values per byte.
+        scales_out: uint8 tensor of shape (num_tiles * 512,) -- swizzled fp8 e4m3fn scales,
+                    where num_tiles = ceil(rows / tile_m) * ceil(cols / tile_n).
+    """
+    if x.dim() != 2:
+        raise ValueError(f"nvfp4_quantize expects a 2D input, got shape {tuple(x.shape)}")
+    if x.dtype not in (torch.bfloat16, torch.float16, torch.float32):
+        raise ValueError(f"nvfp4_quantize requires bf16, fp16, or fp32 input, got {x.dtype}")
+    rows, cols = x.shape
+    if cols % 16 != 0:
+        raise ValueError(f"cols must be divisible by 16, got {cols}")
+
+    x = x.contiguous()
+    tile_m, tile_n = 128, 64
+    num_m_blocks = (rows + tile_m - 1) // tile_m
+    num_n_blocks = (cols + tile_n - 1) // tile_n
+    use_row_mask = rows % tile_m != 0
+    use_col_mask = cols % tile_n != 0
+    num_tiles = num_m_blocks * num_n_blocks
+
+    scales_out = torch.zeros(num_tiles * 512, dtype=torch.uint8, device=x.device)
+    packed_out = torch.zeros(rows, cols // 2, dtype=torch.uint8, device=x.device)
+    s_enc_tensor = torch.tensor([s_enc], dtype=torch.float32, device=x.device)
+
+    kernel = _make_nvfp4_kernel(occupancy)
+    ct.launch(
+        torch.cuda.current_stream(),
+        (num_n_blocks, num_m_blocks, 1),
+        kernel,
+        (x, scales_out, packed_out, s_enc_tensor, num_n_blocks, num_m_blocks, cols, rows, use_col_mask, use_row_mask),
+    )
+    return packed_out, scales_out
+
+
+register_impl("nvfp4_quantize", backend="cutile")(tile_nvfp4_quantize)

--- a/src/tilegym/ops/ops.py
+++ b/src/tilegym/ops/ops.py
@@ -993,3 +993,42 @@ def swa_attention(
         Output tensor of shape (B, H, S_Q, D), fp16
     """
     raise NotImplementedError(f"swa_attention is not implemented for {get_current_backend()}")
+
+
+@dispatch(
+    "nvfp4_quantize",
+)
+def nvfp4_quantize(
+    x: torch.Tensor,
+    s_enc: float = 1.0,
+    **kwargs: Any,
+):
+    """
+    Block quantize a 2D bf16/fp16/fp32 tensor to NVFP4 (fp4_e2m1fn) with
+    swizzled fp8 e4m3fn scales.
+
+    Each 128x64 tile is divided into groups of 16 consecutive elements per row.
+    Per group:
+
+        s     = fp8_e4m3fn( clamp( max(|x_i|) / 6.0 * s_enc,  eps,  fp8_max ) )
+        x_q_i = fp4_e2m1fn( x_i  *  s_enc / fp32(s) )
+
+    where eps = 1.5259e-5 prevents zero scales.
+
+    Scales are stored in a swizzled 512-byte block per 128x64 tile.
+    The 128x4 logical scale grid is interleaved across four 32-row groups,
+    giving byte offset:  (r % 32) * 16  +  (r // 32) * 4  +  c
+    See ops/cutile/experimental/nvfp4_quantize.py for the full layout diagram.
+
+    Args:
+        x:     Input tensor, bf16/fp16/fp32, shape (rows, cols).
+               cols must be divisible by 16.
+        s_enc: Global encoding scale multiplier (default 1.0).
+        **kwargs: Additional backend-specific arguments.
+
+    Returns:
+        packed_out: uint8 tensor shape (rows, cols // 2) -- two fp4 values per byte.
+        scales_out: uint8 tensor shape (num_tiles * 512,) -- swizzled fp8 e4m3fn scales,
+                    where num_tiles = ceil(rows / 128) * ceil(cols / 64).
+    """
+    raise NotImplementedError(f"nvfp4_quantize is not implemented for {get_current_backend()}")

--- a/src/tilegym/suites/__init__.py
+++ b/src/tilegym/suites/__init__.py
@@ -23,9 +23,11 @@ def list_available() -> List[str]:
     available = []
     try:
         from . import flashinfer
+        from . import liger
         from . import unsloth
 
         available.append("flashinfer")
+        available.append("liger")
         available.append("unsloth")
     except ImportError:
         pass

--- a/src/tilegym/suites/liger/__init__.py
+++ b/src/tilegym/suites/liger/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+liger Suite - cutile implementations for Liger-Kernel compatible operations
+
+Usage:
+    from tilegym.suites import liger
+    output = liger.jsd(input_log_prob, target_log_prob)
+"""
+
+from tilegym.backend import is_backend_available
+
+# Import backend implementations to register them
+
+if is_backend_available("cutile"):
+    from . import cutile as _cutile_impl
+
+# Import unified interface
+from .ops import fused_linear_jsd
+from .ops import geglu
+from .ops import jsd
+from .ops import layer_norm
+
+__all__ = [
+    "fused_linear_jsd",
+    "geglu",
+    "jsd",
+    "layer_norm",
+]

--- a/src/tilegym/suites/liger/cutile/__init__.py
+++ b/src/tilegym/suites/liger/cutile/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""CuTile implementations for liger suite."""
+
+from . import fused_linear_jsd  # noqa: F401
+from . import geglu  # noqa: F401
+from . import jsd  # noqa: F401
+from . import layer_norm  # noqa: F401
+
+__all__ = [
+    "fused_linear_jsd",
+    "geglu",
+    "jsd",
+    "layer_norm",
+]

--- a/src/tilegym/suites/liger/cutile/fused_linear_jsd.py
+++ b/src/tilegym/suites/liger/cutile/fused_linear_jsd.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Fused linear + Jensen-Shannon Divergence kernel (CuTile backend).
+
+Forward (chunked):
+  Processes row-chunks to bound peak memory. Per-chunk: two matmuls + one
+  JSD kernel + element-wise softmax-bwd. grad_input/grad_weight accumulated
+  across chunks in forward.
+
+Backward:
+  Returns pre-computed grad_input and grad_weight scaled by grad_output.
+  No matmuls in backward.
+"""
+
+from typing import Optional
+
+import cuda.tile as ct
+import torch
+
+from tilegym.backend import register_impl
+
+from .jsd import _JSD_BLOCK_SIZE
+from .jsd import _jsd_kernel
+from .utils import next_power_of_2
+
+
+def _fused_linear_jsd_forward(
+    student_input,
+    student_weight,
+    teacher_input,
+    teacher_weight,
+    shift_labels,
+    beta,
+    ignore_index,
+    has_label,
+    temperature,
+    compute_grad_input,
+    compute_grad_weight,
+):
+    device = student_input.device
+    dtype = student_input.dtype
+
+    BT, H = student_input.shape
+    V = student_weight.shape[0]
+    # Use _JSD_BLOCK_SIZE (4096) — NOT a local MAX_FUSED_SIZE.
+    # Larger values (e.g. 32768) cause register spill in _jsd_kernel → 5-10x slowdown.
+    BLOCK_SIZE = min(_JSD_BLOCK_SIZE, next_power_of_2(V))
+
+    if has_label:
+        n_non_ignore = (shift_labels != ignore_index).sum().item()
+    else:
+        n_non_ignore = BT
+
+    if n_non_ignore == 0:
+        empty_input_grad = torch.zeros(BT, H, dtype=dtype, device=device) if compute_grad_input else None
+        empty_weight_grad = torch.zeros(V, H, dtype=dtype, device=device) if compute_grad_weight else None
+        return (
+            torch.tensor(0.0, device=device, dtype=dtype),
+            empty_input_grad,
+            empty_weight_grad,
+        )
+
+    inv_n_non_ignore = 1.0 / n_non_ignore
+    label_tensor = shift_labels if has_label else torch.empty(1, device=device, dtype=torch.int64)
+
+    inc_factor = (V + H - 1) // H
+    chunk_size = next_power_of_2((BT + inc_factor - 1) // inc_factor)
+    num_chunks = (BT + chunk_size - 1) // chunk_size
+
+    total_loss = torch.tensor(0.0, device=device, dtype=torch.float32)
+    grad_input = torch.zeros(BT, H, dtype=dtype, device=device) if compute_grad_input else None
+    grad_weight = torch.zeros_like(student_weight) if compute_grad_weight else None
+
+    for chunk_id in range(num_chunks):
+        start_idx = chunk_id * chunk_size
+        end_idx = min((chunk_id + 1) * chunk_size, BT)
+
+        student_input_chunk = student_input[start_idx:end_idx]
+        teacher_input_chunk = teacher_input[start_idx:end_idx]
+
+        student_logits_chunk = (student_input_chunk @ student_weight.t()).to(torch.float32) / temperature
+        teacher_logits_chunk = (teacher_input_chunk @ teacher_weight.t()).to(torch.float32) / temperature
+        chunk_n_rows = student_logits_chunk.shape[0]
+
+        log_prob_s_chunk = torch.log_softmax(student_logits_chunk, dim=-1).contiguous()
+        log_prob_t_chunk = torch.log_softmax(teacher_logits_chunk, dim=-1).contiguous()
+        # Pre-compute softmax before overwriting log_prob_s_chunk with dX in-place.
+        softmax_s_chunk = torch.exp(log_prob_s_chunk)
+        del student_logits_chunk, teacher_logits_chunk
+
+        loss_chunk = torch.zeros(chunk_n_rows, V, dtype=torch.float32, device=device)
+
+        label_chunk = label_tensor[start_idx:end_idx] if has_label else label_tensor
+
+        # Pass log_prob_s_chunk as both X and dX (in-place) — saves one (chunk_size, V)
+        # float32 allocation. Safe: kernel reads X before writing dX within each row.
+        ct.launch(
+            torch.cuda.current_stream(),
+            (chunk_n_rows, 1, 1),
+            _jsd_kernel,
+            (
+                log_prob_s_chunk,
+                log_prob_t_chunk,
+                loss_chunk,
+                log_prob_s_chunk,  # dX in-place
+                label_chunk,
+                float(beta),
+                float(inv_n_non_ignore),
+                int(ignore_index),
+                int(V),
+                int(BLOCK_SIZE),
+                int(has_label),
+            ),
+        )
+        # log_prob_s_chunk now holds dX (written by kernel); softmax_s_chunk holds exp(log_prob_s).
+        dX_chunk = log_prob_s_chunk
+        grad_chunk = (dX_chunk - softmax_s_chunk * dX_chunk.sum(dim=-1, keepdim=True)) / temperature
+        grad_chunk = grad_chunk.to(dtype)
+        del log_prob_s_chunk, log_prob_t_chunk, softmax_s_chunk, dX_chunk
+
+        total_loss = total_loss + loss_chunk.sum()
+
+        if compute_grad_input:
+            grad_input[start_idx:end_idx] = grad_chunk @ student_weight
+        if compute_grad_weight:
+            grad_weight.addmm_(grad_chunk.t(), student_input_chunk)
+
+    return total_loss.to(dtype), grad_input, grad_weight
+
+
+class FusedLinearJSDFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        student_input: torch.Tensor,
+        student_weight: torch.Tensor,
+        teacher_input: torch.Tensor,
+        teacher_weight: torch.Tensor,
+        shift_labels: Optional[torch.Tensor],
+        beta: float,
+        ignore_index: int,
+        temperature: float,
+    ):
+        has_label = False
+        if shift_labels is not None:
+            assert shift_labels.shape == (student_input.shape[0],), (
+                f"shift_labels must have shape (BT,). Got: {shift_labels.shape}"
+            )
+            shift_labels = shift_labels.contiguous()
+            has_label = True
+
+        input_requires_grad = student_input.requires_grad
+        weight_requires_grad = student_weight.requires_grad
+
+        loss, grad_input, grad_weight = _fused_linear_jsd_forward(
+            student_input,
+            student_weight,
+            teacher_input,
+            teacher_weight,
+            shift_labels,
+            beta,
+            ignore_index,
+            has_label,
+            temperature,
+            compute_grad_input=input_requires_grad,
+            compute_grad_weight=weight_requires_grad,
+        )
+
+        ctx.save_for_backward(
+            grad_input if input_requires_grad else torch.empty(0),
+            grad_weight if weight_requires_grad else torch.empty(0),
+        )
+        ctx.input_requires_grad = input_requires_grad
+        ctx.weight_requires_grad = weight_requires_grad
+        return loss
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        grad_input_saved, grad_weight_saved = ctx.saved_tensors
+
+        if not ctx.input_requires_grad and not ctx.weight_requires_grad:
+            return None, None, None, None, None, None, None, None
+
+        if torch.equal(grad_output, torch.tensor(1.0, device=grad_output.device)):
+            grad_input = grad_input_saved if ctx.input_requires_grad else None
+            grad_weight = grad_weight_saved if ctx.weight_requires_grad else None
+        else:
+            # Multiply on device — avoids .item() host-device sync.
+            grad_input = (grad_input_saved * grad_output) if ctx.input_requires_grad else None
+            grad_weight = (grad_weight_saved * grad_output) if ctx.weight_requires_grad else None
+
+        return grad_input, grad_weight, None, None, None, None, None, None
+
+
+@register_impl("liger.fused_linear_jsd", backend="cutile")
+def fused_linear_jsd(
+    student_input: torch.Tensor,
+    student_weight: torch.Tensor,
+    teacher_input: torch.Tensor,
+    teacher_weight: torch.Tensor,
+    shift_labels: Optional[torch.Tensor] = None,
+    beta: float = 0.5,
+    ignore_index: int = -100,
+    temperature: float = 1.0,
+    **kwargs,
+) -> torch.Tensor:
+    return FusedLinearJSDFunction.apply(
+        student_input,
+        student_weight,
+        teacher_input,
+        teacher_weight,
+        shift_labels,
+        beta,
+        ignore_index,
+        temperature,
+    )

--- a/src/tilegym/suites/liger/cutile/geglu.py
+++ b/src/tilegym/suites/liger/cutile/geglu.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+GEGLU activation kernel (CuTile backend).
+
+Computes: c = GELU(a) * b  using the tanh approximation of GELU:
+  GELU(a) = 0.5 * a * (1 + tanh(sqrt(2/pi) * (a + 0.044715 * a^3)))
+
+Row-parallel: grid = (n_rows, 1, 1). Each block handles one row,
+looping over column chunks of size BLOCK_SIZE.
+"""
+
+import cuda.tile as ct
+import torch
+
+from tilegym.backend import register_impl
+
+from .utils import next_power_of_2
+
+MAX_FUSED_SIZE_FWD = 4096  # Forward: tile size cap; aligned path activates when n_cols % BLOCK_SIZE == 0
+MAX_FUSED_SIZE_BWD = 512  # Backward: recomputes tanh + two gradient terms — larger tile causes register spill
+SQRT_2_OVER_PI = 0.7978845608028654
+
+
+@ct.kernel(occupancy=1)
+def _geglu_fwd_ct(
+    A,  # (n_rows, n_cols) input a
+    B,  # (n_rows, n_cols) input b
+    C,  # (n_rows, n_cols) output c
+    n_cols: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    CHECK_BOUNDS: ct.Constant[bool],
+):
+    """GEGLU forward. CHECK_BOUNDS=False (aligned path) is ~17-20% faster on B200."""
+    row_idx = ct.bid(0)
+
+    num_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+    for ci in range(num_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+
+        a = ct.astype(ct.gather(A, (row_idx, col_idx), check_bounds=CHECK_BOUNDS, padding_value=0.0), ct.float32)
+        b = ct.gather(B, (row_idx, col_idx), check_bounds=CHECK_BOUNDS, padding_value=0.0)
+
+        a_sq = a * a
+        tanh_arg = SQRT_2_OVER_PI * (a + 0.044715 * a_sq * a)
+        tanh_result = ct.tanh(tanh_arg)
+        geglu_a = 0.5 * a * (1.0 + tanh_result)
+
+        c = ct.astype(geglu_a, b.dtype) * b
+        ct.scatter(C, (row_idx, col_idx), c, check_bounds=CHECK_BOUNDS)
+
+
+@ct.kernel
+def _geglu_bwd_ct(
+    DC,  # (n_rows, n_cols) upstream gradient
+    A,  # (n_rows, n_cols) saved input a — DA written in-place
+    B,  # (n_rows, n_cols) saved input b — DB written in-place
+    n_cols: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    CHECK_BOUNDS: ct.Constant[bool],
+):
+    """
+    GEGLU backward. CHECK_BOUNDS=False (aligned path) is faster on B200.
+    """
+    row_idx = ct.bid(0)
+
+    num_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+    for ci in range(num_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+
+        dc = ct.astype(ct.gather(DC, (row_idx, col_idx), check_bounds=CHECK_BOUNDS, padding_value=0.0), ct.float32)
+        a = ct.astype(ct.gather(A, (row_idx, col_idx), check_bounds=CHECK_BOUNDS, padding_value=0.0), ct.float32)
+        b = ct.astype(ct.gather(B, (row_idx, col_idx), check_bounds=CHECK_BOUNDS, padding_value=0.0), ct.float32)
+
+        # CSE: term1 = 0.5*(1+tanh), geglu_a = term1*a — shared between db and da
+        a_sq = a * a
+        tanh_arg = SQRT_2_OVER_PI * (a + 0.044715 * a_sq * a)
+        tanh_result = ct.tanh(tanh_arg, rounding_mode=ct.RoundingMode.APPROX)
+        term1 = 0.5 * (1.0 + tanh_result)
+        geglu_a = term1 * a
+
+        db = dc * geglu_a
+
+        # da = dc * b * (term1 + 0.5*a*(1-tanh^2)*sqrt(2/pi)*(1+3*0.044715*a^2))
+        tanh_sq = tanh_result * tanh_result
+        term2 = 0.5 * a * (1.0 - tanh_sq) * (SQRT_2_OVER_PI * (1.0 + 3.0 * 0.044715 * a_sq))
+        da = dc * b * (term1 + term2)
+
+        ct.scatter(A, (row_idx, col_idx), ct.astype(da, A.dtype), check_bounds=CHECK_BOUNDS)
+        ct.scatter(B, (row_idx, col_idx), ct.astype(db, B.dtype), check_bounds=CHECK_BOUNDS)
+
+
+def _calculate_block_size(n_cols, max_fused_size):
+    BLOCK_SIZE = next_power_of_2(n_cols)
+    BLOCK_SIZE = max(BLOCK_SIZE, 128)
+    BLOCK_SIZE = min(BLOCK_SIZE, max_fused_size)
+    # If BLOCK_SIZE divides n_cols exactly, all chunks are full → check_bounds=False (fast path).
+    # Otherwise use it as-is with check_bounds=True for the partial last chunk.
+    return BLOCK_SIZE
+
+
+class GEGLUFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, a, b):
+        ori_shape = a.shape
+        n_cols = ori_shape[-1]
+        a = a.view(-1, n_cols)
+        b = b.view(-1, n_cols)
+
+        if not a.is_contiguous():
+            a = a.contiguous()
+        if not b.is_contiguous():
+            b = b.contiguous()
+
+        n_rows = a.shape[0]
+        c = torch.empty_like(a)
+        BLOCK_SIZE = _calculate_block_size(n_cols, MAX_FUSED_SIZE_FWD)
+        aligned = n_cols % BLOCK_SIZE == 0
+
+        grid = (n_rows, 1, 1)
+        ct.launch(
+            torch.cuda.current_stream(),
+            grid,
+            _geglu_fwd_ct,
+            (a, b, c, int(n_cols), int(BLOCK_SIZE), not aligned),
+        )
+        ctx.save_for_backward(a, b)
+        ctx.ori_shape = ori_shape
+        return c.view(*ori_shape)
+
+    @staticmethod
+    def backward(ctx, dc):
+        a, b = ctx.saved_tensors
+        ori_shape = ctx.ori_shape
+        n_cols = ori_shape[-1]
+        dc = dc.view(-1, n_cols).contiguous()
+        n_rows = dc.shape[0]
+        BLOCK_SIZE = _calculate_block_size(n_cols, MAX_FUSED_SIZE_BWD)
+        aligned = n_cols % BLOCK_SIZE == 0
+
+        grid = (n_rows, 1, 1)
+        ct.launch(
+            torch.cuda.current_stream(),
+            grid,
+            _geglu_bwd_ct,
+            (dc, a, b, int(n_cols), int(BLOCK_SIZE), not aligned),
+        )
+        return a.view(*ori_shape), b.view(*ori_shape)
+
+
+@register_impl("liger.geglu", backend="cutile")
+def geglu(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    **kwargs,
+) -> torch.Tensor:
+    return GEGLUFunction.apply(a, b)

--- a/src/tilegym/suites/liger/cutile/jsd.py
+++ b/src/tilegym/suites/liger/cutile/jsd.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import functools
+import math
+from typing import Optional
+
+import cuda.tile as ct
+import torch
+
+from tilegym.backend import register_impl
+
+from .utils import next_power_of_2
+
+_JSD_BLOCK_SIZE = 4096
+
+
+def ensure_contiguous(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        def maybe_to_contiguous(x):
+            return x.contiguous() if isinstance(x, torch.Tensor) else x
+
+        args = [maybe_to_contiguous(arg) for arg in args]
+        kwargs = {k: maybe_to_contiguous(v) for k, v in kwargs.items()}
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+@ct.kernel(occupancy=ct.ByTarget(sm_100=4))
+def _jsd_kernel(
+    X,  # (BT, V) log Q (student)
+    Y,  # (BT, V) log P (teacher)
+    loss,  # (BT, V) float32 loss accumulator (pre-initialized to 0)
+    dX,  # (BT, V) gradient output (input dtype)
+    label,  # (BT,) label tensor, or dummy 1-elem tensor when HAS_LABEL=0
+    beta: ct.Constant[float],
+    inv_n_non_ignore: ct.Constant[float],
+    ignore_index: ct.Constant[int],
+    n_cols: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    HAS_LABEL: ct.Constant[int],
+):
+    """
+    cuTile kernel for generalized Jensen-Shannon Divergence.
+
+    JSD(β)(P || Q): loss_i = β·P_i·(log P_i - log M_i) + (1-β)·Q_i·(log Q_i - log M_i)
+    where M = β·P + (1-β)·Q
+
+    Inputs X = log Q (student), Y = log P (teacher) are log-probabilities.
+
+    Special cases:
+      beta == 0.0  →  forward KL:  KL(P || Q)
+      beta == 1.0  →  reverse KL:  KL(Q || P)
+      else         →  generalized JSD
+    """
+    row_idx = ct.bid(0)
+
+    if HAS_LABEL:
+        lbl = ct.load(label, row_idx, shape=())
+        if lbl == ignore_index:
+            # Zero out dX for this row; loss stays at 0 (pre-initialized on host)
+            num_chunks_early = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+            for ci in range(num_chunks_early):
+                col_indices = ct.arange(BLOCK_SIZE, dtype=ct.int32) + ci * BLOCK_SIZE
+                ct.scatter(dX, (row_idx, col_indices), ct.full((BLOCK_SIZE,), 0.0, dtype=dX.dtype), check_bounds=True)
+            return
+
+    num_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+    for chunk_idx in range(num_chunks):
+        col_indices = ct.arange(BLOCK_SIZE, dtype=ct.int32) + chunk_idx * BLOCK_SIZE
+
+        # Load X (log Q) and Y (log P); out-of-bounds positions padded with -inf
+        X_tile = ct.gather(X, (row_idx, col_indices), check_bounds=True, padding_value=-math.inf)
+        Y_tile = ct.gather(Y, (row_idx, col_indices), check_bounds=True, padding_value=-math.inf)
+
+        X_f32 = ct.astype(X_tile, ct.float32)
+        Y_f32 = ct.astype(Y_tile, ct.float32)
+
+        # Pre-define outputs before compile-time branches (cuTile compiler requirement)
+        loss_tile = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+        dX_tile = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+
+        if beta == 0.0:  # forward KL: KL(P || Q)
+            Y_max = ct.max(Y_f32, 0, keepdims=True)
+            Y_prob = ct.exp(Y_f32 - Y_max) * ct.exp(Y_max)
+            loss_tile = Y_prob * (Y_f32 - X_f32)
+            dX_tile = -Y_prob
+
+        elif beta == 1.0:  # reverse KL: KL(Q || P)
+            X_max = ct.max(X_f32, 0, keepdims=True)
+            X_prob = ct.exp(X_f32 - X_max) * ct.exp(X_max)
+            loss_tile = X_prob * (X_f32 - Y_f32)
+            # dX = X_prob*(X - Y) + X_prob; uses unscaled loss_tile
+            dX_tile = loss_tile + X_prob
+
+        else:  # generalized JSD: M = beta*P + (1-beta)*Q
+            X_max = ct.max(X_f32, 0, keepdims=True)
+            Y_max = ct.max(Y_f32, 0, keepdims=True)
+            max_val = ct.maximum(X_max, Y_max)
+            exp_max = ct.exp(max_val)
+            Q = ct.exp(X_f32 - max_val) * exp_max  # = exp(X)
+            P = ct.exp(Y_f32 - max_val) * exp_max  # = exp(Y)
+            beta_P = beta * P
+            one_minus_beta_Q = (1.0 - beta) * Q
+            M = beta_P + one_minus_beta_Q
+            log_M = ct.log(M)
+            loss_tile = beta_P * Y_f32 + one_minus_beta_Q * X_f32 - M * log_M
+            dX_tile = one_minus_beta_Q * (X_f32 - log_M)
+
+        loss_tile = loss_tile * inv_n_non_ignore
+        dX_tile = dX_tile * inv_n_non_ignore
+
+        ct.scatter(loss, (row_idx, col_indices), loss_tile, check_bounds=True)
+        ct.scatter(dX, (row_idx, col_indices), ct.astype(dX_tile, dX.dtype), check_bounds=True)
+
+
+def _jsd_forward(_input, target, shift_labels, beta, ignore_index, has_label):
+    BT, V = _input.shape
+    BLOCK_SIZE = min(_JSD_BLOCK_SIZE, next_power_of_2(V))
+
+    # loss pre-initialized to 0: ignored rows contribute 0, partial-chunk pads stay 0
+    loss = torch.zeros(_input.shape, dtype=torch.float32, device=_input.device)
+    dX = torch.empty_like(_input)
+
+    if has_label:
+        n_non_ignore = (shift_labels != ignore_index).sum().item()
+    else:
+        n_non_ignore = BT
+
+    if n_non_ignore == 0:
+        return torch.tensor(0.0, device=_input.device, dtype=_input.dtype), torch.zeros_like(_input)
+
+    inv_n_non_ignore = 1.0 / n_non_ignore
+
+    # ct.launch does not accept None; pass a dummy 1-element tensor when no labels
+    label_tensor = shift_labels if has_label else torch.empty(1, device=_input.device, dtype=torch.int64)
+
+    ct.launch(
+        torch.cuda.current_stream(),
+        (BT, 1, 1),
+        _jsd_kernel,
+        (
+            _input,
+            target,
+            loss,
+            dX,
+            label_tensor,
+            float(beta),
+            float(inv_n_non_ignore),
+            int(ignore_index),
+            int(V),
+            int(BLOCK_SIZE),
+            int(has_label),
+        ),
+    )
+
+    return torch.sum(loss).to(_input.dtype), dX
+
+
+def _jsd_backward(dX, grad_output):
+    if torch.equal(grad_output, torch.tensor(1.0, device=grad_output.device)):
+        return dX
+    else:
+        return grad_output * dX
+
+
+class JSDFunction(torch.autograd.Function):
+    r"""
+    cuTile autograd wrapper for the generalized Jensen-Shannon Divergence loss.
+
+    JSD(β)(P || Q) = β * KL(P || M) + (1-β) * KL(Q || M),  M = β*P + (1-β)*Q
+
+    Inputs are expected as log-probabilities (log-space).
+    """
+
+    @staticmethod
+    @ensure_contiguous
+    def forward(
+        ctx,
+        _input: torch.Tensor,
+        target: torch.Tensor,
+        shift_labels: Optional[torch.Tensor],
+        beta: float,
+        ignore_index: int,
+    ) -> torch.Tensor:
+        has_label = False
+        if shift_labels is not None:
+            assert shift_labels.shape == (_input.shape[0],), (
+                f"shift_labels must have shape (BT,). Got: {shift_labels.shape}"
+            )
+            shift_labels = shift_labels.contiguous()
+            has_label = True
+
+        loss, dX = _jsd_forward(_input, target, shift_labels, beta, ignore_index, has_label)
+        ctx.save_for_backward(dX)
+        return loss
+
+    @staticmethod
+    @ensure_contiguous
+    def backward(ctx, grad_output: torch.Tensor):
+        (dX,) = ctx.saved_tensors
+        dX = _jsd_backward(dX, grad_output)
+        return (dX, None, None, None, None)
+
+
+@register_impl("liger.jsd", backend="cutile")
+def jsd(
+    input: torch.Tensor,
+    target: torch.Tensor,
+    shift_labels: Optional[torch.Tensor] = None,
+    beta: float = 0.5,
+    ignore_index: int = -100,
+    **kwargs,
+) -> torch.Tensor:
+    return JSDFunction.apply(input, target, shift_labels, beta, ignore_index)

--- a/src/tilegym/suites/liger/cutile/layer_norm.py
+++ b/src/tilegym/suites/liger/cutile/layer_norm.py
@@ -1,0 +1,407 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Layer Normalization kernel (CuTile backend).
+
+Forward: row-parallel (one block per row). Single-pass computes sum and sum_sq
+  via fold trick → mean and variance. Second pass applies normalization:
+  Y = (X - mean) * rstd * W + B. Mean and RSTD cached for backward.
+
+Backward: Split into two kernels for maximum SM parallelism:
+
+  Kernel 1 — DX kernel: grid=(n_rows, 1, 1), one block per row.
+    Per row: loads X, DY, W, Mean[row], RSTD[row]; computes x_hat, wdy, c1, c2;
+    writes DX[row]. High block count hides memory latency (same as forward).
+
+  Kernel 2 — DW/DB kernel: grid=(sm_count, 1, 1), persistent loop.
+    Block b processes rows [b*rpp, (b+1)*rpp); accumulates dW+=dy*x_hat, dB+=dy.
+    DW/DB partial buffers: (sm_count, n_cols). Host reduces dim=0.
+    Second read of X/DY hits L2 cache (still warm from DX kernel).
+
+  This split avoids the latency-bound regime of the old combined (148-block)
+  kernel: the DX kernel launches n_rows blocks (like HF's vectorized kernel),
+  giving warp occupancy ~60% and hiding long-scoreboard stalls.
+"""
+
+import math
+
+import cuda.tile as ct
+import torch
+
+from tilegym.backend import register_impl
+
+from .utils import next_power_of_2
+
+# Cached secondary stream for concurrent DW/DB kernel launch.
+# Lazily created per device on first backward call; avoids stream creation overhead.
+_dw_stream_cache: dict = {}
+
+
+def _calculate_settings(n_cols):
+    BLOCK_SIZE = next_power_of_2(n_cols)
+    if BLOCK_SIZE > 65536:
+        raise RuntimeError(f"Hidden dimension {n_cols} exceeds maximum supported size of 65536.")
+    num_warps = 4
+    if BLOCK_SIZE >= 32768:
+        num_warps = 32
+    elif BLOCK_SIZE >= 8192:
+        num_warps = 16
+    elif BLOCK_SIZE >= 2048:
+        num_warps = 8
+    return BLOCK_SIZE, num_warps
+
+
+@ct.kernel(occupancy=1)
+def _layer_norm_fwd_ct(
+    X,  # (n_rows, n_cols) input
+    Y,  # (n_rows, n_cols) output
+    W,  # (n_cols,) scale
+    B,  # (n_cols,) bias
+    Mean,  # (n_rows,) cached mean
+    RSTD,  # (n_rows,) cached reciprocal std
+    n_cols: ct.Constant[int],
+    eps: ct.Constant[float],
+    BLOCK_SIZE: ct.Constant[int],
+    ALIGNED: ct.Constant[bool],
+):
+    """
+    Layer norm forward.
+
+    Row-parallel: one block per row. Grid=(n_rows,1,1): every row_idx in [0,n_rows).
+    When ALIGNED=True (n_cols is power-of-2), BLOCK_SIZE==n_cols and column accesses
+    are exactly in-bounds → check_bounds=False enables hardware TMA path.
+    """
+    row_idx = ct.bid(0)
+    n_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+    check_bounds = not ALIGNED
+
+    # ---- Pass 1: compute sum(x) and sum(x^2) via fold trick ----
+    # OOB column positions (when ALIGNED=False, last chunk) padded with 0.0 → correct
+    sum_tile = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+    sum_sq_tile = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+        x = ct.astype(ct.gather(X, (row_idx, col_idx), check_bounds=check_bounds, padding_value=0.0), ct.float32)
+        sum_tile = ct.add(sum_tile, x)
+        sum_sq_tile = ct.add(sum_sq_tile, x * x)
+
+    total_sum = ct.sum(sum_tile, 0, keepdims=False)  # scalar
+    total_sum_sq = ct.sum(sum_sq_tile, 0, keepdims=False)  # scalar
+    mean = total_sum / n_cols
+    var = total_sum_sq / n_cols - mean * mean
+    rstd = ct.rsqrt(var + eps)  # scalar
+
+    # Cache mean and rstd for backward
+    ct.scatter(Mean, row_idx, ct.astype(mean, Mean.dtype))
+    ct.scatter(RSTD, row_idx, ct.astype(rstd, RSTD.dtype))
+
+    # ---- Pass 2: Y = (X - mean) * rstd * W + B ----
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+        x = ct.astype(ct.gather(X, (row_idx, col_idx), check_bounds=check_bounds, padding_value=0.0), ct.float32)
+        w = ct.astype(ct.gather(W, col_idx, check_bounds=check_bounds, padding_value=0.0), ct.float32)
+        b = ct.astype(ct.gather(B, col_idx, check_bounds=check_bounds, padding_value=0.0), ct.float32)
+        y = (x - mean) * rstd * w + b
+        ct.scatter(Y, (row_idx, col_idx), ct.astype(y, Y.dtype), check_bounds=check_bounds)
+
+
+@ct.kernel(occupancy=1)
+def _layer_norm_bwd_dx_ct(
+    X,  # (n_rows, n_cols) saved input
+    DY,  # (n_rows, n_cols) upstream gradient
+    W,  # (n_cols,) scale
+    Mean,  # (n_rows,) saved mean
+    RSTD,  # (n_rows,) saved rstd
+    DX,  # (n_rows, n_cols) output gradient w.r.t. input
+    n_cols: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    ALIGNED: ct.Constant[bool],
+):
+    """
+    Layer norm backward — DX kernel only.
+
+    Grid: (n_rows, 1, 1). One block per row → high concurrency hides latency.
+    Each block: load X[row], DY[row], W, Mean[row], RSTD[row]; compute DX[row].
+    Does NOT compute DW/DB — handled by separate _layer_norm_bwd_dw_ct kernel.
+
+    When ALIGNED=True: check_bounds=False → hardware TMA path for all accesses.
+    """
+    row_idx = ct.bid(0)
+    col_idx = ct.arange(BLOCK_SIZE, dtype=ct.int32)
+    check_bounds = not ALIGNED
+
+    mean = ct.astype(ct.load(Mean, row_idx, shape=(), latency=3), ct.float32)
+    rstd = ct.astype(ct.load(RSTD, row_idx, shape=(), latency=3), ct.float32)
+
+    w = ct.astype(ct.gather(W, col_idx, check_bounds=check_bounds, padding_value=0.0), ct.float32)
+    _lat = 3 if BLOCK_SIZE <= 1024 else 6
+    x = ct.astype(
+        ct.gather(X, (row_idx, col_idx), check_bounds=check_bounds, padding_value=0.0, latency=_lat), ct.float32
+    )
+    dy = ct.astype(
+        ct.gather(DY, (row_idx, col_idx), check_bounds=check_bounds, padding_value=0.0, latency=_lat), ct.float32
+    )
+
+    inv_n_cols = 1.0 / n_cols
+    x_hat = (x - mean) * rstd
+    wdy = w * dy
+    c1 = ct.sum(x_hat * wdy, 0, keepdims=False) * inv_n_cols
+    c2 = ct.sum(wdy, 0, keepdims=False) * inv_n_cols
+    dx = (wdy - (x_hat * c1 + c2)) * rstd
+    ct.scatter(DX, (row_idx, col_idx), ct.astype(dx, DX.dtype), check_bounds=check_bounds)
+
+
+@ct.kernel(occupancy=1)
+def _layer_norm_bwd_dw_ct(
+    X,  # (n_rows, n_cols) saved input
+    DY,  # (n_rows, n_cols) upstream gradient
+    Mean,  # (n_rows,) saved mean
+    RSTD,  # (n_rows,) saved rstd
+    DWDB_partial,  # (2*num_programs, n_cols) stacked DW [0:num_programs) + DB [num_programs:2*num_programs)
+    n_rows: ct.Constant[int],
+    n_cols: ct.Constant[int],
+    num_programs: ct.Constant[int],
+    rows_per_program: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    ALIGNED: ct.Constant[bool],
+):
+    """
+    Layer norm backward — DW/DB accumulation kernel.
+
+    Grid: (num_programs, 1, 1). Block b processes rows [b*rpp, min((b+1)*rpp, n_rows)).
+    Writes DW partial to row block_id and DB partial to row (num_programs + block_id)
+    in the stacked DWDB_partial tensor. Host sums each half in a single call.
+
+    When ALIGNED=True: check_bounds=False → hardware TMA for all accesses.
+    """
+    block_id = ct.bid(0)
+    col_idx = ct.arange(BLOCK_SIZE, dtype=ct.int32)
+    check_bounds = not ALIGNED
+
+    dW_acc = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+    dB_acc = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+
+    for ri in range(rows_per_program):
+        row_idx = block_id * rows_per_program + ri
+        if row_idx < n_rows:
+            mean = ct.astype(ct.load(Mean, row_idx, shape=(), latency=3), ct.float32)
+            rstd = ct.astype(ct.load(RSTD, row_idx, shape=(), latency=3), ct.float32)
+            _lat = 3 if BLOCK_SIZE <= 1024 else 6
+            x = ct.astype(
+                ct.gather(X, (row_idx, col_idx), check_bounds=check_bounds, padding_value=0.0, latency=_lat), ct.float32
+            )
+            dy = ct.astype(
+                ct.gather(DY, (row_idx, col_idx), check_bounds=check_bounds, padding_value=0.0, latency=_lat),
+                ct.float32,
+            )
+            x_hat = (x - mean) * rstd
+            dW_acc = ct.add(dW_acc, dy * x_hat)
+            dB_acc = ct.add(dB_acc, dy)
+
+    # Write DW to row block_id, DB to row (num_programs + block_id) in stacked buffer.
+    # ALIGNED=True: BLOCK_SIZE==n_cols, ct.store is safe (no OOB).
+    # ALIGNED=False: BLOCK_SIZE>n_cols, must use scatter with check_bounds=True to
+    #   avoid writing OOB padding elements (col_idx already defined above).
+    db_row = num_programs + block_id
+    if ALIGNED:
+        ct.store(DWDB_partial, index=(block_id, 0), tile=dW_acc.reshape((1, BLOCK_SIZE)))
+        ct.store(DWDB_partial, index=(db_row, 0), tile=dB_acc.reshape((1, BLOCK_SIZE)))
+    else:
+        ct.scatter(DWDB_partial, (block_id, col_idx), dW_acc, check_bounds=True)
+        ct.scatter(DWDB_partial, (db_row, col_idx), dB_acc, check_bounds=True)
+
+
+def _layer_norm_forward_ct(X, W, B, eps):
+    shape = X.shape
+    dim = shape[-1]
+    X2d = X.view(-1, dim).contiguous()
+    n_rows, n_cols = X2d.shape
+
+    BLOCK_SIZE, _ = _calculate_settings(n_cols)
+    aligned = (n_cols & (n_cols - 1)) == 0  # True when n_cols is a power of 2
+
+    Y = torch.empty_like(X2d)
+    Mean = torch.empty(n_rows, dtype=X.dtype, device=X.device)
+    RSTD = torch.empty(n_rows, dtype=X.dtype, device=X.device)
+
+    grid = (n_rows, 1, 1)
+    ct.launch(
+        torch.cuda.current_stream(),
+        grid,
+        _layer_norm_fwd_ct,
+        (
+            X2d,
+            Y,
+            W.contiguous(),
+            B.contiguous(),
+            Mean,
+            RSTD,
+            int(n_cols),
+            float(eps),
+            int(BLOCK_SIZE),
+            bool(aligned),
+        ),
+    )
+
+    return Y.view(*shape), X2d, Mean, RSTD, BLOCK_SIZE
+
+
+def _layer_norm_backward_ct(dY, X, W, B, Mean, RSTD, BLOCK_SIZE, compute_dW=True, compute_dB=True):
+    shape = dY.shape
+    dim = shape[-1]
+    dY2d = dY.view(-1, dim).contiguous()
+    n_rows, n_cols = dY2d.shape
+
+    sm_count = torch.cuda.get_device_properties(X.device).multi_processor_count
+    aligned = (n_cols & (n_cols - 1)) == 0  # True when n_cols is a power of 2
+
+    X_contig = X.contiguous()
+    W_contig = W.contiguous()
+
+    DX = torch.empty_like(X)
+
+    # Fast path: skip DW/DB entirely if neither W nor B needs gradients.
+    # This halves memory traffic and eliminates the secondary kernel + stream sync.
+    if not compute_dW and not compute_dB:
+        main_stream = torch.cuda.current_stream()
+        dx_grid = (n_rows, 1, 1)
+        ct.launch(
+            main_stream,
+            dx_grid,
+            _layer_norm_bwd_dx_ct,
+            (
+                X_contig,
+                dY2d,
+                W_contig,
+                Mean,
+                RSTD,
+                DX,
+                int(n_cols),
+                int(BLOCK_SIZE),
+                bool(aligned),
+            ),
+        )
+        DX = DX.view(*shape)
+        DW = torch.zeros_like(W)
+        DB = torch.zeros_like(B)
+        return DX, DW, DB
+
+    dw_scale = 1
+    num_programs = sm_count * dw_scale
+    # Stacked buffer: rows [0:num_programs) = dW partial, rows [num_programs:2*num_programs) = dB partial.
+    # One .sum() call reduces both halves in a single CUDA kernel, saving ~5-10us over two calls.
+    # Use torch.empty (not zeros): every row is fully written by one block in the DW/DB kernel
+    # (grid=(num_programs,), block b writes rows b and num_programs+b), so no initialization needed.
+    DWDB_partial = torch.empty(2 * num_programs, n_cols, dtype=torch.float32, device=W.device)
+
+    rows_per_program = math.ceil(n_rows / num_programs)
+    dx_grid = (n_rows, 1, 1)
+    dw_grid = (num_programs, 1, 1)
+
+    # Launch DX and DW/DB kernels concurrently on two streams.
+    # Both kernels only READ X and DY (no write conflict), so parallel execution is safe.
+    # DX kernel: n_rows blocks → high concurrency, hides latency.
+    # DW/DB kernel: sm_count blocks, persistent loop → shares remaining SM capacity.
+    # Two-stream overlap gives 1.2–1.6x speedup over sequential launch.
+    main_stream = torch.cuda.current_stream()
+    device_idx = X.device.index if X.device.index is not None else 0
+    if device_idx not in _dw_stream_cache:
+        _dw_stream_cache[device_idx] = torch.cuda.Stream(device=X.device)
+    dw_stream = _dw_stream_cache[device_idx]
+
+    ct.launch(
+        main_stream,
+        dx_grid,
+        _layer_norm_bwd_dx_ct,
+        (
+            X_contig,
+            dY2d,
+            W_contig,
+            Mean,
+            RSTD,
+            DX,
+            int(n_cols),
+            int(BLOCK_SIZE),
+            bool(aligned),
+        ),
+    )
+
+    # DW/DB kernel on secondary stream — runs concurrently with DX kernel.
+    ct.launch(
+        dw_stream,
+        dw_grid,
+        _layer_norm_bwd_dw_ct,
+        (
+            X_contig,
+            dY2d,
+            Mean,
+            RSTD,
+            DWDB_partial,
+            int(n_rows),
+            int(n_cols),
+            int(num_programs),
+            int(rows_per_program),
+            int(BLOCK_SIZE),
+            bool(aligned),
+        ),
+    )
+
+    # Run partial sums on dw_stream immediately after DW/DB kernel — overlaps with DX.
+    # Single sum over stacked (2*num_programs, n_cols) → (2, n_cols); split into DW/DB.
+    with torch.cuda.stream(dw_stream):
+        DWDB = DWDB_partial.view(2, num_programs, n_cols).sum(dim=1)
+
+    # Sync dw_stream back to main stream: wait for DW/DB kernel + sums.
+    main_stream.wait_stream(dw_stream)
+
+    DX = DX.view(*shape)
+    DW = DWDB[0].to(W.dtype)
+    DB = DWDB[1].to(B.dtype)
+    return DX, DW, DB
+
+
+class LayerNormFunction(torch.autograd.Function):
+    """CuTile autograd wrapper for layer normalization."""
+
+    @staticmethod
+    def forward(ctx, X, W, B, eps):
+        X = X.contiguous()
+        W = W.contiguous()
+        B = B.contiguous()
+        Y, X_saved, Mean, RSTD, BLOCK_SIZE = _layer_norm_forward_ct(X, W, B, eps)
+        ctx.save_for_backward(X_saved, W, B, Mean, RSTD)
+        ctx.BLOCK_SIZE = BLOCK_SIZE
+        return Y
+
+    @staticmethod
+    def backward(ctx, dY):
+        X, W, B, Mean, RSTD = ctx.saved_tensors
+        dY = dY.contiguous()
+        need_dW = ctx.needs_input_grad[1]
+        need_dB = ctx.needs_input_grad[2]
+        DX, DW, DB = _layer_norm_backward_ct(
+            dY,
+            X,
+            W,
+            B,
+            Mean,
+            RSTD,
+            ctx.BLOCK_SIZE,
+            compute_dW=need_dW,
+            compute_dB=need_dB,
+        )
+        return DX, DW if need_dW else None, DB if need_dB else None, None
+
+
+@register_impl("liger.layer_norm", backend="cutile")
+def layer_norm(
+    X: torch.Tensor,
+    W: torch.Tensor,
+    B: torch.Tensor,
+    eps: float = 1e-5,
+    **kwargs,
+) -> torch.Tensor:
+    return LayerNormFunction.apply(X, W, B, eps)

--- a/src/tilegym/suites/liger/cutile/utils.py
+++ b/src/tilegym/suites/liger/cutile/utils.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+
+def next_power_of_2(n: int):
+    """Return the smallest power of 2 greater than or equal to n"""
+    n -= 1
+    n |= n >> 1
+    n |= n >> 2
+    n |= n >> 4
+    n |= n >> 8
+    n |= n >> 16
+    n |= n >> 32
+    n += 1
+    return n

--- a/src/tilegym/suites/liger/ops.py
+++ b/src/tilegym/suites/liger/ops.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+liger Suite - Unified interface for Liger-Kernel compatible operations
+"""
+
+from typing import Callable
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+import torch
+
+from tilegym.backend import dispatch
+from tilegym.backend import get_current_backend
+
+
+@dispatch(
+    "liger.jsd",
+)
+def jsd(
+    input: torch.Tensor,
+    target: torch.Tensor,
+    shift_labels: Optional[torch.Tensor] = None,
+    beta: float = 0.5,
+    ignore_index: int = -100,
+) -> torch.Tensor:
+    """
+    Generalized Jensen-Shannon Divergence loss.
+
+    JSD(β)(P || Q) = β * KL(P || M) + (1-β) * KL(Q || M), M = β*P + (1-β)*Q.
+
+    Args:
+        input: Student model log-probabilities with shape (BT, V)
+        target: Teacher model log-probabilities with shape (BT, V)
+        shift_labels: Optional token indices for per-row masking, shape (BT,)
+        beta: Interpolation coefficient in [0, 1].
+            beta=0 → forward KL, beta=1 → reverse KL, beta=0.5 → symmetric JSD.
+            Default: 0.5
+        ignore_index: Label index to ignore when shift_labels is provided. Default: -100
+
+    Returns:
+        Scalar loss tensor
+    """
+    raise NotImplementedError(f"jsd is not implemented for {get_current_backend()}")
+
+
+@dispatch(
+    "liger.fused_linear_jsd",
+)
+def fused_linear_jsd(
+    student_input: torch.Tensor,
+    student_weight: torch.Tensor,
+    teacher_input: torch.Tensor,
+    teacher_weight: torch.Tensor,
+    shift_labels: Optional[torch.Tensor] = None,
+    beta: float = 0.5,
+    ignore_index: int = -100,
+    temperature: float = 1.0,
+) -> torch.Tensor:
+    """
+    Fused linear + Jensen-Shannon Divergence loss (chunked to avoid materializing logits).
+
+    Computes JSD between student and teacher distributions without materializing the
+    full (BT, V) logit matrices.
+
+    Reference: https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/fused_linear_jsd.py
+
+    Args:
+        student_input: Student hidden states of shape (BT, H).
+        student_weight: Student vocabulary weight of shape (V, H).
+        teacher_input: Teacher hidden states of shape (BT, H).
+        teacher_weight: Teacher vocabulary weight of shape (V, H).
+        shift_labels: Optional token indices for masking, shape (BT,). Default: None
+        beta: JSD interpolation coefficient in [0, 1]. Default: 0.5
+        ignore_index: Label index to ignore. Default: -100
+        temperature: Temperature for softmax scaling. Default: 1.0
+
+    Returns:
+        Scalar loss tensor.
+    """
+    raise NotImplementedError(f"fused_linear_jsd is not implemented for {get_current_backend()}")
+
+
+@dispatch(
+    "liger.geglu",
+)
+def geglu(
+    a: torch.Tensor,
+    b: torch.Tensor,
+) -> torch.Tensor:
+    """
+    GEGLU activation: c = GELU(a) * b using tanh approximation.
+
+    Computes: c = 0.5 * a * (1 + tanh(sqrt(2/pi) * (a + 0.044715 * a^3))) * b
+
+    Reference: https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/geglu.py
+
+    Args:
+        a: Input gate tensor of shape (*, N).
+        b: Input value tensor of shape (*, N).
+
+    Returns:
+        Output tensor of same shape as a and b.
+    """
+    raise NotImplementedError(f"geglu is not implemented for {get_current_backend()}")
+
+
+@dispatch(
+    "liger.layer_norm",
+)
+def layer_norm(
+    X: torch.Tensor,
+    W: torch.Tensor,
+    B: torch.Tensor,
+    eps: float = 1e-5,
+) -> torch.Tensor:
+    """
+    Layer Normalization.
+
+    Normalizes each row of X independently, then applies affine transform Y = norm(X) * W + B.
+
+    Reference: https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/layer_norm.py
+
+    Args:
+        X: Input tensor of shape (*, H).
+        W: Affine scale weight of shape (H,).
+        B: Affine shift bias of shape (H,).
+        eps: Epsilon for numerical stability. Default: 1e-5
+
+    Returns:
+        Normalized output tensor of same shape as X.
+    """
+    raise NotImplementedError(f"layer_norm is not implemented for {get_current_backend()}")

--- a/tests/benchmark/bench_nvfp4_quantize.py
+++ b/tests/benchmark/bench_nvfp4_quantize.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import math
+import tempfile
+
+import torch
+import triton
+
+import tilegym
+import tilegym.ops
+from tilegym.backend import is_backend_available
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+FP4_MAX = 6.0
+FP8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
+
+
+def _is_tileir_v13_3_available() -> bool:
+    """Return True if the tileiras compiler supports V_13_3 bytecode (required for fp4)."""
+    try:
+        from cuda.tile._bytecode.version import BytecodeVersion
+        from cuda.tile._cext import dev_features_enabled
+        from cuda.tile._compile import _get_max_supported_bytecode_version
+
+        return (
+            dev_features_enabled()
+            and _get_max_supported_bytecode_version(tempfile.gettempdir(), allow_dev=True) >= BytecodeVersion.V_13_3
+        )
+    except Exception:
+        return False
+
+
+# No "torch" backend: there is no PyTorch equivalent for swizzled NVFP4
+# quantization. The reference backend serves as the correctness baseline instead.
+ALL_BACKENDS = [
+    ("cutile", "CuTile", ("orange", "-")) if is_backend_available("cutile") else None,
+]
+
+
+def get_supported_backends():
+    if not _is_tileir_v13_3_available():
+        return []
+    return [p for p in ALL_BACKENDS if p is not None]
+
+
+def create_benchmark_config(dtype):
+    available_backends = get_supported_backends()
+    if not available_backends:
+        return None
+
+    backends, names, styles = zip(*available_backends)
+    dtype_name = str(dtype).split(".")[-1]
+
+    return triton.testing.Benchmark(
+        x_names=["rows", "cols"],
+        x_vals=[[2048, c] for c in range(2048, 50_001, 1024)],
+        line_arg="backend",
+        line_vals=list(backends),
+        line_names=list(names),
+        styles=list(styles),
+        ylabel="GB/s",
+        plot_name=f"nvfp4-quantize-{dtype_name}-GBps",
+        args={"dtype": dtype},
+    )
+
+
+@triton.testing.perf_report([create_benchmark_config(dtype) for dtype in [torch.float32, torch.bfloat16]])
+def bench_nvfp4_quantize(rows, cols, backend, dtype, device=DEVICE):
+    x = torch.randn(rows, cols, dtype=dtype, device=device)
+    s_enc = (FP4_MAX * FP8_E4M3_MAX) / (x.abs().max().item() + 1e-12)
+
+    fn = lambda: tilegym.ops.nvfp4_quantize(x, s_enc=s_enc, backend=backend)
+
+    ms = triton.testing.do_bench(fn)
+
+    # Input read + packed output write (cols//2 bytes) + scales write (num_tiles * 512 bytes)
+    num_tiles = math.ceil(rows / 128) * math.ceil(cols / 64)
+    input_bytes = x.numel() * x.element_size()
+    packed_bytes = rows * (cols // 2)  # uint8
+    scales_bytes = num_tiles * 512  # uint8
+    total_bytes = input_bytes + packed_bytes + scales_bytes
+
+    gb_per_s = total_bytes * 1e-9 / (ms * 1e-3)
+    return gb_per_s
+
+
+if __name__ == "__main__":
+    bench_nvfp4_quantize.run(print_data=True)

--- a/tests/benchmark/bench_nvfp4_quantize.py
+++ b/tests/benchmark/bench_nvfp4_quantize.py
@@ -86,4 +86,5 @@ def bench_nvfp4_quantize(rows, cols, backend, dtype, device=DEVICE):
 
 
 if __name__ == "__main__":
-    bench_nvfp4_quantize.run(print_data=True)
+    if get_supported_backends():
+        bench_nvfp4_quantize.run(print_data=True)

--- a/tests/ops/experimental/test_nvfp4_quantize.py
+++ b/tests/ops/experimental/test_nvfp4_quantize.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import math
+import tempfile
+
+import pytest
+import torch
+
+import tilegym
+import tilegym.ops
+from tests import common
+from tilegym.backend import set_backend
+
+FP4_MAX = 6.0
+FP8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
+
+
+def _is_tileir_v13_3_available() -> bool:
+    """Return True if the tileiras compiler supports V_13_3 bytecode (required for fp4)."""
+    try:
+        from cuda.tile._bytecode.version import BytecodeVersion
+        from cuda.tile._cext import dev_features_enabled
+        from cuda.tile._compile import _get_max_supported_bytecode_version
+
+        return (
+            dev_features_enabled()
+            and _get_max_supported_bytecode_version(tempfile.gettempdir(), allow_dev=True) >= BytecodeVersion.V_13_3
+        )
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_tileir_v13_3_available(),
+    reason="Requires TileIR bytecode V_13_3+ (fp4_e2m1fn / pack_to_bytes)",
+)
+
+_backends = ["cutile"]
+
+
+class TestNVFP4Quantize(common.PyTestCase):
+    # ------------------------------------------------------------------ #
+    # Output shapes                                                        #
+    # ------------------------------------------------------------------ #
+    @pytest.mark.parametrize(
+        "rows,cols",
+        [
+            (128, 64),  # single tile, rows%128==0, cols%64==0
+            (512, 256),  # multiple tiles, rows%128==0, cols%64==0
+            (128, 80),  # partial col (80%64==16)
+            (256, 48),  # partial col (48%64!=0)
+            (64, 64),  # partial row (64%128!=0)
+            (192, 64),  # partial row (192%128==64)
+            (160, 80),  # partial row AND partial col
+            (17, 64),  # rows not divisible by 16
+            (33, 48),  # rows not divisible by 16, partial col
+            (1, 64),  # single row (extreme partial row block)
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_output_shapes(self, rows, cols, backend):
+        try:
+            set_backend(backend)
+        except Exception as e:
+            pytest.skip(f"Backend is not supported: {e}")
+        self.setUp()
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        x = torch.randn(rows, cols, dtype=torch.bfloat16, device="cuda")
+        s_enc = (FP4_MAX * FP8_E4M3_MAX) / (x.abs().max().item() + 1e-12)
+        packed, scales = tilegym.ops.nvfp4_quantize(x, s_enc=s_enc)
+        num_n_blocks = math.ceil(cols / 64)
+        num_m_blocks = math.ceil(rows / 128)
+        num_tiles = num_m_blocks * num_n_blocks
+        assert packed.shape == (rows, cols // 2), f"packed shape: {packed.shape}"
+        assert scales.shape == (num_tiles * 512,), f"scales shape: {scales.shape}"
+        assert packed.dtype == torch.uint8
+        assert scales.dtype == torch.uint8
+
+    # ------------------------------------------------------------------ #
+    # Input dtypes (smoke test)                                            #
+    # ------------------------------------------------------------------ #
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_input_dtypes(self, dtype, backend):
+        try:
+            set_backend(backend)
+        except Exception as e:
+            pytest.skip(f"Backend is not supported: {e}")
+        self.setUp()
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+        x = torch.randn(128, 64, dtype=dtype, device="cuda")
+        s_enc = (FP4_MAX * FP8_E4M3_MAX) / (x.abs().max().item() + 1e-12)
+        packed, scales = tilegym.ops.nvfp4_quantize(x, s_enc=s_enc)
+        assert packed.shape == (128, 32)
+        assert scales.shape == (512,)
+
+    # ------------------------------------------------------------------ #
+    # Input validation                                                     #
+    # ------------------------------------------------------------------ #
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_invalid_inputs(self, backend):
+        try:
+            set_backend(backend)
+        except Exception as e:
+            pytest.skip(f"Backend is not supported: {e}")
+        self.setUp()
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        with pytest.raises(ValueError):
+            tilegym.ops.nvfp4_quantize(torch.randn(4, 128, 64, dtype=torch.bfloat16, device="cuda"))
+        with pytest.raises(ValueError):
+            tilegym.ops.nvfp4_quantize(torch.randint(0, 127, (128, 64), dtype=torch.int8, device="cuda"))
+        with pytest.raises(ValueError):
+            tilegym.ops.nvfp4_quantize(torch.randn(128, 63, dtype=torch.bfloat16, device="cuda"))

--- a/tests/suites/liger/__init__.py
+++ b/tests/suites/liger/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT

--- a/tests/suites/liger/test_fused_linear_jsd.py
+++ b/tests/suites/liger/test_fused_linear_jsd.py
@@ -1,0 +1,293 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import gc
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import fused_linear_jsd
+
+
+class Test_Liger_FusedLinearJSD(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @staticmethod
+    def reference_jsd(student_logits, teacher_logits, shift_labels=None, beta=0.5, ignore_index=-100, temperature=1.0):
+        """PyTorch float32 reference for JSD.
+
+        beta=0 → forward KL: KL(teacher || student)
+        beta=1 → reverse KL: KL(student || teacher)
+        else   → generalized JSD(beta)
+        Matches the jsd kernel's special-casing for boundary betas.
+        """
+        student_logits = student_logits.float() / temperature
+        teacher_logits = teacher_logits.float() / temperature
+
+        student_log_prob = F.log_softmax(student_logits, dim=-1)
+        teacher_log_prob = F.log_softmax(teacher_logits, dim=-1)
+        student_prob = torch.exp(student_log_prob)
+        teacher_prob = torch.exp(teacher_log_prob)
+
+        if beta == 0.0:  # forward KL: KL(teacher || student)
+            loss = teacher_prob * (teacher_log_prob - student_log_prob)
+        elif beta == 1.0:  # reverse KL: KL(student || teacher)
+            loss = student_prob * (student_log_prob - teacher_log_prob)
+        else:
+            M = beta * teacher_prob + (1 - beta) * student_prob
+            log_M = torch.log(M.clamp(min=1e-40))
+            loss = beta * teacher_prob * (teacher_log_prob - log_M) + (1 - beta) * student_prob * (
+                student_log_prob - log_M
+            )  # (BT, V)
+
+        if shift_labels is not None:
+            mask = (shift_labels != ignore_index).float().unsqueeze(-1)  # (BT, 1)
+            loss = loss * mask
+            n_non_ignore = (shift_labels != ignore_index).sum().clamp(min=1)
+            return loss.sum() / n_non_ignore
+        else:
+            return loss.sum() / student_logits.shape[0]
+
+    @pytest.mark.parametrize(
+        "BT, H, V, dtype",
+        [
+            (4, 64, 128, torch.float32),
+            (8, 128, 256, torch.float32),
+            (4, 64, 128, torch.float16),
+            (4, 64, 128, torch.bfloat16),
+            # Shapes from Liger test/transformers/test_fused_linear_jsd.py
+            (63, 41, 41, torch.float32),
+            (188, 31, 123, torch.float32),
+            # Corner cases
+            (1, 64, 128, torch.float32),  # single-token batch (normalization edge)
+            (4, 64, 32768, torch.float32),  # large V aligned (power-of-2 path)
+            (3, 7, 11, torch.float32),  # all-prime tiny dims (non-aligned worst case)
+        ],
+    )
+    @pytest.mark.parametrize("beta", [0.5, 0.1])
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_forward(self, BT, H, V, dtype, beta, backend, monkeypatch):
+        """Test forward loss matches reference JSD."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        student_input = torch.randn(BT, H, dtype=dtype, device=device)
+        student_weight = torch.randn(V, H, dtype=dtype, device=device)
+        teacher_input = torch.randn(BT, H, dtype=dtype, device=device)
+        teacher_weight = torch.randn(V, H, dtype=dtype, device=device)
+
+        atol = 3e-2 if dtype != torch.float32 else 1e-2
+        rtol = 3e-2 if dtype != torch.float32 else 1e-2
+
+        loss_test = fused_linear_jsd(
+            student_input.clone(),
+            student_weight,
+            teacher_input.clone(),
+            teacher_weight,
+            beta=beta,
+        )
+
+        # Reference: compute full logits first
+        with torch.no_grad():
+            student_logits_ref = student_input.float() @ student_weight.float().t()
+            teacher_logits_ref = teacher_input.float() @ teacher_weight.float().t()
+        loss_ref = self.reference_jsd(student_logits_ref, teacher_logits_ref, beta=beta)
+
+        assert torch.allclose(loss_test.float(), loss_ref.float(), atol=atol, rtol=rtol), (
+            f"JSD loss mismatch: test={loss_test.item():.6f}, ref={loss_ref.item():.6f}, "
+            f"diff={abs(loss_test.item() - loss_ref.item()):.6f}"
+        )
+
+    @pytest.mark.parametrize(
+        "BT, H, V, dtype",
+        [
+            (4, 64, 128, torch.float32),
+            (8, 128, 256, torch.float32),
+            (63, 41, 41, torch.float32),
+            (188, 31, 123, torch.float32),
+            # Corner cases
+            (1, 64, 128, torch.float32),  # single-token batch
+            (4, 64, 128, torch.float16),  # half precision backward
+            (4, 64, 128, torch.bfloat16),  # bfloat16 backward
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_backward(self, BT, H, V, dtype, backend, monkeypatch):
+        """Test backward gradient w.r.t. student_input."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        student_input_data = torch.randn(BT, H, dtype=dtype, device=device)
+        student_weight = torch.randn(V, H, dtype=dtype, device=device)
+        teacher_input = torch.randn(BT, H, dtype=dtype, device=device)
+        teacher_weight = torch.randn(V, H, dtype=dtype, device=device)
+
+        atol = 1e-1
+        rtol = 1e-1
+
+        # Test implementation
+        s_input_test = student_input_data.clone().requires_grad_(True)
+        loss_test = fused_linear_jsd(s_input_test, student_weight, teacher_input, teacher_weight)
+        loss_test.backward()
+
+        # Reference (float32)
+        s_input_ref = student_input_data.clone().float().requires_grad_(True)
+        s_logits = s_input_ref @ student_weight.float().t()
+        t_logits = (teacher_input.float() @ teacher_weight.float().t()).detach()
+        loss_ref = self.reference_jsd(s_logits, t_logits)
+        loss_ref.backward()
+
+        assert torch.allclose(s_input_test.grad.float(), s_input_ref.grad.float(), atol=atol, rtol=rtol), (
+            f"dInput mismatch: max_diff="
+            f"{((s_input_test.grad.float() - s_input_ref.grad.float()).abs().max()).item():.6f}"
+        )
+
+    @pytest.mark.parametrize(
+        "BT, H, V, dtype",
+        [
+            (4, 64, 128, torch.float32),
+            (8, 128, 256, torch.float32),  # larger shape
+            (16, 64, 128, torch.float32),  # more tokens to ignore
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_with_labels(self, BT, H, V, dtype, backend, monkeypatch):
+        """Test with shift_labels (some tokens ignored)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        student_input = torch.randn(BT, H, dtype=dtype, device=device)
+        student_weight = torch.randn(V, H, dtype=dtype, device=device)
+        teacher_input = torch.randn(BT, H, dtype=dtype, device=device)
+        teacher_weight = torch.randn(V, H, dtype=dtype, device=device)
+        shift_labels = torch.randint(0, V, (BT,), device=device)
+        shift_labels[: BT // 4] = -100
+
+        loss_test = fused_linear_jsd(
+            student_input.clone(),
+            student_weight,
+            teacher_input.clone(),
+            teacher_weight,
+            shift_labels=shift_labels,
+        )
+
+        with torch.no_grad():
+            student_logits_ref = student_input.float() @ student_weight.float().t()
+            teacher_logits_ref = teacher_input.float() @ teacher_weight.float().t()
+        loss_ref = self.reference_jsd(student_logits_ref, teacher_logits_ref, shift_labels=shift_labels)
+
+        assert torch.allclose(loss_test.float(), loss_ref.float(), atol=1e-2, rtol=1e-2), (
+            f"JSD with labels mismatch: test={loss_test.item():.6f}, ref={loss_ref.item():.6f}"
+        )
+
+    @pytest.mark.parametrize(
+        "BT, H, V, dtype",
+        [
+            (1024, 1024, 4096, torch.bfloat16),  # (B=8, T=128) from Liger chunked_loss test
+            (1024, 1024, 4096, torch.float32),
+            (141, 31, 123, torch.bfloat16),  # (B=3, T=47) random shape from Liger chunked_loss test
+            (141, 31, 123, torch.float32),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "temperature, beta",
+        [
+            (1.0, 0.5),
+            (2.0, 0.8),
+            (0.5, 0.2),
+        ],
+    )
+    @pytest.mark.parametrize("ignore_index", [-100, 42])
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_liger_shapes(self, BT, H, V, dtype, temperature, beta, ignore_index, backend, monkeypatch):
+        """Liger chunked_loss shapes: student H//2, teacher H (different hidden dims).
+
+        Mirrors upstream test/chunked_loss/test_jsd_loss.py: TorchLMHeadJSD uses
+        H//2 for student and H for teacher.  Checks loss + dInput + dWeight.
+        """
+        self.setUp()
+        if not tilegym.is_backend_available(backend):
+            pytest.skip(f"Backend {backend} is not available")
+        tilegym.set_backend(backend)
+
+        atol = 5e-2 if dtype != torch.float32 else 1e-5
+        rtol = 5e-1 if dtype != torch.float32 else 5e-4
+
+        torch.manual_seed(42)
+        device = torch.device("cuda")
+        Hs = H // 2  # student hidden size (mirrors Liger upstream)
+
+        # Scale weights with kaiming-like init (std = 1/sqrt(fan_in)) so logit std ≈ 1,
+        # avoiding float32 underflow that causes M → 0 → log(M) = -inf → NaN in JSD.
+        student_weight = torch.randn(V, Hs, dtype=dtype, device=device) / math.sqrt(Hs)
+        teacher_weight = torch.randn(V, H, dtype=dtype, device=device) / math.sqrt(H)
+
+        _tensor = torch.randn(BT, Hs, device=device, dtype=dtype)
+        teacher_input = torch.randn(BT, H, device=device, dtype=dtype)
+
+        target = torch.randint(0, V, (BT,), device=device, dtype=torch.long)
+        num_ignore = torch.randint(1, max(2, BT // 2), (1,)).item()
+        target[torch.randperm(BT)[:num_ignore]] = ignore_index
+
+        # Reference: full matmul → float32 logits → reference_jsd (mirrors TorchLMHeadJSD)
+        student_input_ref = _tensor.detach().clone().requires_grad_(True)
+        student_weight_ref = student_weight.detach().clone().requires_grad_(True)
+        s_logits_ref = (student_input_ref.float() @ student_weight_ref.float().t()) / temperature
+        t_logits_ref = (teacher_input.float() @ teacher_weight.float().t()).detach() / temperature
+        loss_ref = self.reference_jsd(
+            s_logits_ref,
+            t_logits_ref,
+            shift_labels=target,
+            beta=beta,
+            ignore_index=ignore_index,
+            temperature=1.0,  # pre-divided above
+        )
+        loss_ref.backward()
+
+        # TileGym fused kernel
+        student_input_tg = _tensor.detach().clone().requires_grad_(True)
+        student_weight_tg = student_weight.detach().clone().requires_grad_(True)
+        loss_tg = fused_linear_jsd(
+            student_input_tg,
+            student_weight_tg,
+            teacher_input,
+            teacher_weight,
+            shift_labels=target,
+            beta=beta,
+            ignore_index=ignore_index,
+            temperature=temperature,
+        )
+        loss_tg.backward()
+
+        assert torch.allclose(loss_ref.float(), loss_tg.float(), atol=atol, rtol=rtol), (
+            f"[{dtype} T={temperature} β={beta} ig={ignore_index}] Loss mismatch: "
+            f"ref={loss_ref.item():.6f}, tg={loss_tg.item():.6f}, "
+            f"diff={abs(loss_ref.item() - loss_tg.item()):.6f}"
+        )
+
+        assert torch.allclose(student_input_ref.grad.float(), student_input_tg.grad.float(), atol=atol, rtol=rtol), (
+            f"[{dtype} T={temperature} β={beta}] dInput mismatch: max_diff="
+            f"{(student_input_ref.grad.float() - student_input_tg.grad.float()).abs().max().item():.6f}"
+        )
+
+        assert torch.allclose(student_weight_ref.grad.float(), student_weight_tg.grad.float(), atol=atol, rtol=rtol), (
+            f"[{dtype} T={temperature} β={beta}] dWeight mismatch: max_diff="
+            f"{(student_weight_ref.grad.float() - student_weight_tg.grad.float()).abs().max().item():.6f}"
+        )

--- a/tests/suites/liger/test_geglu.py
+++ b/tests/suites/liger/test_geglu.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import gc
+
+import pytest
+import torch
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import geglu
+
+
+class Test_Liger_GEGLU(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @staticmethod
+    def reference(a, b):
+        """PyTorch float32 reference for GEGLU (tanh approximation)."""
+        a_f32 = a.float()
+        b_f32 = b.float()
+        sqrt_2_over_pi = 0.7978845608028654
+        a_cubed = a_f32 * a_f32 * a_f32
+        tanh_arg = sqrt_2_over_pi * (a_f32 + 0.044715 * a_cubed)
+        geglu_a = 0.5 * a_f32 * (1 + torch.tanh(tanh_arg))
+        return (geglu_a * b_f32).to(a.dtype)
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((8, 512), torch.float32),
+            ((16, 1024), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+            ((2, 4, 512), torch.float32),  # multi-dimensional
+            ((4, 300), torch.float32),  # non-power-of-2
+            # Shapes from Liger test/transformers/test_geglu.py
+            ((2, 2, 8), torch.float32),
+            ((9, 7, 41), torch.float32),
+            ((9, 41, 341), torch.float32),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_forward(self, shape, dtype, backend, monkeypatch):
+        """Test forward output matches PyTorch reference."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        a = torch.randn(*shape, dtype=dtype, device=device)
+        b = torch.randn(*shape, dtype=dtype, device=device)
+
+        atol = 1e-2 if dtype != torch.float32 else 5e-3
+        rtol = 1e-2 if dtype != torch.float32 else 5e-3
+
+        c_test = geglu(a.clone(), b.clone())
+        c_ref = self.reference(a, b)
+
+        assert torch.allclose(c_test.float(), c_ref.float(), atol=atol, rtol=rtol), (
+            f"Forward mismatch: max_diff={((c_test.float() - c_ref.float()).abs().max()).item():.6f}"
+        )
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((8, 512), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+            ((9, 7, 41), torch.float32),
+            ((9, 41, 341), torch.float32),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_backward(self, shape, dtype, backend, monkeypatch):
+        """Test backward gradients (da, db) match PyTorch reference."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        a_data = torch.randn(*shape, dtype=dtype, device=device)
+        b_data = torch.randn(*shape, dtype=dtype, device=device)
+
+        atol = 1e-1
+        rtol = 1e-1
+
+        # Test implementation
+        a_test = a_data.clone().requires_grad_(True)
+        b_test = b_data.clone().requires_grad_(True)
+        c_test = geglu(a_test, b_test)
+        c_test.backward(torch.ones_like(c_test))
+
+        # Reference (float32)
+        a_ref = a_data.clone().float().requires_grad_(True)
+        b_ref = b_data.clone().float().requires_grad_(True)
+        c_ref = self.reference(a_ref, b_ref.to(a_ref.dtype))
+        c_ref.backward(torch.ones_like(c_ref))
+
+        assert torch.allclose(a_test.grad.float(), a_ref.grad.float(), atol=atol, rtol=rtol), (
+            f"da mismatch: max_diff={((a_test.grad.float() - a_ref.grad.float()).abs().max()).item():.6f}"
+        )
+        assert torch.allclose(b_test.grad.float(), b_ref.grad.float(), atol=atol, rtol=rtol), (
+            f"db mismatch: max_diff={((b_test.grad.float() - b_ref.grad.float()).abs().max()).item():.6f}"
+        )

--- a/tests/suites/liger/test_jsd.py
+++ b/tests/suites/liger/test_jsd.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import pytest
+import torch
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import jsd
+
+
+class Test_Liger_JSD(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @staticmethod
+    def reference(input, target, shift_labels=None, beta=0.5, ignore_index=-100):
+        """
+        PyTorch reference implementation of generalized JSD loss.
+
+        JSD(β)(P || Q) = β * KL(P || M) + (1-β) * KL(Q || M), M = β*P + (1-β)*Q
+        where Q = exp(input), P = exp(target).
+        """
+        Q = torch.exp(input.float())
+        P = torch.exp(target.float())
+
+        if beta == 0.0:  # forward KL: KL(P || Q)
+            loss = P * (target.float() - input.float())
+        elif beta == 1.0:  # reverse KL: KL(Q || P)
+            loss = Q * (input.float() - target.float())
+        else:
+            M = beta * P + (1 - beta) * Q
+            log_M = torch.log(M)
+            loss = beta * P * target.float() + (1 - beta) * Q * input.float() - M * log_M
+
+        if shift_labels is not None:
+            mask = (shift_labels != ignore_index).float()
+            n_non_ignore = mask.sum()
+            loss = loss * mask.unsqueeze(-1)
+        else:
+            n_non_ignore = input.shape[0]
+
+        if n_non_ignore == 0:
+            return torch.tensor(0.0, device=input.device, dtype=input.dtype)
+
+        return (loss.sum() / n_non_ignore).to(input.dtype)
+
+    @pytest.mark.parametrize(
+        "BT, V, beta, dtype",
+        [
+            (4, 256, 0.5, torch.float32),
+            (8, 512, 0.5, torch.float32),
+            (16, 1024, 0.5, torch.float32),
+            (4, 256, 0.0, torch.float32),
+            (4, 256, 1.0, torch.float32),
+            (8, 512, 0.3, torch.float32),
+            (4, 256, 0.5, torch.float16),
+            (4, 256, 0.5, torch.bfloat16),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op(self, BT, V, beta, dtype, backend, monkeypatch):
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        input_logits = torch.randn(BT, V, device=device, dtype=dtype, requires_grad=True)
+        target_logits = torch.randn(BT, V, device=device, dtype=dtype, requires_grad=False)
+        input_log_prob = torch.nn.functional.log_softmax(input_logits, dim=-1).detach().requires_grad_(True)
+        target_log_prob = torch.nn.functional.log_softmax(target_logits, dim=-1)
+
+        dout = torch.tensor(1.0, device=device, dtype=dtype)
+
+        self.assertCorrectness(
+            jsd,
+            self.reference,
+            {
+                "input": input_log_prob,
+                "target": target_log_prob,
+                "beta": beta,
+            },
+            gradient=dout,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+    @pytest.mark.parametrize(
+        "BT, V, beta, dtype",
+        [
+            (8, 512, 0.5, torch.float32),
+            (16, 1024, 0.5, torch.float32),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_with_labels(self, BT, V, beta, dtype, backend, monkeypatch):
+        """Test JSD with shift_labels (masking ignored tokens)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        input_log_prob = (
+            torch.nn.functional.log_softmax(torch.randn(BT, V, device=device, dtype=dtype), dim=-1)
+            .detach()
+            .requires_grad_(True)
+        )
+        target_log_prob = torch.nn.functional.log_softmax(torch.randn(BT, V, device=device, dtype=dtype), dim=-1)
+        # Set half the labels to ignore_index=-100
+        shift_labels = torch.randint(0, V, (BT,), device=device)
+        shift_labels[: BT // 2] = -100
+
+        dout = torch.tensor(1.0, device=device, dtype=dtype)
+
+        self.assertCorrectness(
+            jsd,
+            self.reference,
+            {
+                "input": input_log_prob,
+                "target": target_log_prob,
+                "shift_labels": shift_labels,
+                "beta": beta,
+            },
+            gradient=dout,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+    @pytest.mark.parametrize(
+        "BT, V, beta, dtype",
+        [
+            (2048, 3200, 0.5, torch.float32),
+            (2048, 3200, 0.5, torch.bfloat16),
+            (16441, 1271, 0.5, torch.float32),
+            (8, 512, 0.5, torch.float16),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_not_last_layer(self, BT, V, beta, dtype, backend, monkeypatch):
+        """JSD gradients are correct when loss is not the final layer (non-unit upstream grad)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        input_log_prob = (
+            torch.nn.functional.log_softmax(torch.randn(BT, V, device=device, dtype=dtype), dim=-1)
+            .detach()
+            .requires_grad_(True)
+        )
+        target_log_prob = torch.nn.functional.log_softmax(torch.randn(BT, V, device=device, dtype=dtype), dim=-1)
+
+        # Simulate a scaling factor of 2.0 upstream (output * 2.0 before backward)
+        dout = torch.tensor(2.0, device=device, dtype=dtype)
+
+        self.assertCorrectness(
+            jsd,
+            self.reference,
+            {
+                "input": input_log_prob,
+                "target": target_log_prob,
+                "beta": beta,
+            },
+            gradient=dout,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+    @pytest.mark.parametrize(
+        "BT, V, dtype",
+        [
+            (2048, 3200, torch.float32),
+            (2048, 3200, torch.bfloat16),
+            (16441, 1271, torch.float32),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_symmetry(self, BT, V, dtype, backend, monkeypatch):
+        """JSD is symmetric at beta=0.5: jsd(P, Q) == jsd(Q, P)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        input_log_prob = torch.nn.functional.log_softmax(
+            torch.randn(BT, V, device=device, dtype=dtype), dim=-1
+        ).detach()
+        target_log_prob = torch.nn.functional.log_softmax(
+            torch.randn(BT, V, device=device, dtype=dtype), dim=-1
+        ).detach()
+
+        out1 = jsd(input_log_prob, target_log_prob, beta=0.5)
+        out2 = jsd(target_log_prob, input_log_prob, beta=0.5)
+
+        torch.testing.assert_close(out1, out2, atol=1e-2, rtol=1e-2)
+
+    @pytest.mark.parametrize(
+        "BT, V, beta, ignore_index, dtype",
+        [
+            (8, 512, 0.5, 2, torch.float32),
+            (8, 512, 0.5, 42, torch.float32),
+            (16, 1024, 0.3, 2, torch.bfloat16),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_nondefault_ignore_index(self, BT, V, beta, ignore_index, dtype, backend, monkeypatch):
+        """JSD with non-default ignore_index values (2, 42) in shift_labels."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        input_log_prob = (
+            torch.nn.functional.log_softmax(torch.randn(BT, V, device=device, dtype=dtype), dim=-1)
+            .detach()
+            .requires_grad_(True)
+        )
+        target_log_prob = torch.nn.functional.log_softmax(torch.randn(BT, V, device=device, dtype=dtype), dim=-1)
+        shift_labels = torch.randint(0, V, (BT,), device=device)
+        # Randomly assign ~half to ignore_index
+        num_ignore = max(1, BT // 2)
+        shift_labels[torch.randperm(BT)[:num_ignore]] = ignore_index
+
+        dout = torch.tensor(1.0, device=device, dtype=dtype)
+
+        self.assertCorrectness(
+            jsd,
+            self.reference,
+            {
+                "input": input_log_prob,
+                "target": target_log_prob,
+                "shift_labels": shift_labels,
+                "beta": beta,
+                "ignore_index": ignore_index,
+            },
+            gradient=dout,
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+    @pytest.mark.parametrize(
+        "BT, V, dtype",
+        [
+            (20, 32, torch.float32),
+            (20, 32, torch.bfloat16),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_all_ignored(self, BT, V, dtype, backend, monkeypatch):
+        """JSD returns 0 and has zero gradient when all tokens are masked by ignore_index."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        ignore_index = -100
+        input_log_prob = (
+            torch.nn.functional.log_softmax(torch.randn(BT, V, device=device, dtype=dtype), dim=-1)
+            .detach()
+            .requires_grad_(True)
+        )
+        target_log_prob = torch.nn.functional.log_softmax(torch.randn(BT, V, device=device, dtype=dtype), dim=-1)
+        shift_labels = torch.full((BT,), ignore_index, device=device, dtype=torch.long)
+
+        out = jsd(input_log_prob, target_log_prob, shift_labels=shift_labels, beta=0.5)
+
+        torch.testing.assert_close(out, torch.zeros_like(out), atol=1e-6, rtol=0.0)
+
+        out.backward(torch.tensor(1.0, device=device, dtype=dtype))
+        torch.testing.assert_close(input_log_prob.grad, torch.zeros_like(input_log_prob.grad), atol=1e-6, rtol=0.0)

--- a/tests/suites/liger/test_layer_norm.py
+++ b/tests/suites/liger/test_layer_norm.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import gc
+
+import pytest
+import torch
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import layer_norm
+
+
+class Test_Liger_LayerNorm(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @staticmethod
+    def reference(X, W, B, eps=1e-5):
+        """PyTorch float32 reference for layer normalization."""
+        return torch.nn.functional.layer_norm(X.float(), [X.shape[-1]], W.float(), B.float(), eps).to(X.dtype)
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((8, 512), torch.float32),
+            ((16, 1024), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+            ((2, 4, 512), torch.float32),  # multi-dimensional
+            ((4, 300), torch.float32),  # non-power-of-2 hidden dim
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op(self, shape, dtype, backend, monkeypatch):
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        H = shape[-1]
+
+        X = torch.randn(*shape, dtype=dtype, device=device)
+        W = torch.ones(H, dtype=dtype, device=device)
+        B = torch.zeros(H, dtype=dtype, device=device)
+
+        self.assertCorrectness(
+            layer_norm,
+            self.reference,
+            {"X": X, "W": W, "B": B},
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((8, 512), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+            ((16, 1024), torch.float32),
+            ((2, 4, 512), torch.float32),
+            ((4, 300), torch.float32),  # non-power-of-2
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_backward(self, shape, dtype, backend, monkeypatch):
+        """Test backward pass (gradients for X, W, B)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        H = shape[-1]
+
+        X = torch.randn(*shape, dtype=dtype, device=device, requires_grad=True)
+        W = torch.ones(H, dtype=dtype, device=device, requires_grad=True)
+        B = torch.zeros(H, dtype=dtype, device=device, requires_grad=True)
+
+        dout = torch.ones(*shape, dtype=dtype, device=device)
+
+        self.assertCorrectness(
+            layer_norm,
+            self.reference,
+            {"X": X, "W": W, "B": B},
+            gradient=dout,
+            atol=1e-2,
+            rtol=1e-1,
+        )


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->

Update codes.

This PR contains **4** new commit(s).

### Commits included:

```
2021bca feat(ops/nvfp4): add nvfp4_quantize operator
666dbae Add liger kernels
f5d7aa6 Update improve-cutile-kernel-perf skill
ead58ec bench(nvfp4): skip benchmark when TileIR FP4 support is unavailable
```

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: ["ops", "benchmark"]
```

## Checklist
- [ ] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

