### PR TITLE
[tests] test_gemma_attention: guard set_backend in test_op with try/skip & other updates

### DIFF
--- a/src/tilegym/ops/cutile/activation/geglu.py
+++ b/src/tilegym/ops/cutile/activation/geglu.py
@@ -16,8 +16,6 @@ from .gelu import standard_normal_cdf_ct
 from .gelu import standard_normal_pdf_ct
 
 # Approximation mode constants
-
-
 GELU_EXACT = 0
 GELU_TANH = 1
 

--- a/src/tilegym/ops/cutile/activation/geglu.py
+++ b/src/tilegym/ops/cutile/activation/geglu.py
@@ -16,6 +16,8 @@ from .gelu import standard_normal_cdf_ct
 from .gelu import standard_normal_pdf_ct
 
 # Approximation mode constants
+
+
 GELU_EXACT = 0
 GELU_TANH = 1
 

--- a/src/tilegym/ops/cutile/activation/gelu.py
+++ b/src/tilegym/ops/cutile/activation/gelu.py
@@ -10,8 +10,6 @@ import torch
 from tilegym.backend import register_impl
 
 # Approximation mode constants
-
-
 GELU_EXACT = 0
 GELU_TANH = 1
 
@@ -135,8 +133,6 @@ def _gelu_kernel(
 
 
 # Wrapper class for autograd integration
-
-
 class _GeluCuTileFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x, approximate):

--- a/src/tilegym/ops/cutile/activation/gelu.py
+++ b/src/tilegym/ops/cutile/activation/gelu.py
@@ -10,6 +10,8 @@ import torch
 from tilegym.backend import register_impl
 
 # Approximation mode constants
+
+
 GELU_EXACT = 0
 GELU_TANH = 1
 
@@ -133,6 +135,8 @@ def _gelu_kernel(
 
 
 # Wrapper class for autograd integration
+
+
 class _GeluCuTileFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x, approximate):

--- a/src/tilegym/ops/cutile/activation/relu.py
+++ b/src/tilegym/ops/cutile/activation/relu.py
@@ -30,8 +30,6 @@ def _relu_fwd_kernel(x, y, N_ELEMENTS: ct.Constant[int], BLOCK_SIZE: ct.Constant
 
 
 # Wrapper Classes
-
-
 class _ReluCuTileFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x):

--- a/src/tilegym/ops/cutile/activation/relu.py
+++ b/src/tilegym/ops/cutile/activation/relu.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: MIT
-
 import cuda.tile as ct
 import torch
 
 from tilegym.backend import register_impl
+
+# ReLU
 
 
 @ct.kernel
@@ -26,6 +27,9 @@ def _relu_fwd_kernel(x, y, N_ELEMENTS: ct.Constant[int], BLOCK_SIZE: ct.Constant
     y_f32 = ct.maximum(x_f32, zeros)
     y_tile = ct.astype(y_f32, x_tile.dtype)
     ct.scatter(y, offsets, y_tile)
+
+
+# Wrapper Classes
 
 
 class _ReluCuTileFunction(torch.autograd.Function):
@@ -55,6 +59,9 @@ class _ReluCuTileFunction(torch.autograd.Function):
     @staticmethod
     def backward(ctx, dy):
         raise NotImplementedError("Backward pass for ReLU activation is not implemented")
+
+
+# Public API Functions
 
 
 @register_impl("relu", backend="cutile")

--- a/src/tilegym/ops/cutile/attention.py
+++ b/src/tilegym/ops/cutile/attention.py
@@ -19,8 +19,6 @@ from .utils import cached_replace_hints
 from .utils import next_power_of_2
 
 # Module-level tune caches for fmha forward, dkdv backward, and dq backward
-
-
 _fmha_fwd_tune_cache: dict = {}
 _fmha_bwd_dkdv_tune_cache: dict = {}
 _fmha_bwd_dq_tune_cache: dict = {}
@@ -38,8 +36,6 @@ ConstBool = ct.Constant[bool]
 # @ct.kernel() entry point so it can be reused by different kernels
 # (e.g. standalone prefill attention and fused POD attention) without
 # duplicating the attention computation code.
-
-
 def fmha_kernel_impl(
     Q,
     K,

--- a/src/tilegym/ops/cutile/attention.py
+++ b/src/tilegym/ops/cutile/attention.py
@@ -19,6 +19,8 @@ from .utils import cached_replace_hints
 from .utils import next_power_of_2
 
 # Module-level tune caches for fmha forward, dkdv backward, and dq backward
+
+
 _fmha_fwd_tune_cache: dict = {}
 _fmha_bwd_dkdv_tune_cache: dict = {}
 _fmha_bwd_dq_tune_cache: dict = {}
@@ -28,7 +30,6 @@ logger = get_logger(__name__)
 INV_LOG_2 = 1.0 / math.log(2)
 LN2 = math.log(2)
 
-# Define type aliases for Constant integers and booleans
 ConstInt = ct.Constant[int]
 ConstBool = ct.Constant[bool]
 
@@ -37,6 +38,8 @@ ConstBool = ct.Constant[bool]
 # @ct.kernel() entry point so it can be reused by different kernels
 # (e.g. standalone prefill attention and fused POD attention) without
 # duplicating the attention computation code.
+
+
 def fmha_kernel_impl(
     Q,
     K,
@@ -159,6 +162,89 @@ def fmha_kernel_impl(
     acc = ct.truediv(acc, l_i, flush_to_zero=True, rounding_mode=RMd.APPROX)
     acc = acc.reshape((1, 1, TILE_M, TILE_D)).astype(Out.dtype)
     ct.store(Out, index=(batch_idx, head_idx, bid_x, 0), tile=acc)
+
+
+_FMHA_BWD_DKDV_TILE_CONFIGS_BY_D = {
+    64: ([32, 64, 128], [64, 128]),
+    128: ([16, 32, 64], [32, 64]),
+    256: ([32], [32, 64]),
+}
+
+_FMHA_BWD_DQ_TILE_CONFIGS_BY_D = {
+    64: ([64, 128], [32, 64, 128]),
+    128: ([32, 64], [16, 32, 64]),
+    256: ([64], [32, 64]),
+}
+
+
+def _iter_tile_configs(tile_ms: list[int], tile_ns: list[int]):
+    for tm in tile_ms:
+        for tn in tile_ns:
+            yield SimpleNamespace(TILE_M=tm, TILE_N=tn)
+
+
+def _fmha_autotune_configs(head_dim: int | None = None):
+    """
+    Iterator of autotune configurations for FMHA forward kernel.
+    """
+    gpu_capability = torch.cuda.get_device_capability()
+
+    if gpu_capability in [(12, 0), (12, 1)]:
+        # sm120, sm121
+        yield SimpleNamespace(TILE_M=64, TILE_N=64, num_ctas=1, occupancy=2)
+    elif gpu_capability[0] < 9:
+        # GPU capability < 9.0
+        yield SimpleNamespace(TILE_M=64, TILE_N=64, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_M=128, TILE_N=64, num_ctas=1, occupancy=2)
+    else:
+        # sm100 (Blackwell)
+        yield SimpleNamespace(TILE_M=256, TILE_N=128, num_ctas=1, occupancy=1)
+        yield SimpleNamespace(TILE_M=128, TILE_N=128, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_M=256, TILE_N=128, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_M=256, TILE_N=128, num_ctas=2, occupancy=2)
+
+
+def _fmha_bwd_autotune_configs(head_dim: int | None = None):
+    """Reference configs for FMHA backward (used for padding/preprocess only).
+
+    The actual autotuning is done by _fmha_bwd_dkdv_autotune_configs and
+    _fmha_bwd_dq_autotune_configs. This function provides the superset of
+    tile sizes for padding calculation.
+    """
+    key = _head_dim_key(head_dim)
+    dkdv_ms, dkdv_ns = _FMHA_BWD_DKDV_TILE_CONFIGS_BY_D.get(key, ([32, 64, 128], [64, 128]))
+    dq_ms, dq_ns = _FMHA_BWD_DQ_TILE_CONFIGS_BY_D.get(key, ([64, 128], [32, 64, 128]))
+    tile_ms = sorted(set(dkdv_ms + dq_ms))
+    tile_ns = sorted(set(dkdv_ns + dq_ns))
+    yield from _iter_tile_configs(tile_ms, tile_ns)
+
+
+def _fmha_bwd_dkdv_autotune_configs(head_dim: int | None = None):
+    """Autotune configurations for dK/dV kernel.
+
+    Only tunes tile sizes; num_ctas and occupancy are left to the compiler.
+
+    Search dimensions:
+    - TILE_M: [32, 64, 128] (Q tile, inner loop)
+    - TILE_N: [64, 128] (K/V tile, this block's tile)
+    """
+    key = _head_dim_key(head_dim)
+    tile_ms, tile_ns = _FMHA_BWD_DKDV_TILE_CONFIGS_BY_D.get(key, ([32, 64, 128], [64, 128]))
+    yield from _iter_tile_configs(tile_ms, tile_ns)
+
+
+def _fmha_bwd_dq_autotune_configs(head_dim: int | None = None):
+    """Autotune configurations for dQ kernel.
+
+    Only tunes tile sizes; num_ctas and occupancy are left to the compiler.
+
+    Search dimensions:
+    - TILE_M: [64, 128] (Q tile, this block's tile)
+    - TILE_N: [32, 64, 128] (K/V tile, inner loop)
+    """
+    key = _head_dim_key(head_dim)
+    tile_ms, tile_ns = _FMHA_BWD_DQ_TILE_CONFIGS_BY_D.get(key, ([64, 128], [32, 64, 128]))
+    yield from _iter_tile_configs(tile_ms, tile_ns)
 
 
 @experimental_kernel
@@ -599,63 +685,6 @@ def _fmha_bwd_dq_kernel(
     ct.store(dQ, index=(batch_idx, head_idx, bid_m, 0), tile=dq_store)
 
 
-_FMHA_BWD_DKDV_TILE_CONFIGS_BY_D = {
-    64: ([32, 64, 128], [64, 128]),
-    128: ([16, 32, 64], [32, 64]),
-    256: ([32], [32, 64]),
-}
-
-_FMHA_BWD_DQ_TILE_CONFIGS_BY_D = {
-    64: ([64, 128], [32, 64, 128]),
-    128: ([32, 64], [16, 32, 64]),
-    256: ([64], [32, 64]),
-}
-
-
-def _head_dim_key(head_dim: int | None) -> int | None:
-    if head_dim is None:
-        return None
-    return next_power_of_2(head_dim)
-
-
-def _iter_tile_configs(tile_ms: list[int], tile_ns: list[int]):
-    for tm in tile_ms:
-        for tn in tile_ns:
-            yield SimpleNamespace(TILE_M=tm, TILE_N=tn)
-
-
-def _kernel_hints(cfg, *, default_occupancy: int | None = 2):
-    hints = {}
-    num_ctas = getattr(cfg, "num_ctas", None)
-    occupancy = getattr(cfg, "occupancy", default_occupancy)
-    if num_ctas is not None:
-        hints["num_ctas"] = num_ctas
-    if occupancy is not None:
-        hints["occupancy"] = occupancy
-    return hints
-
-
-def _fmha_autotune_configs(head_dim: int | None = None):
-    """
-    Iterator of autotune configurations for FMHA forward kernel.
-    """
-    gpu_capability = torch.cuda.get_device_capability()
-
-    if gpu_capability in [(12, 0), (12, 1)]:
-        # sm120, sm121
-        yield SimpleNamespace(TILE_M=64, TILE_N=64, num_ctas=1, occupancy=2)
-    elif gpu_capability[0] < 9:
-        # GPU capability < 9.0
-        yield SimpleNamespace(TILE_M=64, TILE_N=64, num_ctas=1, occupancy=2)
-        yield SimpleNamespace(TILE_M=128, TILE_N=64, num_ctas=1, occupancy=2)
-    else:
-        # sm100 (Blackwell)
-        yield SimpleNamespace(TILE_M=256, TILE_N=128, num_ctas=1, occupancy=1)
-        yield SimpleNamespace(TILE_M=128, TILE_N=128, num_ctas=1, occupancy=2)
-        yield SimpleNamespace(TILE_M=256, TILE_N=128, num_ctas=1, occupancy=2)
-        yield SimpleNamespace(TILE_M=256, TILE_N=128, num_ctas=2, occupancy=2)
-
-
 @ct.kernel
 def _fmha_kernel(
     Q,
@@ -696,6 +725,23 @@ def _fmha_kernel(
         bid_x,
         bid_y,
     )
+
+
+def _head_dim_key(head_dim: int | None) -> int | None:
+    if head_dim is None:
+        return None
+    return next_power_of_2(head_dim)
+
+
+def _kernel_hints(cfg, *, default_occupancy: int | None = 2):
+    hints = {}
+    num_ctas = getattr(cfg, "num_ctas", None)
+    occupancy = getattr(cfg, "occupancy", default_occupancy)
+    if num_ctas is not None:
+        hints["num_ctas"] = num_ctas
+    if occupancy is not None:
+        hints["occupancy"] = occupancy
+    return hints
 
 
 def _cutile_autotune_fmha(
@@ -851,49 +897,6 @@ def tile_fmha(
     kernel_configs = kwargs.get("kernel_configs", None)
     o = _tile_prefill_fmha(q, k, v, scaling, is_causal, kernel_configs)
     return o
-
-
-def _fmha_bwd_autotune_configs(head_dim: int | None = None):
-    """Reference configs for FMHA backward (used for padding/preprocess only).
-
-    The actual autotuning is done by _fmha_bwd_dkdv_autotune_configs and
-    _fmha_bwd_dq_autotune_configs. This function provides the superset of
-    tile sizes for padding calculation.
-    """
-    key = _head_dim_key(head_dim)
-    dkdv_ms, dkdv_ns = _FMHA_BWD_DKDV_TILE_CONFIGS_BY_D.get(key, ([32, 64, 128], [64, 128]))
-    dq_ms, dq_ns = _FMHA_BWD_DQ_TILE_CONFIGS_BY_D.get(key, ([64, 128], [32, 64, 128]))
-    tile_ms = sorted(set(dkdv_ms + dq_ms))
-    tile_ns = sorted(set(dkdv_ns + dq_ns))
-    yield from _iter_tile_configs(tile_ms, tile_ns)
-
-
-def _fmha_bwd_dkdv_autotune_configs(head_dim: int | None = None):
-    """Autotune configurations for dK/dV kernel.
-
-    Only tunes tile sizes; num_ctas and occupancy are left to the compiler.
-
-    Search dimensions:
-    - TILE_M: [32, 64, 128] (Q tile, inner loop)
-    - TILE_N: [64, 128] (K/V tile, this block's tile)
-    """
-    key = _head_dim_key(head_dim)
-    tile_ms, tile_ns = _FMHA_BWD_DKDV_TILE_CONFIGS_BY_D.get(key, ([32, 64, 128], [64, 128]))
-    yield from _iter_tile_configs(tile_ms, tile_ns)
-
-
-def _fmha_bwd_dq_autotune_configs(head_dim: int | None = None):
-    """Autotune configurations for dQ kernel.
-
-    Only tunes tile sizes; num_ctas and occupancy are left to the compiler.
-
-    Search dimensions:
-    - TILE_M: [64, 128] (Q tile, this block's tile)
-    - TILE_N: [32, 64, 128] (K/V tile, inner loop)
-    """
-    key = _head_dim_key(head_dim)
-    tile_ms, tile_ns = _FMHA_BWD_DQ_TILE_CONFIGS_BY_D.get(key, ([64, 128], [32, 64, 128]))
-    yield from _iter_tile_configs(tile_ms, tile_ns)
 
 
 def fmha_forward_with_lse(

--- a/src/tilegym/ops/cutile/attention_sink.py
+++ b/src/tilegym/ops/cutile/attention_sink.py
@@ -15,8 +15,6 @@ from tilegym.autotune import is_autotune_enabled
 from tilegym.backend import register_impl
 
 # Module-level tune cache: (batch_size, n_heads, n_ctx, head_dim, n_kv_ctx, bandwidth, dtype, device) -> (best_cfg, tuned_kernel)
-
-
 _attention_sink_tune_cache: dict = {}
 
 INV_LOG_2 = 1.0 / math.log(2)

--- a/src/tilegym/ops/cutile/attention_sink.py
+++ b/src/tilegym/ops/cutile/attention_sink.py
@@ -15,13 +15,32 @@ from tilegym.autotune import is_autotune_enabled
 from tilegym.backend import register_impl
 
 # Module-level tune cache: (batch_size, n_heads, n_ctx, head_dim, n_kv_ctx, bandwidth, dtype, device) -> (best_cfg, tuned_kernel)
+
+
 _attention_sink_tune_cache: dict = {}
 
 INV_LOG_2 = 1.0 / math.log(2)
 
-# Define type aliases for Constant integers and booleans
 ConstInt = ct.Constant[int]
 ConstBool = ct.Constant[bool]
+
+
+def _attention_sink_autotune_configs():
+    """
+    Iterator of autotune configurations for attention_sink kernel.
+    """
+    gpu_capability = torch.cuda.get_device_capability()
+
+    if gpu_capability[0] < 9:
+        for TILE_M in [128, 64]:
+            for TILE_N in [64]:
+                for occupancy in [1, 2]:
+                    yield SimpleNamespace(TILE_M=TILE_M, TILE_N=TILE_N, num_ctas=1, occupancy=occupancy)
+    else:
+        for TILE_M in [256, 128, 64]:
+            for TILE_N in [128, 64]:
+                for occupancy in [1, 2, 4]:
+                    yield SimpleNamespace(TILE_M=TILE_M, TILE_N=TILE_N, num_ctas=1, occupancy=occupancy)
 
 
 @ct.kernel(occupancy=2)
@@ -158,24 +177,6 @@ def _attention_sink_kernel(
     acc = ct.truediv(acc, z, flush_to_zero=True, rounding_mode=RMd.APPROX)
     acc = acc.reshape((1, 1, TILE_M, TILE_D)).astype(Out.dtype)
     ct.store(Out, index=(batch_idx, head_idx, bid_x, 0), tile=acc)
-
-
-def _attention_sink_autotune_configs():
-    """
-    Iterator of autotune configurations for attention_sink kernel.
-    """
-    gpu_capability = torch.cuda.get_device_capability()
-
-    if gpu_capability[0] < 9:
-        for TILE_M in [128, 64]:
-            for TILE_N in [64]:
-                for occupancy in [1, 2]:
-                    yield SimpleNamespace(TILE_M=TILE_M, TILE_N=TILE_N, num_ctas=1, occupancy=occupancy)
-    else:
-        for TILE_M in [256, 128, 64]:
-            for TILE_N in [128, 64]:
-                for occupancy in [1, 2, 4]:
-                    yield SimpleNamespace(TILE_M=TILE_M, TILE_N=TILE_N, num_ctas=1, occupancy=occupancy)
 
 
 def _cutile_autotune_attention_sink(

--- a/src/tilegym/ops/cutile/attention_sink_decode.py
+++ b/src/tilegym/ops/cutile/attention_sink_decode.py
@@ -13,7 +13,6 @@ from tilegym.ops.cutile.splitk_reduce import splitk_reduce
 
 from .utils import next_power_of_2
 
-# Type aliases for constants
 ConstInt = ct.Constant[int]
 ConstFloat = ct.Constant[float]
 ConstBool = ct.Constant[bool]

--- a/src/tilegym/ops/cutile/bmm.py
+++ b/src/tilegym/ops/cutile/bmm.py
@@ -12,8 +12,6 @@ from cuda.tile.tune import exhaustive_search
 from tilegym.backend import register_impl
 
 # Module-level tune cache: (batch_size, M, N, K, transpose_a, transpose_b, dtype, device) -> (best_cfg, tuned_kernel)
-
-
 _bmm_tune_cache: dict = {}
 
 
@@ -61,8 +59,6 @@ def _bmm_autotune_configs():
 
 
 # CuTile implementation of BMM kernel
-
-
 @ct.kernel
 def _bmm_kernel(A, B, C, TM: ct.Constant[int], TN: ct.Constant[int], TK: ct.Constant[int]):
     """CuTile kernel for batch matrix multiplication

--- a/src/tilegym/ops/cutile/bmm.py
+++ b/src/tilegym/ops/cutile/bmm.py
@@ -12,10 +12,57 @@ from cuda.tile.tune import exhaustive_search
 from tilegym.backend import register_impl
 
 # Module-level tune cache: (batch_size, M, N, K, transpose_a, transpose_b, dtype, device) -> (best_cfg, tuned_kernel)
+
+
 _bmm_tune_cache: dict = {}
 
 
+def _bmm_autotune_configs():
+    if torch.cuda.get_device_capability() in [(12, 0), (12, 1)]:
+        # B200 (sm_120/121): Use smaller tiles with occupancy tuning, num_ctas=1
+        for TILE_M in [64, 128]:
+            for TILE_N in [64, 128]:
+                for TILE_K in [32, 64]:
+                    for occupancy in [1, 2, 4]:
+                        yield SimpleNamespace(
+                            TILE_M=TILE_M,
+                            TILE_N=TILE_N,
+                            TILE_K=TILE_K,
+                            GROUP_SIZE_M=8,
+                            occupancy=occupancy,
+                            num_ctas=1,
+                        )
+    elif torch.cuda.get_device_capability()[0] < 9:
+        # SM80 (A100): avoid 256×256 tiles and num_ctas=2 (not supported).
+        for TILE_M in [64, 128]:
+            for TILE_N in [64, 128]:
+                for TILE_K in [32, 64, 128]:
+                    for occupancy in [1, 2]:
+                        yield SimpleNamespace(
+                            TILE_M=TILE_M, TILE_N=TILE_N, TILE_K=TILE_K, GROUP_SIZE_M=8, occupancy=occupancy, num_ctas=1
+                        )
+    elif torch.cuda.get_device_capability() == (9, 0):
+        # H100 (sm_90): Medium tiles with occupancy tuning
+        for TILE_M in [64, 128, 256]:
+            for TILE_N in [64, 128, 256]:
+                for TILE_K in [64]:
+                    for occupancy in [1, 2]:
+                        yield SimpleNamespace(
+                            TILE_M=TILE_M, TILE_N=TILE_N, TILE_K=TILE_K, GROUP_SIZE_M=8, occupancy=occupancy, num_ctas=2
+                        )
+    else:
+        # Other GPUs (e.g., GB100): Larger tiles with num_ctas=2
+        for TILE_M in [128, 256]:
+            for TILE_N in [256]:
+                for TILE_K in [64]:
+                    yield SimpleNamespace(
+                        TILE_M=TILE_M, TILE_N=TILE_N, TILE_K=TILE_K, GROUP_SIZE_M=8, occupancy=1, num_ctas=2
+                    )
+
+
 # CuTile implementation of BMM kernel
+
+
 @ct.kernel
 def _bmm_kernel(A, B, C, TM: ct.Constant[int], TN: ct.Constant[int], TK: ct.Constant[int]):
     """CuTile kernel for batch matrix multiplication
@@ -167,49 +214,6 @@ def _static_persistent_bmm_kernel(
         # Reshape to 3D for store
         result_3d = ct.reshape(result, (1, TILE_M, TILE_N))
         ct.store(C, index=(bid_q, bid_m, bid_n), tile=result_3d, order=(0, 1, 2), latency=3)
-
-
-def _bmm_autotune_configs():
-    if torch.cuda.get_device_capability() in [(12, 0), (12, 1)]:
-        # B200 (sm_120/121): Use smaller tiles with occupancy tuning, num_ctas=1
-        for TILE_M in [64, 128]:
-            for TILE_N in [64, 128]:
-                for TILE_K in [32, 64]:
-                    for occupancy in [1, 2, 4]:
-                        yield SimpleNamespace(
-                            TILE_M=TILE_M,
-                            TILE_N=TILE_N,
-                            TILE_K=TILE_K,
-                            GROUP_SIZE_M=8,
-                            occupancy=occupancy,
-                            num_ctas=1,
-                        )
-    elif torch.cuda.get_device_capability()[0] < 9:
-        # SM80 (A100): avoid 256×256 tiles and num_ctas=2 (not supported).
-        for TILE_M in [64, 128]:
-            for TILE_N in [64, 128]:
-                for TILE_K in [32, 64, 128]:
-                    for occupancy in [1, 2]:
-                        yield SimpleNamespace(
-                            TILE_M=TILE_M, TILE_N=TILE_N, TILE_K=TILE_K, GROUP_SIZE_M=8, occupancy=occupancy, num_ctas=1
-                        )
-    elif torch.cuda.get_device_capability() == (9, 0):
-        # H100 (sm_90): Medium tiles with occupancy tuning
-        for TILE_M in [64, 128, 256]:
-            for TILE_N in [64, 128, 256]:
-                for TILE_K in [64]:
-                    for occupancy in [1, 2]:
-                        yield SimpleNamespace(
-                            TILE_M=TILE_M, TILE_N=TILE_N, TILE_K=TILE_K, GROUP_SIZE_M=8, occupancy=occupancy, num_ctas=2
-                        )
-    else:
-        # Other GPUs (e.g., GB100): Larger tiles with num_ctas=2
-        for TILE_M in [128, 256]:
-            for TILE_N in [256]:
-                for TILE_K in [64]:
-                    yield SimpleNamespace(
-                        TILE_M=TILE_M, TILE_N=TILE_N, TILE_K=TILE_K, GROUP_SIZE_M=8, occupancy=1, num_ctas=2
-                    )
 
 
 def _persistent_bmm_autotune_base(stream, a, b, output, batch_size, M, N, K, transpose_a, transpose_b):

--- a/src/tilegym/ops/cutile/dropout.py
+++ b/src/tilegym/ops/cutile/dropout.py
@@ -10,29 +10,6 @@ import torch
 from tilegym.backend import register_impl
 
 
-def _mix_seed(seed: int) -> int:
-    """Pre-mix a user-provided seed into a well-spread signed int32.
-
-    The cuTile kernel's internal hash (3 rounds of XOR-shift) does not
-    amplify small seed deltas — e.g. seed=11 vs seed=99 only differ in
-    the low bits of `combined = offsets*prime + seed`, and bit 30 of the
-    final hash (which drives the p=0.5 keep decision) ends up identical
-    across all lanes, so the mask is independent of the seed.
-
-    Multiplying the seed by Knuth's constant 0x9E3779B1 (== floor(2^32 / phi))
-    spreads the bits evenly across all 32 positions. Same input seed still
-    yields the same mixed seed (reproducibility), while different seeds
-    produce bit patterns with large Hamming distance, which the kernel's
-    XOR-shift can then amplify into a proper per-lane mask difference.
-    """
-    mixed = (int(seed) * 2654435761) & 0xFFFFFFFF
-    # Convert unsigned uint32 bit pattern to signed int32 (two's complement)
-    # so it can be passed as a `ct.Constant[int]` to the int32 kernel arg.
-    if mixed >= 0x80000000:
-        mixed -= 0x100000000
-    return mixed
-
-
 @ct.kernel
 def _dropout_kernel(
     x,
@@ -95,6 +72,29 @@ def _dropout_kernel(
         # In inference mode, just copy input to output
         output_tile = x_tile
     ct.scatter(output, offsets, output_tile)
+
+
+def _mix_seed(seed: int) -> int:
+    """Pre-mix a user-provided seed into a well-spread signed int32.
+
+    The cuTile kernel's internal hash (3 rounds of XOR-shift) does not
+    amplify small seed deltas — e.g. seed=11 vs seed=99 only differ in
+    the low bits of `combined = offsets*prime + seed`, and bit 30 of the
+    final hash (which drives the p=0.5 keep decision) ends up identical
+    across all lanes, so the mask is independent of the seed.
+
+    Multiplying the seed by Knuth's constant 0x9E3779B1 (== floor(2^32 / phi))
+    spreads the bits evenly across all 32 positions. Same input seed still
+    yields the same mixed seed (reproducibility), while different seeds
+    produce bit patterns with large Hamming distance, which the kernel's
+    XOR-shift can then amplify into a proper per-lane mask difference.
+    """
+    mixed = (int(seed) * 2654435761) & 0xFFFFFFFF
+    # Convert unsigned uint32 bit pattern to signed int32 (two's complement)
+    # so it can be passed as a `ct.Constant[int]` to the int32 kernel arg.
+    if mixed >= 0x80000000:
+        mixed -= 0x100000000
+    return mixed
 
 
 class _DropoutCuTileFunction(torch.autograd.Function):

--- a/src/tilegym/ops/cutile/experimental/fused_linear_cross_entropy.py
+++ b/src/tilegym/ops/cutile/experimental/fused_linear_cross_entropy.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: MIT
-
 """Forward-only chunked fused Linear + Cross-Entropy for cuTile experiments."""
 
 import cuda.tile as ct

--- a/src/tilegym/ops/cutile/experimental/mhc.py
+++ b/src/tilegym/ops/cutile/experimental/mhc.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: MIT
-
 from math import ceil
 from types import SimpleNamespace
 
@@ -15,7 +14,6 @@ from tilegym.logger import get_logger
 
 logger = get_logger(__name__)
 
-# Type aliases for constants
 ConstInt = ct.Constant[int]
 LOG2E = 1.4426950408889634
 
@@ -31,6 +29,25 @@ def _compute_bid(tile_id, num_bid_in_group, num_bid_m, GROUP_SIZE_M):
 
 def _sigmoid(x):
     return 1.0 / (1.0 + ct.exp(-x))
+
+
+def _mhc_split_gemm_rms_autotune_configs():
+    tile_ms = (64, 128)
+    tile_ks = (64, 128)
+    split_ks = (1, 2, 4, 8, 16)
+    group_size_ms = (8, 16)
+    tile_n = 32
+    for tile_m in tile_ms:
+        for tile_k in tile_ks:
+            for split_k in split_ks:
+                for group_size_m in group_size_ms:
+                    yield SimpleNamespace(
+                        TILE_SIZE_M=tile_m,
+                        TILE_SIZE_N=tile_n,
+                        TILE_SIZE_K=tile_k,
+                        SPLIT_K=split_k,
+                        GROUP_SIZE_M=group_size_m,
+                    )
 
 
 @experimental_kernel
@@ -190,25 +207,6 @@ def _mhc_finalize_scale_bias_sigmoid_kernel(
     ct.store(Y, index=(bid_m, bid_n), tile=out)
 
 
-def _mhc_split_gemm_rms_autotune_configs():
-    tile_ms = (64, 128)
-    tile_ks = (64, 128)
-    split_ks = (1, 2, 4, 8, 16)
-    group_size_ms = (8, 16)
-    tile_n = 32
-    for tile_m in tile_ms:
-        for tile_k in tile_ks:
-            for split_k in split_ks:
-                for group_size_m in group_size_ms:
-                    yield SimpleNamespace(
-                        TILE_SIZE_M=tile_m,
-                        TILE_SIZE_N=tile_n,
-                        TILE_SIZE_K=tile_k,
-                        SPLIT_K=split_k,
-                        GROUP_SIZE_M=group_size_m,
-                    )
-
-
 def _cutile_autotune_mhc_split_gemm_rms(stream, x, w, M, N, K, cfg=None):
     if cfg is not None:
         if isinstance(cfg, dict):
@@ -324,19 +322,6 @@ def _cutile_autotune_mhc_split_gemm_rms(stream, x, w, M, N, K, cfg=None):
     return y_acc, r_acc, best_cfg
 
 
-def _mhc_split_gemm_rms(x: torch.Tensor, w: torch.Tensor, **kwargs):
-    M, K = x.shape
-    KB, N = w.shape
-    assert K == KB, f"Incompatible matrices: K dimension of X is {K}, K dimension of W is {KB}"
-
-    cfg = kwargs.pop("cfg", None)
-    kwargs.pop("w_nt", None)
-    w = w.contiguous()
-
-    stream = torch.cuda.current_stream()
-    return _cutile_autotune_mhc_split_gemm_rms(stream, x, w, M, N, K, cfg=cfg)
-
-
 def _mhc_finalize_scale_bias_sigmoid(
     y_acc: torch.Tensor,
     r_acc: torch.Tensor,
@@ -390,6 +375,46 @@ def _mhc_finalize_scale_bias_sigmoid(
         ),
     )
     return y, r
+
+
+@register_impl("mhc_gemm_rms_scale", backend="cutile")
+def mhc_gemm_rms_scale(
+    x: torch.Tensor,
+    w: torch.Tensor,
+    n: int,
+    alpha_pre: float,
+    alpha_post: float,
+    alpha_res: float,
+    bias: torch.Tensor,
+    **kwargs,
+):
+    cfg = kwargs.pop("cfg", None)
+    kwargs.pop("w_nt", None)
+    w = w.contiguous()
+
+    M, K = x.shape
+    _, N = w.shape
+    y_acc, r_acc, cfg = _cutile_autotune_mhc_split_gemm_rms(
+        torch.cuda.current_stream(),
+        x,
+        w,
+        M,
+        N,
+        K,
+        cfg=cfg,
+    )
+    return _mhc_finalize_scale_bias_sigmoid(
+        y_acc,
+        r_acc,
+        n,
+        alpha_pre,
+        alpha_post,
+        alpha_res,
+        bias,
+        M,
+        K,
+        cfg=cfg,
+    )
 
 
 @experimental_kernel
@@ -467,71 +492,6 @@ def _mhc_apply_residual_kernel(
     ct.store(Out, index=(row, 0, c_tile), tile=out_tile)
 
 
-@experimental_kernel
-@ct.kernel
-def _mhc_sinkhorn_kernel(
-    Y,
-    N: ct.Constant[int],
-):
-    """Sinkhorn-Knopp normalization for residual block (in-place on Y)."""
-    row = ct.bid(0)
-    total = N * N
-    mat = ct.load(Y, index=(row, 0), shape=(1, total))
-    mat = ct.reshape(mat, (N, N))
-    mat = ct.astype(mat, ct.float32)
-    mat = ct.exp2(mat * LOG2E)
-
-    for _ in range(20):
-        row_sum = ct.sum(mat, axis=1, keepdims=True)
-        mat = mat / row_sum
-        col_sum = ct.sum(mat, axis=0, keepdims=True)
-        mat = mat / col_sum
-
-    mat = ct.reshape(mat, (1, total))
-    mat = ct.astype(mat, Y.dtype)
-    ct.store(Y, index=(row, 0), tile=mat)
-
-
-@register_impl("mhc_gemm_rms_scale", backend="cutile")
-def mhc_gemm_rms_scale(
-    x: torch.Tensor,
-    w: torch.Tensor,
-    n: int,
-    alpha_pre: float,
-    alpha_post: float,
-    alpha_res: float,
-    bias: torch.Tensor,
-    **kwargs,
-):
-    cfg = kwargs.pop("cfg", None)
-    kwargs.pop("w_nt", None)
-    w = w.contiguous()
-
-    M, K = x.shape
-    _, N = w.shape
-    y_acc, r_acc, cfg = _cutile_autotune_mhc_split_gemm_rms(
-        torch.cuda.current_stream(),
-        x,
-        w,
-        M,
-        N,
-        K,
-        cfg=cfg,
-    )
-    return _mhc_finalize_scale_bias_sigmoid(
-        y_acc,
-        r_acc,
-        n,
-        alpha_pre,
-        alpha_post,
-        alpha_res,
-        bias,
-        M,
-        K,
-        cfg=cfg,
-    )
-
-
 @register_impl("mhc_apply_residual", backend="cutile")
 def mhc_apply_residual(
     x: torch.Tensor,
@@ -570,6 +530,31 @@ def mhc_apply_residual(
         ),
     )
     return out
+
+
+@experimental_kernel
+@ct.kernel
+def _mhc_sinkhorn_kernel(
+    Y,
+    N: ct.Constant[int],
+):
+    """Sinkhorn-Knopp normalization for residual block (in-place on Y)."""
+    row = ct.bid(0)
+    total = N * N
+    mat = ct.load(Y, index=(row, 0), shape=(1, total))
+    mat = ct.reshape(mat, (N, N))
+    mat = ct.astype(mat, ct.float32)
+    mat = ct.exp2(mat * LOG2E)
+
+    for _ in range(20):
+        row_sum = ct.sum(mat, axis=1, keepdims=True)
+        mat = mat / row_sum
+        col_sum = ct.sum(mat, axis=0, keepdims=True)
+        mat = mat / col_sum
+
+    mat = ct.reshape(mat, (1, total))
+    mat = ct.astype(mat, Y.dtype)
+    ct.store(Y, index=(row, 0), tile=mat)
 
 
 @register_impl("mhc_sinkhorn", backend="cutile")

--- a/src/tilegym/ops/cutile/experimental/nvfp4_quantize.py
+++ b/src/tilegym/ops/cutile/experimental/nvfp4_quantize.py
@@ -26,8 +26,6 @@ ConstBool = ct.Constant[bool]
 # Currently uses a fixed 128x64 tile (128 rows x 64 cols per CTA).
 # Future work: support additional tile sizes (e.g. 64x64, 256x64) to enable
 # auto-tuning across tile configurations for different matrix shapes.
-
-
 @lru_cache(maxsize=None)
 def _make_nvfp4_kernel(occupancy: int):
     @experimental_kernel

--- a/src/tilegym/ops/cutile/experimental/nvfp4_quantize.py
+++ b/src/tilegym/ops/cutile/experimental/nvfp4_quantize.py
@@ -26,6 +26,8 @@ ConstBool = ct.Constant[bool]
 # Currently uses a fixed 128x64 tile (128 rows x 64 cols per CTA).
 # Future work: support additional tile sizes (e.g. 64x64, 256x64) to enable
 # auto-tuning across tile configurations for different matrix shapes.
+
+
 @lru_cache(maxsize=None)
 def _make_nvfp4_kernel(occupancy: int):
     @experimental_kernel

--- a/src/tilegym/ops/cutile/experimental/sparse_mla.py
+++ b/src/tilegym/ops/cutile/experimental/sparse_mla.py
@@ -30,10 +30,6 @@ _SPARSE_MLA_TILE_HS = [1, 2, 4, 8, 16, 32, 64]
 _SPARSE_MLA_TILE_NS = [16, 32, 64, 128]
 
 
-def _is_power_of_2(x):
-    return x > 0 and (x & (x - 1)) == 0
-
-
 def _validate_sparse_mla_config(cfg, topk, H, query_group_size, *, explicit=False):
     """Validate a (TILE_H, TILE_N) config. Raises ValueError/AssertionError if invalid.
 
@@ -214,6 +210,10 @@ def _sparse_mla_fwd_kernel(
     acc = ct.reshape(acc, (1, TILE_H, 1, TILE_D))
     acc = ct.astype(acc, Out.dtype)
     ct.store(Out, index=(batch_idx, h_block_idx, s_i, 0), tile=acc)
+
+
+def _is_power_of_2(x):
+    return x > 0 and (x & (x - 1)) == 0
 
 
 def _launch_sparse_mla_fwd(

--- a/src/tilegym/ops/cutile/experimental/swa_attention.py
+++ b/src/tilegym/ops/cutile/experimental/swa_attention.py
@@ -124,8 +124,6 @@ def _swa_fwd_kernel(
 
 
 # -- HuggingFace model integration --
-
-
 def get_swa_fmha_interface(window_size=4096, backend=None):
     """Returns a drop-in replacement for ALL_ATTENTION_FUNCTIONS["sdpa"].
 

--- a/src/tilegym/ops/cutile/experimental/swa_attention.py
+++ b/src/tilegym/ops/cutile/experimental/swa_attention.py
@@ -26,6 +26,12 @@ INV_LOG_2 = 1.0 / math.log(2)  # pre-computed for exp2-based softmax
 _NEG_INF = -1e30  # sentinel for masked-out attention positions
 
 
+# -- host launcher --
+
+_DEFAULT_TILE_M = 64
+_DEFAULT_TILE_N = 128  # autotuned: 1.9x faster than N=64 on B300
+
+
 def _cdiv(a, b):
     return (a + b - 1) // b
 
@@ -115,89 +121,6 @@ def _swa_fwd_kernel(
     l_i = ct.maximum(l_i, ct.full((TILE_M,), 1e-6, dtype=ct.float32))
     out = acc / ct.expand_dims(l_i, axis=1)
     ct.store(Out, index=(q_offset, 0), tile=ct.astype(out, ct.float16))
-
-
-# -- host launcher --
-
-_DEFAULT_TILE_M = 64
-_DEFAULT_TILE_N = 128  # autotuned: 1.9x faster than N=64 on B300
-
-
-@register_impl("swa_attention", backend="cutile")
-def tile_swa_attention(q, k, v, window_size, scaling=None, is_causal=True, **kwargs):
-    # q: (B, H, S_Q, D), k/v: (B, H_K, S_K, D) -- fp16
-    if q.dtype not in (torch.float16,):
-        raise ValueError(f"SWA kernel requires fp16 input, got {q.dtype}")
-
-    B, H, S_Q, D = q.shape
-    _, H_K, S_K, _ = k.shape
-
-    if scaling is None:
-        scaling = 1.0 / math.sqrt(D)
-    if window_size <= 0:
-        window_size = S_K  # non-positive W means full causal
-
-    # expand KV heads for GQA (Mistral uses 8 KV heads for 32 Q heads)
-    if H_K != H:
-        if H_K > H or H % H_K != 0:
-            raise ValueError(
-                f"Invalid GQA head configuration: query heads H={H} must be an integer multiple of KV heads H_K={H_K}."
-            )
-        kv_repeat = H // H_K
-        k = k.repeat_interleave(kv_repeat, dim=1)
-        v = v.repeat_interleave(kv_repeat, dim=1)
-
-    TILE_M = _DEFAULT_TILE_M
-    TILE_N = _DEFAULT_TILE_N
-
-    # compute strides: how many tiles each head occupies in the flat buffer
-    stride_q = _cdiv(S_Q, TILE_M)
-    stride_kv = _cdiv(S_K, TILE_N)
-    S_Q_padded = stride_q * TILE_M
-    S_K_padded = stride_kv * TILE_N
-
-    # flatten (B, H, S, D) -> (B*H, S, D) for contiguous tile indexing
-    q_3d = q.reshape(B * H, S_Q, D)
-    k_3d = k.reshape(B * H, S_K, D)
-    v_3d = v.reshape(B * H, S_K, D)
-
-    # pad seq dim to tile boundary so tile loads don't cross head boundaries
-    if S_Q_padded != S_Q:
-        q_3d = F.pad(q_3d, (0, 0, 0, S_Q_padded - S_Q))
-    if S_K_padded != S_K:
-        k_3d = F.pad(k_3d, (0, 0, 0, S_K_padded - S_K))
-        v_3d = F.pad(v_3d, (0, 0, 0, S_K_padded - S_K))
-
-    # reshape to (B*H*S_padded, D) -- the kernel indexes this as a 2D tile grid
-    q_flat = q_3d.reshape(-1, D).contiguous()
-    k_flat = k_3d.reshape(-1, D).contiguous()
-    v_flat = v_3d.reshape(-1, D).contiguous()
-    out_flat = torch.empty_like(q_flat)
-
-    ct.launch(
-        torch.cuda.current_stream(),
-        (stride_q, B * H, 1),
-        _swa_fwd_kernel,
-        (
-            q_flat,
-            k_flat,
-            v_flat,
-            out_flat,
-            scaling,
-            S_K,
-            window_size,
-            stride_q,
-            stride_kv,
-            TILE_M,
-            TILE_N,
-            D,
-            is_causal,
-        ),
-    )
-
-    # strip padding and reshape back to (B, H, S_Q, D)
-    out_3d = out_flat.reshape(B * H, S_Q_padded, D)[:, :S_Q, :]
-    return out_3d.reshape(B, H, S_Q, D).contiguous()
 
 
 # -- HuggingFace model integration --
@@ -295,3 +218,80 @@ def apply_tilegym_swa_to_mistral(window_size=4096, use_cutile=True):
         pass
     except Exception:
         raise
+
+
+@register_impl("swa_attention", backend="cutile")
+def tile_swa_attention(q, k, v, window_size, scaling=None, is_causal=True, **kwargs):
+    # q: (B, H, S_Q, D), k/v: (B, H_K, S_K, D) -- fp16
+    if q.dtype not in (torch.float16,):
+        raise ValueError(f"SWA kernel requires fp16 input, got {q.dtype}")
+
+    B, H, S_Q, D = q.shape
+    _, H_K, S_K, _ = k.shape
+
+    if scaling is None:
+        scaling = 1.0 / math.sqrt(D)
+    if window_size <= 0:
+        window_size = S_K  # non-positive W means full causal
+
+    # expand KV heads for GQA (Mistral uses 8 KV heads for 32 Q heads)
+    if H_K != H:
+        if H_K > H or H % H_K != 0:
+            raise ValueError(
+                f"Invalid GQA head configuration: query heads H={H} must be an integer multiple of KV heads H_K={H_K}."
+            )
+        kv_repeat = H // H_K
+        k = k.repeat_interleave(kv_repeat, dim=1)
+        v = v.repeat_interleave(kv_repeat, dim=1)
+
+    TILE_M = _DEFAULT_TILE_M
+    TILE_N = _DEFAULT_TILE_N
+
+    # compute strides: how many tiles each head occupies in the flat buffer
+    stride_q = _cdiv(S_Q, TILE_M)
+    stride_kv = _cdiv(S_K, TILE_N)
+    S_Q_padded = stride_q * TILE_M
+    S_K_padded = stride_kv * TILE_N
+
+    # flatten (B, H, S, D) -> (B*H, S, D) for contiguous tile indexing
+    q_3d = q.reshape(B * H, S_Q, D)
+    k_3d = k.reshape(B * H, S_K, D)
+    v_3d = v.reshape(B * H, S_K, D)
+
+    # pad seq dim to tile boundary so tile loads don't cross head boundaries
+    if S_Q_padded != S_Q:
+        q_3d = F.pad(q_3d, (0, 0, 0, S_Q_padded - S_Q))
+    if S_K_padded != S_K:
+        k_3d = F.pad(k_3d, (0, 0, 0, S_K_padded - S_K))
+        v_3d = F.pad(v_3d, (0, 0, 0, S_K_padded - S_K))
+
+    # reshape to (B*H*S_padded, D) -- the kernel indexes this as a 2D tile grid
+    q_flat = q_3d.reshape(-1, D).contiguous()
+    k_flat = k_3d.reshape(-1, D).contiguous()
+    v_flat = v_3d.reshape(-1, D).contiguous()
+    out_flat = torch.empty_like(q_flat)
+
+    ct.launch(
+        torch.cuda.current_stream(),
+        (stride_q, B * H, 1),
+        _swa_fwd_kernel,
+        (
+            q_flat,
+            k_flat,
+            v_flat,
+            out_flat,
+            scaling,
+            S_K,
+            window_size,
+            stride_q,
+            stride_kv,
+            TILE_M,
+            TILE_N,
+            D,
+            is_causal,
+        ),
+    )
+
+    # strip padding and reshape back to (B, H, S_Q, D)
+    out_3d = out_flat.reshape(B * H, S_Q_padded, D)[:, :S_Q, :]
+    return out_3d.reshape(B, H, S_Q, D).contiguous()

--- a/src/tilegym/ops/cutile/flash_decode.py
+++ b/src/tilegym/ops/cutile/flash_decode.py
@@ -22,8 +22,6 @@ INV_LOG_2 = 1.0 / math.log(2)
 # @ct.kernel() entry point so it can be reused by different kernels
 # (e.g. standalone decode attention and fused POD attention) without
 # duplicating the decode computation code.
-
-
 def attention_decode_kernel_grouped_impl(
     Q,
     K,

--- a/src/tilegym/ops/cutile/flash_decode.py
+++ b/src/tilegym/ops/cutile/flash_decode.py
@@ -13,7 +13,6 @@ from tilegym.ops.cutile.splitk_reduce import splitk_reduce
 
 from .utils import next_power_of_2
 
-# Type aliases for constants
 ConstInt = ct.Constant[int]
 
 INV_LOG_2 = 1.0 / math.log(2)
@@ -23,6 +22,8 @@ INV_LOG_2 = 1.0 / math.log(2)
 # @ct.kernel() entry point so it can be reused by different kernels
 # (e.g. standalone decode attention and fused POD attention) without
 # duplicating the decode computation code.
+
+
 def attention_decode_kernel_grouped_impl(
     Q,
     K,

--- a/src/tilegym/ops/cutile/gemma_attention.py
+++ b/src/tilegym/ops/cutile/gemma_attention.py
@@ -23,8 +23,6 @@ from cuda.tile.tune import exhaustive_search
 from tilegym.backend import register_impl
 
 # Module-level tune cache: (B, H, S_qo, S_kv, BLOCK_D, query_group_size, stage, window_size, soft_cap_val, has_soft_cap, dtype, device) -> (best_cfg, tuned_kernel)
-
-
 _gemma_fmha_tune_cache: dict = {}
 
 INV_LOG_2 = 1.0 / math.log(2)

--- a/src/tilegym/ops/cutile/gemma_attention.py
+++ b/src/tilegym/ops/cutile/gemma_attention.py
@@ -23,13 +23,13 @@ from cuda.tile.tune import exhaustive_search
 from tilegym.backend import register_impl
 
 # Module-level tune cache: (B, H, S_qo, S_kv, BLOCK_D, query_group_size, stage, window_size, soft_cap_val, has_soft_cap, dtype, device) -> (best_cfg, tuned_kernel)
+
+
 _gemma_fmha_tune_cache: dict = {}
 
-# Constants
 INV_LOG_2 = 1.0 / math.log(2)
 LOG_2 = math.log(2)
 
-# Define type aliases for Constant integers and booleans
 ConstInt = ct.Constant[int]
 ConstFloat = ct.Constant[float]
 ConstBool = ct.Constant[bool]
@@ -158,6 +158,17 @@ def _gemma_attn_fwd_inner(
     return acc, l_i, m_i
 
 
+def _gemma_fmha_autotune_configs():
+    """Iterator of autotune configurations for gemma FMHA kernel."""
+    gpu_capability = torch.cuda.get_device_capability()
+    if gpu_capability[0] < 9:
+        yield SimpleNamespace(BLOCK_M=64, BLOCK_N=64, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(BLOCK_M=128, BLOCK_N=64, num_ctas=1, occupancy=2)
+    else:
+        yield SimpleNamespace(BLOCK_M=256, BLOCK_N=128, num_ctas=1, occupancy=1)
+        yield SimpleNamespace(BLOCK_M=128, BLOCK_N=128, num_ctas=1, occupancy=2)
+
+
 @ct.kernel(occupancy=2)
 def _gemma_fmha_kernel(
     Q,
@@ -271,17 +282,6 @@ def _gemma_fmha_kernel(
     acc = ct.truediv(acc, l_i[:, None], flush_to_zero=True, rounding_mode=RMd.APPROX)
     acc = acc.reshape((1, 1, BLOCK_M, BLOCK_D)).astype(Out.dtype)
     ct.store(Out, index=(batch_idx, head_idx, bid_x, 0), tile=acc)
-
-
-def _gemma_fmha_autotune_configs():
-    """Iterator of autotune configurations for gemma FMHA kernel."""
-    gpu_capability = torch.cuda.get_device_capability()
-    if gpu_capability[0] < 9:
-        yield SimpleNamespace(BLOCK_M=64, BLOCK_N=64, num_ctas=1, occupancy=2)
-        yield SimpleNamespace(BLOCK_M=128, BLOCK_N=64, num_ctas=1, occupancy=2)
-    else:
-        yield SimpleNamespace(BLOCK_M=256, BLOCK_N=128, num_ctas=1, occupancy=1)
-        yield SimpleNamespace(BLOCK_M=128, BLOCK_N=128, num_ctas=1, occupancy=2)
 
 
 def _cutile_autotune_gemma_fmha(

--- a/src/tilegym/ops/cutile/gemma_attention_decode.py
+++ b/src/tilegym/ops/cutile/gemma_attention_decode.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: MIT
-
 """
 Gemma-specific attention decode implementation with soft cap and sliding window support.
 
@@ -23,11 +22,9 @@ from tilegym.backend import register_impl
 from .splitk_reduce import splitk_reduce
 from .utils import next_power_of_2
 
-# Constants
 INV_LOG_2 = 1.0 / math.log(2)
 LOG_2 = math.log(2)
 
-# Type aliases for constants
 ConstInt = ct.Constant[int]
 ConstFloat = ct.Constant[float]
 ConstBool = ct.Constant[bool]

--- a/src/tilegym/ops/cutile/group_gemm.py
+++ b/src/tilegym/ops/cutile/group_gemm.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: MIT
-
-
 from types import SimpleNamespace
 
 import cuda.tile as ct

--- a/src/tilegym/ops/cutile/group_gemm.py
+++ b/src/tilegym/ops/cutile/group_gemm.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+
 from types import SimpleNamespace
 
 import cuda.tile as ct
@@ -16,9 +17,24 @@ logger = get_logger(__name__)
 # Module-level tune cache: (group_shapes, transpose_b, dtype, device) -> (best_cfg, tuned_kernel)
 _group_gemm_tune_cache: dict = {}
 
-# Type aliases for constants
 ConstInt = ct.Constant[int]
 ConstBool = ct.Constant[bool]
+
+
+def _group_gemm_autotune_configs():
+    """
+    Iterator of autotune configurations for group GEMM kernel.
+    """
+    gpu_capability = torch.cuda.get_device_capability()
+    if gpu_capability in [(12, 0), (12, 1)]:
+        yield SimpleNamespace(TILE_M=64, TILE_N=128, TILE_K=128, num_ctas=1, occupancy=1)
+        yield SimpleNamespace(TILE_M=128, TILE_N=128, TILE_K=128, num_ctas=1, occupancy=1)
+        yield SimpleNamespace(TILE_M=128, TILE_N=128, TILE_K=64, num_ctas=1, occupancy=1)
+    elif gpu_capability[0] < 9:
+        yield SimpleNamespace(TILE_M=128, TILE_N=128, TILE_K=128, num_ctas=1, occupancy=1)
+    else:
+        yield SimpleNamespace(TILE_M=128, TILE_N=128, TILE_K=128, num_ctas=1, occupancy=1)
+        yield SimpleNamespace(TILE_M=256, TILE_N=256, TILE_K=64, num_ctas=2, occupancy=1)
 
 
 @ct.kernel
@@ -103,22 +119,6 @@ def _group_gemm_kernel(
 
         # Update the end position for the next group
         last_problem_end = last_problem_end + num_tiles
-
-
-def _group_gemm_autotune_configs():
-    """
-    Iterator of autotune configurations for group GEMM kernel.
-    """
-    gpu_capability = torch.cuda.get_device_capability()
-    if gpu_capability in [(12, 0), (12, 1)]:
-        yield SimpleNamespace(TILE_M=64, TILE_N=128, TILE_K=128, num_ctas=1, occupancy=1)
-        yield SimpleNamespace(TILE_M=128, TILE_N=128, TILE_K=128, num_ctas=1, occupancy=1)
-        yield SimpleNamespace(TILE_M=128, TILE_N=128, TILE_K=64, num_ctas=1, occupancy=1)
-    elif gpu_capability[0] < 9:
-        yield SimpleNamespace(TILE_M=128, TILE_N=128, TILE_K=128, num_ctas=1, occupancy=1)
-    else:
-        yield SimpleNamespace(TILE_M=128, TILE_N=128, TILE_K=128, num_ctas=1, occupancy=1)
-        yield SimpleNamespace(TILE_M=256, TILE_N=256, TILE_K=64, num_ctas=2, occupancy=1)
 
 
 def _cutile_autotune_group_gemm(stream, group_A, group_B, group_C, transpose_b, device):

--- a/src/tilegym/ops/cutile/layer_norm_legacy.py
+++ b/src/tilegym/ops/cutile/layer_norm_legacy.py
@@ -26,25 +26,34 @@ def _persistent_layer_norm_autotune_configs():
     Autotune config generator for persistent layer norm.
 
     Generates configurations:
-    - BLOCK_N: [2, 4, 8, 16, 32] - number of rows per block
+    - BLOCK_N: [1, 2, 4, 8, 16, 32] - number of rows per block
     - num_ctas: [1] - single CTA for this kernel
     """
-    for block_n in [2, 4, 8, 16, 32]:
+    for block_n in [1, 2, 4, 8, 16, 32]:
         yield SimpleNamespace(BLOCK_N=block_n, num_ctas=1)
 
 
-def _get_default_persistent_layer_norm_configs():
+def _get_default_persistent_layer_norm_configs(BLOCK_D=None):
     """GPU-specific defaults when autotune is disabled."""
     gpu_capability = torch.cuda.get_device_capability()
     if gpu_capability[0] < 9:
-        # Smaller BLOCK_N reduces shared memory pressure on pre-SM90 GPUs.
-        return {"BLOCK_N": 4, "num_ctas": 1}
+        # SM80 (A100): limit BLOCK_N for 2-block occupancy.
+        if BLOCK_D is not None:
+            max_block_n = max(1, 10496 // BLOCK_D)
+            p = 1
+            while p * 2 <= max_block_n:
+                p *= 2
+            block_n = min(8, p)
+        else:
+            block_n = 8
+        return {"BLOCK_N": block_n, "num_ctas": 1}
     return {"BLOCK_N": 8, "num_ctas": 1}
 
 
 def _persistent_layer_norm_early_config_prune(configs, N, D, BLOCK_D):
     """Prune configs that exceed register limits."""
     pruned_configs = []
+    _cap = torch.cuda.get_device_capability()
     for cfg in configs:
         BLOCK_N = cfg.BLOCK_N
         # Register limit check: BLOCK_N * BLOCK_D / (8 * 32) <= 256
@@ -269,7 +278,7 @@ def _persistent_layer_norm_autotune_base(
 
     # If all configs pruned, use default
     if not pruned_configs:
-        pruned_configs = [SimpleNamespace(**_get_default_persistent_layer_norm_configs())]
+        pruned_configs = [SimpleNamespace(**_get_default_persistent_layer_norm_configs(BLOCK_D))]
 
     def search_space():
         for cfg in pruned_configs:
@@ -366,23 +375,7 @@ def _cutile_persistent_layer_norm_fwd(
     # Calculate block sizes
     BLOCK_D = next_power_of_2(D)
 
-    # BLOCK_D is a ct.Constant; tileiras compile time grows super-linearly with it.
-    # This kernel cannot use a smaller tile because LayerNorm statistics are global
-    # over all columns. Fall back to torch.nn.functional for large D on pre-SM90.
-    gpu_capability = torch.cuda.get_device_capability(x.device)
-    _sm80_max_block_d = 1024
-    if gpu_capability[0] < 9 and BLOCK_D > _sm80_max_block_d:
-        import torch.nn.functional as F
-
-        y_out = F.layer_norm(x, (D,), weight, bias, eps)
-        if compute_mean_and_rstd:
-            x_fp32 = x.float()
-            mean.copy_(x_fp32.mean(dim=-1))
-            rstd.copy_((1.0 / (x_fp32.var(dim=-1, unbiased=False) + eps).sqrt()))
-        return y_out, mean, rstd, BLOCK_D, 8
-
-    # Autotune disabled on pre-SM90: per-constant compilation is too slow per config.
-    enable_autotune = is_autotune_enabled() and gpu_capability[0] >= 9
+    enable_autotune = is_autotune_enabled()
 
     if enable_autotune:
         _persistent_layer_norm_autotune_base(
@@ -405,7 +398,7 @@ def _cutile_persistent_layer_norm_fwd(
         )
     else:
         # Use fixed default configs
-        configs = _get_default_persistent_layer_norm_configs()
+        configs = _get_default_persistent_layer_norm_configs(BLOCK_D)
         BLOCK_N = configs["BLOCK_N"]
         NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
 

--- a/src/tilegym/ops/cutile/layer_norm_legacy.py
+++ b/src/tilegym/ops/cutile/layer_norm_legacy.py
@@ -14,8 +14,6 @@ from tilegym.backend import register_impl
 from .utils import next_power_of_2
 
 # Module-level tune cache: (N, D, BLOCK_D, IS_SWISH, TRAINING, COMPUTE_MEAN_AND_RSTD, dtype, device) -> (best_cfg, tuned_kernel)
-
-
 _layer_norm_legacy_tune_cache: dict = {}
 
 PAD_ZERO = ct.PaddingMode.ZERO

--- a/src/tilegym/ops/cutile/layer_norm_legacy.py
+++ b/src/tilegym/ops/cutile/layer_norm_legacy.py
@@ -14,9 +14,43 @@ from tilegym.backend import register_impl
 from .utils import next_power_of_2
 
 # Module-level tune cache: (N, D, BLOCK_D, IS_SWISH, TRAINING, COMPUTE_MEAN_AND_RSTD, dtype, device) -> (best_cfg, tuned_kernel)
+
+
 _layer_norm_legacy_tune_cache: dict = {}
 
 PAD_ZERO = ct.PaddingMode.ZERO
+
+
+def _persistent_layer_norm_autotune_configs():
+    """
+    Autotune config generator for persistent layer norm.
+
+    Generates configurations:
+    - BLOCK_N: [2, 4, 8, 16, 32] - number of rows per block
+    - num_ctas: [1] - single CTA for this kernel
+    """
+    for block_n in [2, 4, 8, 16, 32]:
+        yield SimpleNamespace(BLOCK_N=block_n, num_ctas=1)
+
+
+def _get_default_persistent_layer_norm_configs():
+    """GPU-specific defaults when autotune is disabled."""
+    gpu_capability = torch.cuda.get_device_capability()
+    if gpu_capability[0] < 9:
+        # Smaller BLOCK_N reduces shared memory pressure on pre-SM90 GPUs.
+        return {"BLOCK_N": 4, "num_ctas": 1}
+    return {"BLOCK_N": 8, "num_ctas": 1}
+
+
+def _persistent_layer_norm_early_config_prune(configs, N, D, BLOCK_D):
+    """Prune configs that exceed register limits."""
+    pruned_configs = []
+    for cfg in configs:
+        BLOCK_N = cfg.BLOCK_N
+        # Register limit check: BLOCK_N * BLOCK_D / (8 * 32) <= 256
+        if BLOCK_N * BLOCK_D / (8 * 32) <= 256:
+            pruned_configs.append(cfg)
+    return pruned_configs
 
 
 @ct.kernel
@@ -78,97 +112,6 @@ def _layer_norm_fwd_kernel(
         y = x_hat * w + b
         y = ct.astype(y, X.dtype)
         ct.scatter(Y, (row_tile, cols), y)
-
-
-class _LayerNorm(torch.autograd.Function):
-    @staticmethod
-    def forward(ctx, x, normalized_shape, weight, bias, eps, weight_shift=0.0):
-        # allocate output
-        y = torch.empty_like(x)
-        # reshape input data into 2D tensor
-        x_arg = x.reshape(-1, x.shape[-1])
-        M, N = x_arg.shape
-        mean = torch.empty((M,), dtype=torch.float32, device="cuda")
-        rstd = torch.empty((M,), dtype=torch.float32, device="cuda")
-        # Less than 64KB per feature: enqueue fused kernel
-        MAX_FUSED_SIZE = 65536 // x.element_size()
-        # Largest power-of-2 <= N so partial last block is handled by kernel masking (e.g. N=9 -> BLOCK_SIZE=8).
-        BLOCK_SIZE = min(MAX_FUSED_SIZE, 1 << (N.bit_length() - 1)) if N >= 1 else 1
-        if N > MAX_FUSED_SIZE:
-            raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
-        # heuristics for number of warps
-        num_warps = min(max(BLOCK_SIZE // 256, 1), 8)
-
-        # Pass X, Y as 2D (M, N) so gather/scatter bounds (row < M, cols < N) mask partial block
-        # (e.g. N=9, BLOCK_SIZE=8) without writing into the next row.
-        y_arg = y.reshape(-1, y.shape[-1])
-        grid = (M,)
-        ct.launch(
-            torch.cuda.current_stream(),
-            grid,
-            _layer_norm_fwd_kernel,
-            (
-                x_arg,
-                y_arg,
-                weight,
-                bias,
-                mean,
-                rstd,
-                N,
-                eps,
-                weight_shift,
-                BLOCK_SIZE,
-            ),
-        )
-        ctx.save_for_backward(x, weight, bias, mean, rstd)
-        ctx.BLOCK_SIZE = BLOCK_SIZE
-        ctx.num_warps = num_warps
-        ctx.eps = eps
-        ctx.weight_shift = weight_shift
-        return y
-
-    @staticmethod
-    def backward(ctx, dy):
-        raise NotImplementedError("LayerNorm backward is not implemented for this backend")
-
-
-def _switch_to_contiguous_if_needed(x: torch.Tensor) -> torch.Tensor:
-    """Switch tensor to contiguous layout if needed."""
-    if x.stride(-1) == 1:
-        return x
-    return x.contiguous()
-
-
-def _persistent_layer_norm_autotune_configs():
-    """
-    Autotune config generator for persistent layer norm.
-
-    Generates configurations:
-    - BLOCK_N: [2, 4, 8, 16, 32] - number of rows per block
-    - num_ctas: [1] - single CTA for this kernel
-    """
-    for block_n in [2, 4, 8, 16, 32]:
-        yield SimpleNamespace(BLOCK_N=block_n, num_ctas=1)
-
-
-def _get_default_persistent_layer_norm_configs():
-    """GPU-specific defaults when autotune is disabled."""
-    gpu_capability = torch.cuda.get_device_capability()
-    if gpu_capability[0] < 9:
-        # Smaller BLOCK_N reduces shared memory pressure on pre-SM90 GPUs.
-        return {"BLOCK_N": 4, "num_ctas": 1}
-    return {"BLOCK_N": 8, "num_ctas": 1}
-
-
-def _persistent_layer_norm_early_config_prune(configs, N, D, BLOCK_D):
-    """Prune configs that exceed register limits."""
-    pruned_configs = []
-    for cfg in configs:
-        BLOCK_N = cfg.BLOCK_N
-        # Register limit check: BLOCK_N * BLOCK_D / (8 * 32) <= 256
-        if BLOCK_N * BLOCK_D / (8 * 32) <= 256:
-            pruned_configs.append(cfg)
-    return pruned_configs
 
 
 @ct.kernel
@@ -236,6 +179,65 @@ def _persistent_layer_norm_fwd_kernel(
             y = ct.sigmoid(y) * x
         y = ct.astype(y, ct.bfloat16)
         ct.store(Y, index=(current_pid, 0), tile=y, allow_tma=False)
+
+
+def _switch_to_contiguous_if_needed(x: torch.Tensor) -> torch.Tensor:
+    """Switch tensor to contiguous layout if needed."""
+    if x.stride(-1) == 1:
+        return x
+    return x.contiguous()
+
+
+class _LayerNorm(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, normalized_shape, weight, bias, eps, weight_shift=0.0):
+        # allocate output
+        y = torch.empty_like(x)
+        # reshape input data into 2D tensor
+        x_arg = x.reshape(-1, x.shape[-1])
+        M, N = x_arg.shape
+        mean = torch.empty((M,), dtype=torch.float32, device="cuda")
+        rstd = torch.empty((M,), dtype=torch.float32, device="cuda")
+        # Less than 64KB per feature: enqueue fused kernel
+        MAX_FUSED_SIZE = 65536 // x.element_size()
+        # Largest power-of-2 <= N so partial last block is handled by kernel masking (e.g. N=9 -> BLOCK_SIZE=8).
+        BLOCK_SIZE = min(MAX_FUSED_SIZE, 1 << (N.bit_length() - 1)) if N >= 1 else 1
+        if N > MAX_FUSED_SIZE:
+            raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+        # heuristics for number of warps
+        num_warps = min(max(BLOCK_SIZE // 256, 1), 8)
+
+        # Pass X, Y as 2D (M, N) so gather/scatter bounds (row < M, cols < N) mask partial block
+        # (e.g. N=9, BLOCK_SIZE=8) without writing into the next row.
+        y_arg = y.reshape(-1, y.shape[-1])
+        grid = (M,)
+        ct.launch(
+            torch.cuda.current_stream(),
+            grid,
+            _layer_norm_fwd_kernel,
+            (
+                x_arg,
+                y_arg,
+                weight,
+                bias,
+                mean,
+                rstd,
+                N,
+                eps,
+                weight_shift,
+                BLOCK_SIZE,
+            ),
+        )
+        ctx.save_for_backward(x, weight, bias, mean, rstd)
+        ctx.BLOCK_SIZE = BLOCK_SIZE
+        ctx.num_warps = num_warps
+        ctx.eps = eps
+        ctx.weight_shift = weight_shift
+        return y
+
+    @staticmethod
+    def backward(ctx, dy):
+        raise NotImplementedError("LayerNorm backward is not implemented for this backend")
 
 
 def _persistent_layer_norm_autotune_base(

--- a/src/tilegym/ops/cutile/matmul.py
+++ b/src/tilegym/ops/cutile/matmul.py
@@ -13,8 +13,6 @@ from tilegym.backend import register_impl
 from tilegym.logger import get_logger
 
 # Module-level tune caches: (M, N, K, dtype, device) -> (best_cfg, tuned_kernel)
-
-
 _matmul_tune_cache: dict = {}
 _static_persistent_matmul_tune_cache: dict = {}
 

--- a/src/tilegym/ops/cutile/matmul.py
+++ b/src/tilegym/ops/cutile/matmul.py
@@ -13,12 +13,13 @@ from tilegym.backend import register_impl
 from tilegym.logger import get_logger
 
 # Module-level tune caches: (M, N, K, dtype, device) -> (best_cfg, tuned_kernel)
+
+
 _matmul_tune_cache: dict = {}
 _static_persistent_matmul_tune_cache: dict = {}
 
 logger = get_logger(__name__)
 
-# Type aliases for constants
 ConstInt = ct.Constant[int]
 
 
@@ -34,6 +35,74 @@ def _swizzle_2d(M, N, TILE_SIZE_M, TILE_SIZE_N, GROUP_SIZE_M):
     bid_m = first_bid_m + (bid % group_size_m)
     bid_n = (bid % num_bid_in_group) // group_size_m
     return bid_m, bid_n
+
+
+def _compute_bid(tile_id, num_bid_in_group, num_bid_m, GROUP_SIZE_M):
+    group_id = tile_id // num_bid_in_group
+    first_bid_m = group_id * GROUP_SIZE_M
+    group_size_m = ct.minimum(num_bid_m - first_bid_m, GROUP_SIZE_M)
+    bid_m = first_bid_m + (tile_id % group_size_m)
+    bid_n = (tile_id % num_bid_in_group) // group_size_m
+    return bid_m, bid_n
+
+
+def _matmul_autotune_configs():
+    """
+    Iterator of autotune configurations for matmul kernel.
+    """
+    gpu_capability = torch.cuda.get_device_capability()
+
+    if gpu_capability in [(12, 0), (12, 1)]:
+        # sm120, sm121
+        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=64, num_ctas=1, occupancy=1)
+        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=32, num_ctas=1, occupancy=2)
+    elif gpu_capability[0] < 9:
+        # Pre-SM90: num_ctas=1 (CGA unsupported); sweep TILE_K in [32, 64, 128]
+        for TILE_M in [64, 128]:
+            for TILE_N in [64, 128]:
+                for TILE_K in [32, 64, 128]:
+                    for occ in [1, 2]:
+                        yield SimpleNamespace(
+                            TILE_SIZE_M=TILE_M, TILE_SIZE_N=TILE_N, TILE_SIZE_K=TILE_K, num_ctas=1, occupancy=occ
+                        )
+    else:
+        # sm100+ (Blackwell)
+        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=128, TILE_SIZE_K=32, num_ctas=1, occupancy=1)
+        yield SimpleNamespace(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, num_ctas=2, occupancy=1)
+        yield SimpleNamespace(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, num_ctas=4, occupancy=1)
+        yield SimpleNamespace(TILE_SIZE_M=512, TILE_SIZE_N=256, TILE_SIZE_K=64, num_ctas=2, occupancy=1)
+
+
+def _static_persistent_matmul_autotune_configs():
+    """
+    Iterator of autotune configurations for static persistent matmul kernel.
+    """
+    gpu_capability = torch.cuda.get_device_capability()
+
+    if gpu_capability in [(12, 0), (12, 1)]:
+        # sm120, sm121
+        yield SimpleNamespace(TILE_SIZE_M=64, TILE_SIZE_N=64, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_SIZE_M=64, TILE_SIZE_N=64, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=4)
+        yield SimpleNamespace(TILE_SIZE_M=64, TILE_SIZE_N=64, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=1)
+        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=1)
+        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=4)
+        yield SimpleNamespace(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=1)
+    elif gpu_capability[0] < 9:
+        # sm80 (A100)
+        yield SimpleNamespace(TILE_SIZE_M=64, TILE_SIZE_N=64, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_SIZE_M=64, TILE_SIZE_N=128, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=128, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=1)
+        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=128, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=2)
+    else:
+        # sm100+ (Blackwell)
+        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=512, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=4, occupancy=1)
+        yield SimpleNamespace(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=2, occupancy=1)
+        yield SimpleNamespace(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=1)
+        yield SimpleNamespace(
+            TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=128, GROUP_SIZE_M=8, num_ctas=2, occupancy=1
+        )
 
 
 @ct.kernel
@@ -110,15 +179,6 @@ def _matmul_kernel(
     ct.store(C, index=(bidx, bidy), tile=accumulator)
 
 
-def _compute_bid(tile_id, num_bid_in_group, num_bid_m, GROUP_SIZE_M):
-    group_id = tile_id // num_bid_in_group
-    first_bid_m = group_id * GROUP_SIZE_M
-    group_size_m = ct.minimum(num_bid_m - first_bid_m, GROUP_SIZE_M)
-    bid_m = first_bid_m + (tile_id % group_size_m)
-    bid_n = (tile_id % num_bid_in_group) // group_size_m
-    return bid_m, bid_n
-
-
 @ct.kernel
 def _static_persistent_matmul_kernel(
     A,
@@ -187,33 +247,6 @@ def _static_persistent_matmul_kernel(
         ct.store(C, index=(bid_m, bid_n), tile=result)
 
 
-def _matmul_autotune_configs():
-    """
-    Iterator of autotune configurations for matmul kernel.
-    """
-    gpu_capability = torch.cuda.get_device_capability()
-
-    if gpu_capability in [(12, 0), (12, 1)]:
-        # sm120, sm121
-        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=64, num_ctas=1, occupancy=1)
-        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=32, num_ctas=1, occupancy=2)
-    elif gpu_capability[0] < 9:
-        # Pre-SM90: num_ctas=1 (CGA unsupported); sweep TILE_K in [32, 64, 128]
-        for TILE_M in [64, 128]:
-            for TILE_N in [64, 128]:
-                for TILE_K in [32, 64, 128]:
-                    for occ in [1, 2]:
-                        yield SimpleNamespace(
-                            TILE_SIZE_M=TILE_M, TILE_SIZE_N=TILE_N, TILE_SIZE_K=TILE_K, num_ctas=1, occupancy=occ
-                        )
-    else:
-        # sm100+ (Blackwell)
-        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=128, TILE_SIZE_K=32, num_ctas=1, occupancy=1)
-        yield SimpleNamespace(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, num_ctas=2, occupancy=1)
-        yield SimpleNamespace(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, num_ctas=4, occupancy=1)
-        yield SimpleNamespace(TILE_SIZE_M=512, TILE_SIZE_N=256, TILE_SIZE_K=64, num_ctas=2, occupancy=1)
-
-
 def _cutile_autotune_matmul(stream, a, b, c):
     M, N = c.shape
     K = a.shape[1]
@@ -241,38 +274,6 @@ def _cutile_autotune_matmul(stream, a, b, c):
         (a, b, c, best_cfg.TILE_SIZE_M, best_cfg.TILE_SIZE_N, best_cfg.TILE_SIZE_K),
     )
     return c
-
-
-def _static_persistent_matmul_autotune_configs():
-    """
-    Iterator of autotune configurations for static persistent matmul kernel.
-    """
-    gpu_capability = torch.cuda.get_device_capability()
-
-    if gpu_capability in [(12, 0), (12, 1)]:
-        # sm120, sm121
-        yield SimpleNamespace(TILE_SIZE_M=64, TILE_SIZE_N=64, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=2)
-        yield SimpleNamespace(TILE_SIZE_M=64, TILE_SIZE_N=64, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=4)
-        yield SimpleNamespace(TILE_SIZE_M=64, TILE_SIZE_N=64, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=1)
-        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=2)
-        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=1)
-        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=4)
-        yield SimpleNamespace(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=1)
-    elif gpu_capability[0] < 9:
-        # sm80 (A100)
-        yield SimpleNamespace(TILE_SIZE_M=64, TILE_SIZE_N=64, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=2)
-        yield SimpleNamespace(TILE_SIZE_M=64, TILE_SIZE_N=128, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=2)
-        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=2)
-        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=128, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=1)
-        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=128, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=2)
-    else:
-        # sm100+ (Blackwell)
-        yield SimpleNamespace(TILE_SIZE_M=128, TILE_SIZE_N=512, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=4, occupancy=1)
-        yield SimpleNamespace(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=2, occupancy=1)
-        yield SimpleNamespace(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=1)
-        yield SimpleNamespace(
-            TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=128, GROUP_SIZE_M=8, num_ctas=2, occupancy=1
-        )
 
 
 def _cutile_autotune_static_persistent_matmul(stream, a, b, c, M, N, K, trans_a, trans_b):

--- a/src/tilegym/ops/cutile/mla.py
+++ b/src/tilegym/ops/cutile/mla.py
@@ -14,8 +14,6 @@ from tilegym.autotune import is_autotune_disabled
 from tilegym.backend import register_impl
 
 # Module-level tune cache: (S_qo, TILE_D, TILE_KPE, H, query_group_size, dtype, device) -> (best_cfg, tuned_kernel)
-
-
 _mla_tune_cache: dict = {}
 
 

--- a/src/tilegym/ops/cutile/mla.py
+++ b/src/tilegym/ops/cutile/mla.py
@@ -14,7 +14,14 @@ from tilegym.autotune import is_autotune_disabled
 from tilegym.backend import register_impl
 
 # Module-level tune cache: (S_qo, TILE_D, TILE_KPE, H, query_group_size, dtype, device) -> (best_cfg, tuned_kernel)
+
+
 _mla_tune_cache: dict = {}
+
+
+ConstInt = ct.Constant[int]
+
+INV_LOG_2 = 1.0 / math.log(2)
 
 
 def _mla_sm80_autotune_configs():
@@ -29,12 +36,6 @@ def _mla_sm90_autotune_configs():
     for tm in [64, 128, 256]:
         for tn in [64, 128]:
             yield SimpleNamespace(TILE_M=tm, TILE_N=tn, num_ctas=1, occupancy=1)
-
-
-# Type aliases for constants
-ConstInt = ct.Constant[int]
-
-INV_LOG_2 = 1.0 / math.log(2)
 
 
 @ct.kernel
@@ -220,25 +221,6 @@ class _AttentionFunction(torch.autograd.Function):
     @staticmethod
     def backward(ctx, do):
         raise NotImplementedError("Backward pass is not implemented for CuTile MLA")
-
-
-class _Attention:
-    def __init__(self, IS_CAUSAL, kernel_configs):
-        self.IS_CAUSAL = IS_CAUSAL
-        self.kernel_configs = kernel_configs
-
-    def __call__(self, q, k, v, sm_scale, qpe=None, kpe=None):
-        c = _AttentionFunction.apply(
-            q,
-            qpe,
-            k,
-            kpe,
-            v,
-            sm_scale,
-            self.IS_CAUSAL,
-            self.kernel_configs,
-        )
-        return c
 
 
 def _cutile_autotune_mla(stream, q, qpe, k, kpe, v, o, sm_scale, H, query_group_size):

--- a/src/tilegym/ops/cutile/mla_decoding.py
+++ b/src/tilegym/ops/cutile/mla_decoding.py
@@ -10,7 +10,6 @@ from cuda.tile import RoundingMode as RMd
 
 from tilegym.backend import register_impl
 
-# Type aliases for constants
 ConstInt = ct.Constant[int]
 ConstBool = ct.Constant[bool]
 

--- a/src/tilegym/ops/cutile/mla_decoding_split_kv.py
+++ b/src/tilegym/ops/cutile/mla_decoding_split_kv.py
@@ -6,17 +6,15 @@ import math
 
 import cuda.tile as ct
 import torch
-
-# Type aliases for constants
-ConstInt = ct.Constant[int]
-ConstBool = ct.Constant[bool]
-
 from cuda.tile import RoundingMode as RMd
 
 from tilegym.backend import register_impl
 
 from .splitk_reduce import splitk_reduce
 from .utils import next_power_of_2
+
+ConstInt = ct.Constant[int]
+ConstBool = ct.Constant[bool]
 
 INV_LOG_2 = 1.0 / math.log(2)
 

--- a/src/tilegym/ops/cutile/moe_align_block.py
+++ b/src/tilegym/ops/cutile/moe_align_block.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: MIT
-
-
 from typing import Tuple
 
 import cuda.tile as ct

--- a/src/tilegym/ops/cutile/moe_align_block.py
+++ b/src/tilegym/ops/cutile/moe_align_block.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+
 from typing import Tuple
 
 import cuda.tile as ct
@@ -9,10 +10,6 @@ import torch
 
 from tilegym.backend import register_impl
 from tilegym.ops.cutile.utils import next_power_of_2
-
-
-def _ceil_div(a, b):
-    return (a + b - 1) // b
 
 
 @ct.kernel
@@ -160,6 +157,10 @@ def _moe_align_block_size_stage4_kernel(
         ct.scatter(sorted_token_ids, rank_post_pad, current_idx_tile)
         new_token_cnt = token_cnt + ct.ones((1,), dtype=ct.int32)
         ct.scatter(tokens_cnts, cnt_offset, new_token_cnt)
+
+
+def _ceil_div(a, b):
+    return (a + b - 1) // b
 
 
 def _moe_align_block_size(

--- a/src/tilegym/ops/cutile/rms_norm.py
+++ b/src/tilegym/ops/cutile/rms_norm.py
@@ -379,23 +379,6 @@ class _RMSNorm(torch.autograd.Function):
             TILE_SIZE_M = 4  # Default value, could be made configurable
             TILE_SIZE_N = next_power_of_2(N)
 
-            # Pre-SM90: TILE_SIZE_N as a ct.Constant causes per-N recompilation.
-            # Gather kernel avoids this by treating N as a runtime variable.
-            if torch.cuda.get_device_capability(x.device)[0] < 9:
-                MAX_FUSED_SIZE = 4096 // x.element_size()
-                _tile = min(MAX_FUSED_SIZE, next_power_of_2(N))
-                ct.launch(
-                    torch.cuda.current_stream(),
-                    (M,),
-                    _rms_norm_kernel_gather,
-                    (x_arg, weight, y, rstd, N, eps, offset, _tile),
-                )
-                ctx.save_for_backward(x, weight, rstd)
-                ctx.TILE_SIZE = _tile
-                ctx.eps = eps
-                ctx.offset = offset
-                return y.view(*x.shape)
-
             # Other block sizes are more optimal when other dimension is too large/too small
             if TILE_SIZE_N <= 1024:
                 TILE_SIZE_M = 16

--- a/src/tilegym/ops/cutile/rms_norm.py
+++ b/src/tilegym/ops/cutile/rms_norm.py
@@ -11,6 +11,8 @@ from tilegym.experimental import experimental_kernel
 
 from .utils import next_power_of_2
 
+_bwd_cfg: dict = {}  # (M, N) → (tile_m, tile_n, grid, N)
+
 
 @ct.kernel
 def _rms_norm_kernel_multi_wave_cached(
@@ -227,9 +229,6 @@ def _rms_bwd_kernel(dx, dy, x, weight, Rstd, dw_partial, TILE_M: ct.Constant[int
     ct.store(dw_partial, index=(bid, 0), tile=dw_acc, allow_tma=False)
 
 
-_bwd_cfg: dict = {}  # (M, N) → (tile_m, tile_n, grid, N)
-
-
 def _bwd_tiles(M, N):
     """Heuristic tile configuration for backward kernel."""
     T = next_power_of_2(N)
@@ -245,6 +244,27 @@ def _bwd_tiles(M, N):
     if tiles <= 64:
         g = min(g, 32)
     return (tm, T, g, N)
+
+
+def rms_norm_backward_workspace_bytes(M: int, N: int) -> int:
+    """Return temporary workspace traffic for the standalone backward benchmark."""
+    _, tile_n, grid, _ = _bwd_tiles(M, N)
+    return grid * tile_n * 4 * 2
+
+
+def compute_rms_norm_rstd_torch(x: torch.Tensor, eps: float) -> torch.Tensor:
+    """Compute the PyTorch reference RMSNorm rstd used by standalone backward benchmarks."""
+    return _TileRMSNorm.compute_rstd_torch(x, eps)
+
+
+def rms_norm_backward_torch(
+    x: torch.Tensor,
+    dy: torch.Tensor,
+    weight: torch.Tensor,
+    rstd: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """PyTorch reference implementation for standalone RMSNorm backward."""
+    return _TileRMSNorm.rms_norm_backward_torch(x, dy, weight, rstd)
 
 
 def _rms_norm_backward(
@@ -291,12 +311,6 @@ def rms_norm_backward(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Standalone cuTile RMSNorm backward entry point."""
     return _rms_norm_backward(x, dy, weight, rstd)
-
-
-def rms_norm_backward_workspace_bytes(M: int, N: int) -> int:
-    """Return temporary workspace traffic for the standalone backward benchmark."""
-    _, tile_n, grid, _ = _bwd_tiles(M, N)
-    return grid * tile_n * 4 * 2
 
 
 class _RMSNorm(torch.autograd.Function):
@@ -589,21 +603,6 @@ class _TileRMSNorm(nn.Module):
 
     def extra_repr(self):
         return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}, offset={self.offset}"
-
-
-def compute_rms_norm_rstd_torch(x: torch.Tensor, eps: float) -> torch.Tensor:
-    """Compute the PyTorch reference RMSNorm rstd used by standalone backward benchmarks."""
-    return _TileRMSNorm.compute_rstd_torch(x, eps)
-
-
-def rms_norm_backward_torch(
-    x: torch.Tensor,
-    dy: torch.Tensor,
-    weight: torch.Tensor,
-    rstd: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """PyTorch reference implementation for standalone RMSNorm backward."""
-    return _TileRMSNorm.rms_norm_backward_torch(x, dy, weight, rstd)
 
 
 class _RMSNormForGemma3(_TileRMSNorm):

--- a/src/tilegym/ops/cutile/rope.py
+++ b/src/tilegym/ops/cutile/rope.py
@@ -9,7 +9,6 @@ from tilegym.backend import register_impl
 
 from .utils import next_power_of_2
 
-# Type aliases for constants
 ConstInt = ct.Constant[int]
 PAD_ZERO = ct.PaddingMode.ZERO
 

--- a/src/tilegym/ops/cutile/silu_and_mul.py
+++ b/src/tilegym/ops/cutile/silu_and_mul.py
@@ -18,8 +18,6 @@ ConstInt = ct.Constant[int]
 
 # To be launched with grid = number of rows (batch_size)
 # each "block" computes an entire row of the ouptut
-
-
 @ct.kernel
 def _silu_and_mul_kernel_row_wise(
     input,

--- a/src/tilegym/ops/cutile/silu_and_mul.py
+++ b/src/tilegym/ops/cutile/silu_and_mul.py
@@ -13,25 +13,13 @@ from tilegym.experimental import experimental_kernel
 
 from .utils import next_power_of_2
 
-# Type aliases for constants
 ConstInt = ct.Constant[int]
-
-
-def _ensure_contiguous(fn):
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        def maybe_to_contiguous(x):
-            return x.contiguous() if isinstance(x, torch.Tensor) else x
-
-        args = [maybe_to_contiguous(arg) for arg in args]
-        kwargs = {k: maybe_to_contiguous(v) for k, v in kwargs.items()}
-        return fn(*args, **kwargs)
-
-    return wrapper
 
 
 # To be launched with grid = number of rows (batch_size)
 # each "block" computes an entire row of the ouptut
+
+
 @ct.kernel
 def _silu_and_mul_kernel_row_wise(
     input,
@@ -118,6 +106,19 @@ def _silu_and_mul_backward_kernel_row_wise(
     da_tile = dc_tile * (b_tile * silu_grad)
     da_tile = ct.astype(da_tile, input.dtype)
     ct.scatter(grad_a, (row_idx, offsets), da_tile, check_bounds=True)
+
+
+def _ensure_contiguous(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        def maybe_to_contiguous(x):
+            return x.contiguous() if isinstance(x, torch.Tensor) else x
+
+        args = [maybe_to_contiguous(arg) for arg in args]
+        kwargs = {k: maybe_to_contiguous(v) for k, v in kwargs.items()}
+        return fn(*args, **kwargs)
+
+    return wrapper
 
 
 def _silu_and_mul_backward(

--- a/src/tilegym/ops/cutile/softmax.py
+++ b/src/tilegym/ops/cutile/softmax.py
@@ -144,8 +144,6 @@ def _softmax_kernel_chunked(
 
 
 # Launch patterns for the kernels:
-
-
 def _launch_softmax_kernel(input, output, TILE_SIZE=1024):
     """
     Launch the basic cuTile softmax kernel with static persistent scheduling

--- a/src/tilegym/ops/cutile/softmax.py
+++ b/src/tilegym/ops/cutile/softmax.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-
 import math
 
 import cuda.tile as ct
@@ -13,7 +12,6 @@ from tilegym.experimental import experimental_kernel
 
 from .utils import next_power_of_2
 
-# Type aliases for constants
 ConstInt = ct.Constant[int]
 
 
@@ -146,6 +144,8 @@ def _softmax_kernel_chunked(
 
 
 # Launch patterns for the kernels:
+
+
 def _launch_softmax_kernel(input, output, TILE_SIZE=1024):
     """
     Launch the basic cuTile softmax kernel with static persistent scheduling
@@ -266,6 +266,9 @@ def _launch_softmax_kernel_chunked(
             TILE_SIZE,
         ),
     )
+
+
+# Autograd Function Classes
 
 
 class _Softmax(torch.autograd.Function):

--- a/src/tilegym/ops/cutile/splitk_reduce.py
+++ b/src/tilegym/ops/cutile/splitk_reduce.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: MIT
+
 import math
 
 import cuda.tile as ct
@@ -10,7 +11,6 @@ from tilegym.backend import register_impl
 
 from .utils import next_power_of_2
 
-# Type aliases for constants
 ConstInt = ct.Constant[int]
 ConstBool = ct.Constant[bool]
 

--- a/src/tilegym/ops/cutile/swiglu.py
+++ b/src/tilegym/ops/cutile/swiglu.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-
 import cuda.tile as ct
 import torch
 import torch.nn as nn
@@ -25,10 +24,6 @@ def _silu(x):
     return x * _sigmoid(x)
 
 
-def _ceildiv(a, b):
-    return -(a // -b)
-
-
 @ct.kernel
 def _swiglu_forward_kernel(a, b, c, TILE_SIZE: ct.Constant[int]):
     row = ct.bid(0)
@@ -40,34 +35,6 @@ def _swiglu_forward_kernel(a, b, c, TILE_SIZE: ct.Constant[int]):
     a_tile_f32 = a_tile.astype(ct.float32)
     c_tile = _silu(a_tile_f32).astype(a.dtype) * b_tile
     ct.scatter(c, (row, offsets), c_tile, check_bounds=True)
-
-
-def _swiglu_forward(a, b):
-    """
-    a: (batch_size, seq_len, intermediate_size)
-    b: (batch_size, seq_len, intermediate_size)
-    """
-    ori_shape = a.shape
-    n_cols = ori_shape[-1]
-    a = a.view(-1, n_cols)
-    b = b.view(-1, n_cols)
-    c = torch.empty_like(a)
-    n_rows = a.shape[0]
-
-    TILE_SIZE = next_power_of_2(n_cols)
-    grid = (n_rows,)
-    ct.launch(
-        torch.cuda.current_stream(),
-        grid,
-        _swiglu_forward_kernel,
-        (
-            a,
-            b,
-            c,
-            TILE_SIZE,
-        ),
-    )
-    return c.view(*ori_shape)
 
 
 # Backward kernel for swiglu
@@ -102,6 +69,38 @@ def _swiglu_backward_kernel(dc, a, b, da, db, TILE_SIZE: ct.Constant[int]):
     silu_grad = sigmoid_a * (1.0 + a_tile_f32 * one_minus_sigmoid)
     da_tile = dc_tile * b_tile_f32 * silu_grad
     ct.store(da, index=(row, col), tile=da_tile.astype(a.dtype))
+
+
+def _ceildiv(a, b):
+    return -(a // -b)
+
+
+def _swiglu_forward(a, b):
+    """
+    a: (batch_size, seq_len, intermediate_size)
+    b: (batch_size, seq_len, intermediate_size)
+    """
+    ori_shape = a.shape
+    n_cols = ori_shape[-1]
+    a = a.view(-1, n_cols)
+    b = b.view(-1, n_cols)
+    c = torch.empty_like(a)
+    n_rows = a.shape[0]
+
+    TILE_SIZE = next_power_of_2(n_cols)
+    grid = (n_rows,)
+    ct.launch(
+        torch.cuda.current_stream(),
+        grid,
+        _swiglu_forward_kernel,
+        (
+            a,
+            b,
+            c,
+            TILE_SIZE,
+        ),
+    )
+    return c.view(*ori_shape)
 
 
 def _swiglu_backward(dc, a, b):

--- a/src/tilegym/suites/liger/cutile/fused_linear_jsd.py
+++ b/src/tilegym/suites/liger/cutile/fused_linear_jsd.py
@@ -134,7 +134,10 @@ def _fused_linear_jsd_forward(
         if compute_grad_input:
             grad_input[start_idx:end_idx] = grad_chunk_dtype @ student_weight
         if compute_grad_weight:
-            grad_weight.add_(grad_chunk_dtype.t() @ student_input_chunk)
+            if grad_weight.dtype == grad_chunk_dtype.dtype == student_input_chunk.dtype:
+                grad_weight.addmm_(grad_chunk_dtype.t(), student_input_chunk)
+            else:
+                grad_weight.add_(grad_chunk_dtype.t() @ student_input_chunk)
 
     return total_loss, grad_input, grad_weight
 

--- a/tests/benchmark/bench_layernorm.py
+++ b/tests/benchmark/bench_layernorm.py
@@ -35,6 +35,9 @@ def get_supported_backends():
     return [p for p in ALL_BACKENDS if p is not None]
 
 
+_BENCHMARK_N_VALS = [256, 1024, 2048, 4096, 8192, 16384]
+
+
 def create_persistent_benchmark_config(num_rows, dtype):
     """Create benchmark config for persistent layer norm test"""
     available_backends = get_supported_backends()
@@ -46,7 +49,7 @@ def create_persistent_benchmark_config(num_rows, dtype):
 
     return triton.testing.Benchmark(
         x_names=["N"],
-        x_vals=[256, 1024, 2048, 4096, 8192, 16384],
+        x_vals=_BENCHMARK_N_VALS,
         line_arg="backend",
         line_vals=list(backends),
         line_names=list(names),
@@ -71,7 +74,7 @@ def create_legacy_benchmark_config(num_rows, dtype):
 
     return triton.testing.Benchmark(
         x_names=["N"],
-        x_vals=[256, 1024, 2048, 4096, 8192, 16384],
+        x_vals=_BENCHMARK_N_VALS,
         line_arg="backend",
         line_vals=list(backends),
         line_names=list(names),

--- a/tests/benchmark/bench_rmsnorm.py
+++ b/tests/benchmark/bench_rmsnorm.py
@@ -80,7 +80,7 @@ def create_benchmark_config(dtype):
         line_names=labels,
         styles=styles,
         ylabel="GB/s",
-        plot_name=f"rmsnorm-{dtype_name}-M{M_DEFAULT}",
+        plot_name=f"rmsnorm-{dtype_name}-M{M_DEFAULT}-GBps",
         args={
             "dtype": dtype,
             "M": M_DEFAULT,

--- a/tests/ops/test_gemma_attention.py
+++ b/tests/ops/test_gemma_attention.py
@@ -234,7 +234,10 @@ class TestGemmaAttention(common.PyTestCase):
             pytest.skip("Skip on sm80: gemma attention requires SM90+")
 
         self.setUp()
-        set_backend(backend)
+        try:
+            set_backend(backend)
+        except Exception as e:
+            pytest.skip(f"Backend is not supported: {e}")
         device = torch.device("cuda")
 
         # Create test data

--- a/tests/ops/test_gemma_attention_decode.py
+++ b/tests/ops/test_gemma_attention_decode.py
@@ -181,7 +181,10 @@ class TestGemmaAttentionDecode(common.PyTestCase):
         if arch in ["sm80"]:
             pytest.skip("Skip on sm80: Gemma attention decode requires SM90+")
         self.setUp()
-        set_backend(backend)
+        try:
+            set_backend(backend)
+        except Exception as e:
+            pytest.skip(f"Backend is not supported: {e}")
         device = torch.device("cuda")
 
         # Create test data


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->

Update codes.

This PR contains **7** new commit(s).

### Commits included:

```
af2bd35 Reformat: remove some meaningless blank lines
f1762cb fix(bench): add -GBps suffix to rmsnorm plot_name for CI summary parsing
86e3dfe fix(sm80): A100 guards and occupancy-aware defaults for norm kernels
460cf79 [NFC] canonicaize section layout for cutile kernels under ops dir
4c957f7 [liger] optimize fused_linear_jsd
40b4b54 [tests] test_gemma_attention_decode: guard set_backend in test_op with try/skip
a8631ce [tests] test_gemma_attention: guard set_backend in test_op with try/skip
```

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: ["ops", "benchmark"]
```

## Checklist
- [ ] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

