### PR TITLE
skills: Skip non-SKILL.md skill docs in SPDX header check

### DIFF
--- a/.github/scripts/check_spdx_headers.py
+++ b/.github/scripts/check_spdx_headers.py
@@ -314,12 +314,22 @@ def _has_yaml_frontmatter(path: Path) -> bool:
 
 
 def iter_skill_content_files(root_dir: Path) -> Iterator[Path]:
-    """Yield .py and non-frontmatter .md files under .agents/skills/ for SPDX headers.
+    """Yield .py and ``SKILL.md`` files under .agents/skills/ for SPDX headers.
 
-    Files with YAML frontmatter (.md starting with ``---``) are handled by
+    .md files with YAML frontmatter (starting with ``---``) are handled by
     :func:`iter_skill_files` using the frontmatter ``license:`` approach.
-    Everything else that has a recognised comment style gets a standard SPDX
-    comment header (currently dual-licensed CC-BY-4.0 AND Apache-2.0).
+
+    Non-frontmatter, non-``SKILL.md`` markdown files (reference docs,
+    translations, examples, etc.) are intentionally **skipped**: the
+    ``<!--- SPDX-... --->`` comment that the writer would otherwise inject at
+    the top of the file interferes with how skill-loading tools parse those
+    documents. Their license is covered transitively by the parent skill's
+    ``SKILL.md`` (which still carries an SPDX expression) and by the
+    repository-level ``LICENSE`` / ``LICENSES/`` files.
+
+    The ``SKILL.md`` exemption preserves SPDX comment headers on any
+    ``SKILL.md`` that has not yet been migrated to YAML frontmatter, so the
+    skill itself always advertises its license one way or another.
     """
     skills_dir = root_dir / ".agents" / "skills"
     if not skills_dir.is_dir():
@@ -330,9 +340,14 @@ def iter_skill_content_files(root_dir: Path) -> Iterator[Path]:
             # Must have a known comment style
             if get_comment_style(path) is None:
                 continue
-            # .md files with frontmatter are handled by iter_skill_files
-            if path.suffix == ".md" and _has_yaml_frontmatter(path):
-                continue
+            if path.suffix == ".md":
+                # Frontmatter .md files are handled by iter_skill_files.
+                if _has_yaml_frontmatter(path):
+                    continue
+                # Non-frontmatter, non-SKILL.md markdown files are skipped
+                # so they do not get an HTML-comment SPDX header injected.
+                if path.name != "SKILL.md":
+                    continue
             yield path
 
 


### PR DESCRIPTION
## Summary

Update `.github/scripts/check_spdx_headers.py::iter_skill_content_files` to **skip non-frontmatter, non-`SKILL.md` markdown files** under `.agents/skills/`. The `<!--- SPDX-... --->` headers that the SPDX writer would otherwise inject at the top of those reference / translation / example files interfere with how skill-loading tools (Claude Code, Cursor, etc.) parse the body.

This PR only updates the *script*. The actual stripping of headers from existing `.md` files is done in the upstream Ocean repo (<https://gitlab-master.nvidia.com/dl/oai_triton/ocean/-/merge_requests/1518|ocean!1518>) and will land here through the next sync.

## What still carries an SPDX assertion

- All `SKILL.md` files (and frontmatter sub-skill `.md` files) — still carry `license: CC-BY-4.0 AND Apache-2.0` in YAML frontmatter.
- All `.py` files under `.agents/skills/` — still get `# SPDX-...` comment headers.
- Repo-level `LICENSE` and `LICENSES/` files — unchanged, continue to authoritatively cover everything in the tree.

## Test plan

- [x] `python3 .github/scripts/check_spdx_headers.py --action check --root .` -> All files have SPDX headers
- [x] `python3 .github/scripts/check_spdx_headers.py --action write --root .` -> 0 modified once Ocean!1518 lands here
- [x] `python3 .github/infra_tests/test_check_spdx_headers.py` -> All tests passed
- [ ] CI passes on this PR

## CI Configuration

```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: []
```