### PR TITLE
cutile recurrent_gated_delta_rule: autotune + persistent variant & other updates

### DIFF
--- a/.agents/skills/cutile-autotuning/SKILL.md
+++ b/.agents/skills/cutile-autotuning/SKILL.md
@@ -13,10 +13,11 @@ Add autotuning to CuTile kernels using the `exhaustive_search` API with tune-onc
 Follow the decision tree to classify the kernel, design a search space, implement the tune-once/cache/launch pattern, and validate performance.
 
 1. **Classify** — use the Decision Tree to determine search dimensions (occupancy-only vs full tile search)
-2. **Design search space** — select the matching template from `references/kernel-type-templates.md`; prune to ≤ 30 configs via arch filters
+2. **Design search space** — select the matching template from `references/kernel-type-templates.md`; prune to ≤ 30 configs in the final code via arch filters (directed exploration probes may temporarily exceed this — see Design Philosophy)
 3. **Implement** — add `exhaustive_search` + cache + `ct.launch` following the Step-by-Step Workflow; handle in-place writes with split-buffer if needed
 4. **Test** — run correctness with autotune enabled and with `DISABLE_AUTOTUNE=1`
 5. **Validate** — A/B benchmark against fixed best-known config; see `references/search-strategies.md`
+6. **Shrink** — prune dead-weight configs that never win, targeting ≤ 8 configs per architecture to minimize compilation cost (Step 10)
 
 ## Task Router — Jump to What You Need
 
@@ -74,7 +75,7 @@ def my_op(x, output):
 Key rules:
 - **Tune once, cache, launch directly** — `exhaustive_search` runs only on first call per shape; subsequent calls use cached config + `ct.launch` with zero overhead
 - For in-place kernels use split-buffer during search (separate input/output tensors)
-- Keep ≤ 30 configs total
+- Keep ≤ 30 configs in final code (see Design Philosophy for temporary directed probes)
 - `exhaustive_search` requires a `Sequence` (list/tuple) — convert generators with `list()`
 - **Search space must include the original fixed config** — this guarantees autotuning never makes performance worse
 
@@ -82,9 +83,18 @@ Key rules:
 
 For complex kernels (matmul with tile sizes, FMHA, FP8 with num_ctas), read the full guide below + [`kernel-type-templates.md`](references/kernel-type-templates.md).
 
-> **⚠️ Two pitfalls catch almost everyone — check before submitting:**
+> **⚠️ Three pitfalls catch almost everyone — check before submitting:**
+> - **`replace_hints` on hot path?** → Cache BOTH config AND kernel object from `exhaustive_search`. Calling `replace_hints()` every invocation recompiles (100–500× slower) → Pitfall #7
 > - **In-place kernel** (writes back to input tensor)? → MUST use split-buffer pattern during search → Pitfall #1
 > - **Search space empty?** → Check arch filters and `num_ctas` constraints → Pitfall #5
+
+> **Minimum coverage**: On sm100+, FMHA/matmul/varlen search spaces must include both `num_ctas=1` and `num_ctas=2`. For core dimensions (tile sizes, occupancy), keep at least 2 distinct values even if unsure which is better — let `exhaustive_search` decide.
+
+> **When to stop tuning**: A mean speedup in [0.98, 1.02] means your *current* search space isn't helping — but doesn't mean no config will help. Before stopping, check whether you've covered the key dimensions for this kernel type (consult `references/kernel-type-templates.md`). If the search space already covers the template's recommended dimensions and the best result is still noise-floor, then stop — further micro-adjustments won't help. If key dimensions are missing (e.g., never tried `num_ctas=2` for a dual-GEMM kernel), expand the search space rather than giving up.
+>
+> Once correctness tests pass and the autotuned kernel shows speedup over the fixed-config baseline, **stop — do not re-run to "confirm".** GPU kernel timing fluctuates ±5–10 % between invocations due to clock scaling and OS scheduling; a subsequent timing dip does not mean your code is wrong.
+>
+> To improve speedup, only modify the autotune search space (configs, tile sizes, occupancy, num_ctas). Do not modify other code (Python wrapper, stream management, etc.) to chase speedup — kernel performance is determined by the config selection, not by host-side code.
 
 ## Reading Guide
 
@@ -93,9 +103,13 @@ For complex kernels (matmul with tile sizes, FMHA, FP8 with num_ctas), read the 
 
 **5-step summary**: Classify kernel → Design search space ([`parameter-space-design.md`](references/parameter-space-design.md)) → Implement using template ([`kernel-type-templates.md`](references/kernel-type-templates.md)) → Validate with A/B test → Check Pitfall Checklist.
 
+**Reading references**: Read only the reference relevant to your kernel type — e.g., for FMHA, read the Template 5 section in `references/kernel-type-templates.md`; for hardware constraints, read only the target architecture's section. Avoid reading all references end-to-end when a targeted lookup suffices.
+
 ## Design Philosophy
 
-**Build a small, precise search space bottom-up — not a large space trimmed down.** CuTile compilation is much heavier than Triton (~0.5-1s per config), so 30 configs is the hard upper limit. The approach is: classify the kernel type first, then construct only the relevant configs for that type and architecture. Never start with a large cartesian product and prune — start with the minimum viable space and expand only if data shows it's needed.
+**Build a small, precise search space bottom-up — not a large space trimmed down.** CuTile compilation is much heavier than Triton (~0.5-1s per config), so the **final code** should contain ≤ 30 configs. The approach is: classify the kernel type first, then construct only the relevant configs for that type and architecture.
+
+**Directed exploration during development**: If the initial template configs yield speedup < 1.0, you may run a *temporary* larger probe (30–100 configs) via `bash + python3 -c` to identify which dimensions matter — but this probe must be **directional**, not a blind cartesian product. Use the kernel type classification to decide *which* dimensions to vary (e.g. for dual-GEMM, probe `num_ctas × occupancy` while fixing tile sizes; for FMHA, probe `TILE_M × num_ctas` while fixing TILE_N). Once the probe identifies the winning region, lock the final code's search space to ≤ 8 top candidates. Do NOT write the large probe into the source file — it is a one-shot diagnostic tool.
 
 ## Decision Tree: What Search Dimensions Does This Kernel Need?
 
@@ -341,10 +355,11 @@ grid_fn=lambda cfg: (NUM_SMS, 1, 1)
    - **Start from reference configs**, not from scratch. Clone configs from existing production kernels of the same type (e.g., `ops/cutile/matmul.py` for GEMM) and adapt. For GEMM-class kernels, `nvMatmulHeuristics` can suggest 8-16 high-quality candidates that reach 96-99% peak performance — see [`parameter-space-design.md`](references/parameter-space-design.md) for details.
    - Detect the current GPU architecture with `torch.cuda.get_device_capability()`.
    - **Target one architecture at a time.** Generate configs only for the detected arch. Do NOT add branches for other architectures — they cannot be tested on this machine and untested code paths are unreliable. If multi-arch support is needed later, add it in a separate pass on the appropriate hardware.
+   - **When modifying code that already has autotune configs**: see "Handling Existing Autotune Configs (Multi-Architecture)" below. The "do NOT add branches" rule means do not *invent new configs* for untested architectures — it does NOT mean remove existing configs that were previously validated.
    - Identify tunable parameters (tile sizes, occupancy, num_ctas)
    - **Ensure the search space includes the original fixed config** (or an equivalent). This guarantees that the autotuned result is at least as good as the original — no performance regression is possible.
-   - If the generated set exceeds 30, apply tile size filters and pruning rules to reduce it to ≤ 30
-   - *VERIFY*: Total configs ≤ 30 (hard limit: CuTile compilation is heavy, >30 configs will timeout).
+   - If the generated set exceeds 30, apply tile size filters and pruning rules to reduce it to ≤ 30 in the final code
+   - *VERIFY*: Total configs in final code ≤ 30 (CuTile compilation is heavy, >30 configs will timeout). Temporary directed probes during development (30–100 configs, run via `bash + python3 -c`) are allowed — see Design Philosophy.
 
 6. **Implement** the tune-once/cache/launch pattern:
    - Define a `_cache` dict at module level
@@ -358,12 +373,11 @@ grid_fn=lambda cfg: (NUM_SMS, 1, 1)
    - `hints_fn` passes `occupancy` and/or `num_ctas` from config
    - *VERIFY*: `exhaustive_search` receives a `list()` of configs, not a raw generator.
 
-7. **(MANDATORY) Add DISABLE_AUTOTUNE support** for CI and profiling: check `os.environ.get("DISABLE_AUTOTUNE", "0") == "1"` — when set, skip `exhaustive_search` entirely and fall back to `ct.launch` with the first valid config. This is required for:
+7. **(Optional) Add DISABLE_AUTOTUNE support** for CI and profiling: check `os.environ.get("DISABLE_AUTOTUNE", "0") == "1"` — when set, skip `exhaustive_search` entirely and fall back to `ct.launch` with the first valid config. Useful for:
    - CI determinism (autotune adds variable wall time)
    - NCU profiling (prevents autotune trial runs from cluttering the trace — see Pitfall #4)
    - Debugging (isolates kernel correctness from autotune behavior)
-   Place the check *before* the cache lookup so that `DISABLE_AUTOTUNE=1` bypasses all autotune logic. Provide a hardcoded fallback config in case the generator yields zero configs.
-   - *VERIFY*: Running with `DISABLE_AUTOTUNE=1` produces correct results and does not call `exhaustive_search`.
+   Skip this step if your task only requires adding autotuning and the project's tests don't check for `DISABLE_AUTOTUNE`.
 
 8. **Test**: Run correctness tests first (`pytest -k "test_op and cutile"`), then benchmark.
    - *VERIFY*: Correctness passes with autotune enabled AND with `DISABLE_AUTOTUNE=1`.
@@ -371,18 +385,140 @@ grid_fn=lambda cfg: (NUM_SMS, 1, 1)
 9. **Validate with A/B test**: Compare autotune version vs fixed best-known config. See [`search-strategies.md`](references/search-strategies.md) for methodology.
    - *VERIFY*: Autotune version ≥ baseline (or within noise). If worse, check that the search space includes the original fixed config, and that `replace_hints` is being used correctly.
 
-10. **(MANDATORY) Run the test and verify performance before submitting.**
+10. **Shrink the search space** — reduce compilation cost without losing performance.
 
-    Execute the provided test script (e.g. `ENABLE_TILE=1 python3 test.py`) and check:
-    - `correctness: PASS`
-    - `speedup_over_fixed >= 1.0` (autotuned must not be slower than fixed baseline)
+    Templates provide broad search spaces as a starting point (e.g., 9 configs for varlen attention). Not all configs contribute to finding the optimal one — on a given architecture and kernel shape, many large-tile or multi-CTA configs compile for seconds each but are never selected. The goal of this step is to *prune the dead weight* so the final committed code has 5–8 configs per architecture instead of 10–15.
 
-    If `speedup_over_fixed < 1.0`:
-    - Check that the search space includes the original fixed config (this guarantees no regression)
-    - Check if `replace_hints` is being called on every code path — revisit Step 2 (if any path skips `replace_hints`, the decorator's fixed hints are used instead of autotuned values)
-    - Expand search space if all configs perform similarly (see `references/parameter-space-design.md` → "Adapting Search Space")
+    **Why this matters**: Each config in `exhaustive_search` requires a full JIT compilation + warmup + benchmark of the kernel. For complex kernels (FMHA, varlen attention), this costs 2–4 seconds *per config*. Cutting from 9 to 5 configs saves 8–16 seconds of one-time autotuning cost per unique shape, with zero performance loss.
 
-    *⚠️ DO NOT submit without running the test at least once. Writing correct-looking code is not sufficient — autotuning bugs (silent hint override, split-buffer omission) are only caught at runtime.*
+    **Procedure**:
+
+    1. After Step 9 passes, you already have a working autotuned kernel with the full template search space. Now run the test on 2–3 representative shapes and observe which config wins for each shape. You can inspect this by temporarily adding a print inside the cache-miss block:
+       ```python
+       print(f"[autotune] shape={cache_key[:5]} best={result.best.config} "
+             f"time={result.best.time_ms:.3f}ms  "
+             f"configs_tried={len(result.successes)}")
+       ```
+
+    2. Identify which configs are *competitive* — within 5% of the best for at least one shape. Configs that are never within 5% of the best across any test shape are *dead weight*.
+
+    3. Remove dead-weight configs from the generator. Always keep:
+       - The original fixed config (safety net — guarantees no regression)
+       - The config(s) that won on each test shape
+       - Any config within 5% of a winner (may win on untested shapes)
+
+    4. Re-run the test to confirm speedup is unchanged after pruning.
+
+    **Common dead-weight patterns** (prune these first):
+    - `TILE_M=256` configs for attention/varlen kernels where `S_qo` in the test shapes is ≤ 4096 and batch×heads is large — the grid is already saturated at TILE_M=128.
+    - `num_ctas=2` configs for kernels with irregular or small grids — multi-CTA parallelism requires enough CTAs to benefit from cooperative launch, which doesn't hold when `grid[0]` is small.
+    - `occupancy=4` or `occupancy=8` configs on sm100+ for compute-bound kernels — Blackwell typically prefers lower occupancy (1–2) with larger tiles.
+
+    **Target**: ≤ 8 configs per architecture branch in the final code. This keeps the one-time tuning cost under 25 seconds even for the most complex kernels (FMHA, varlen attention).
+
+    - *VERIFY*: Config count ≤ 8 per architecture. `speedup_over_fixed` unchanged after pruning.
+
+11. **(MANDATORY) Verify correctness and performance before finalizing.**
+
+    The verification requirements depend on the task type. In ALL cases, start with the code-level sanity check, then apply the task-specific verification.
+
+    ---
+
+    **A. Code-level sanity check (ALL tasks — do this first)**
+
+    Review your implementation for known performance anti-patterns. These checks catch *implementation bugs*, not algorithmic issues — they apply regardless of whether you are adding, modifying, or fixing autotune code.
+
+    - `replace_hints` must be called *exactly once* per config and the returned kernel object cached (Pitfall #7). If `replace_hints` appears on the hot path (outside the `if cache_key not in` block), you have a recompilation bug that causes 100-500× slowdown.
+    - `exhaustive_search` must be inside the cache-miss block, not called on every kernel invocation.
+    - The fast path should only do: cache lookup → `ct.launch` with the cached tuned kernel. No JIT-triggering calls in between.
+    - The cache must store `(best_cfg, tuned_kernel)` together — not just `best_cfg` alone.
+
+    ---
+
+    **B. Task-specific verification**
+
+    **B1. Adding or modifying autotune configs** (the original code is correct):
+
+    - *Correctness*: autotuned kernel output matches the reference (e.g. `torch` or fixed-config kernel) within tolerance.
+    - *Performance*: autotuned kernel must be *at least as fast* as the original fixed-config kernel. If it is slower:
+      - Check that the search space includes the original fixed config (this guarantees no regression).
+      - Check if `replace_hints` is being called on every code path — revisit Step 2 (if any path skips `replace_hints`, the decorator's fixed hints are used instead of autotuned values).
+      - Expand search space if all configs perform similarly (see `references/parameter-space-design.md` → "Adapting Search Space").
+
+    **B2. Fixing a correctness bug** (the original code produces wrong results):
+
+    - *Correctness is the primary goal*: the fixed kernel must produce correct results. Do NOT compare speedup against the broken original — a correct-but-slower kernel is always better than a fast-but-wrong one.
+    - *Perf sanity check*: after fixing, verify that the implementation is not catastrophically slow due to an implementation bug (e.g. Pitfall #7). Two ways to check:
+      1. *Code review*: confirm the code-level sanity check (Section A above) passes — this catches the most common perf bugs.
+      2. *Runtime check*: if possible, compare your fixed+autotuned kernel against a simple correct baseline (e.g. the equivalent `torch` operation, or the kernel launched with a single hardcoded config and no autotuning). Your autotuned version should not be slower than this naive baseline. Minor overhead from the fix itself (e.g. split-buffer allocation) is acceptable.
+
+    ---
+
+    *⚠️ Autotuning bugs (silent hint override, split-buffer omission, hot-path recompilation) are only caught at runtime — always verify by running the kernel, not just by reading the code.*
+
+### Handling Existing Autotune Configs (Multi-Architecture)
+
+When adding autotune to a kernel, the source code may already contain autotune configs from a previous pass on different hardware. There are three scenarios:
+
+**Scenario 1: No existing autotune code.** The source has no autotune at all — follow the standard "Adding Autotune to a New Kernel" workflow above. Generate configs for the current GPU architecture only.
+
+**Scenario 2: Existing autotune, but no config for the current architecture.** The source already has autotune with configs for other architecture(s) (e.g., sm103) but NOT for the current GPU (e.g., sm100). Steps:
+
+1. Detect the current architecture with `torch.cuda.get_device_capability()`.
+2. Check whether the existing config generator already uses architecture-conditional branching (i.e., `if/elif` on device capability).
+   - **If yes** (conditional yield structure exists): Add a new `elif` branch for the current architecture. Preserve all existing branches **unchanged** — do not modify their config values.
+   - **If no** (flat configs, no architecture branching): Add an `if` branch for the current architecture with new configs, and keep the existing flat configs in the `else` block as the default fallback. This ensures that all other architectures continue to use the original configs unchanged — the code modification must not alter kernel behavior on any architecture other than the current one.
+3. Design configs for the current architecture following the standard workflow (Steps 4–10 above).
+4. Validate only the current architecture's configs (Step 11). Other branches are assumed correct since they were previously validated on their respective hardware.
+
+Example — adding sm100 to a generator that already has sm103 configs (conditional structure exists):
+
+```python
+def _my_autotune_configs():
+    gpu_capability = torch.cuda.get_device_capability()
+
+    if gpu_capability == (10, 0):                   # sm100 (B200)
+        # NEW: configs for sm100 (added in this pass)
+        for occ in [1, 2, 4]:
+            yield SimpleNamespace(occupancy=occ, TILE_M=128, TILE_N=128)
+    elif gpu_capability == (10, 3):                  # sm103 (GB300)
+        # EXISTING: configs for sm103 (do NOT modify)
+        for occ in [2, 4, 8]:
+            yield SimpleNamespace(occupancy=occ, TILE_M=256, TILE_N=128)
+    else:
+        # Fallback for unknown architectures
+        yield SimpleNamespace(occupancy=2, TILE_M=128, TILE_N=128)
+```
+
+Example — adding current-arch configs to flat (non-branching) code:
+
+```python
+# BEFORE: flat configs (no architecture branching)
+def _my_autotune_configs():
+    for occ in [2, 4, 8]:
+        yield SimpleNamespace(occupancy=occ, TILE_M=256, TILE_N=128)
+
+# AFTER: if-branch for current arch, original configs become the else-default
+def _my_autotune_configs():
+    gpu_capability = torch.cuda.get_device_capability()
+
+    if gpu_capability == (10, 0):                    # sm100 (B200) — current arch
+        # NEW: configs designed and tested for sm100
+        for occ in [1, 2, 4]:
+            yield SimpleNamespace(occupancy=occ, TILE_M=128, TILE_N=128)
+    else:
+        # UNCHANGED: original flat configs as default for all other architectures
+        for occ in [2, 4, 8]:
+            yield SimpleNamespace(occupancy=occ, TILE_M=256, TILE_N=128)
+```
+
+**Scenario 3: Existing autotune with config for the current architecture.** The source already has a conditional branch for the current GPU architecture. Only modify the current architecture's branch (e.g., adjust tile sizes, add/remove occupancy values). Do **NOT** modify or remove configs for other architectures.
+
+**Key principles:**
+
+- **"Target one architecture at a time" means only *add or modify* configs for the detected arch** — it does NOT mean delete existing configs for other architectures. Existing configs were validated on their respective hardware and must be preserved.
+- **When adding architecture branching to flat configs**: add an `if` for the current architecture and keep existing configs in the `else` as the default. This guarantees that the code change does not alter kernel behavior on any non-current architecture — the `else` path is identical to the original flat code.
+- **Test/validation (Step 11) only applies to the current architecture's branch.** Other branches are assumed correct since they were previously validated on their respective hardware. You cannot test them here because you don't have access to that hardware.
 
 ### Integration with torch.autograd.Function
 
@@ -434,7 +570,7 @@ ct.launch(stream, grid, tuned_kernel, (Q, Q, ...))  # Q_in == Q_out (in-place)
 
 **Also wrong**: Using `Q.clone()` in `args_fn` — this adds ~4us per clone, which is fatal for small kernels (~5us). The clone+copy pattern caused 0.48x performance in RoPE.
 
-**Tip — isolating output buffers in `args_fn`**: For kernels that write to a dedicated output tensor (not in-place), use `c.clone()` inside `args_fn` to prevent trial runs from overwriting the final output buffer:
+**Tip — isolating output buffers in `args_fn`**: For kernels that write to a dedicated output tensor (not in-place), you *may* use `c.clone()` inside `args_fn` to prevent trial runs from overwriting the final output buffer. This is only needed when the caller reads the output tensor after `exhaustive_search` returns — if you immediately overwrite it with `ct.launch`, clone is unnecessary:
 
 ```python
 # Output tensor c will be overwritten by each trial — clone it so trials don't
@@ -452,12 +588,12 @@ This is safe because the clone cost (~4us) is negligible relative to compute-bou
 
 ### Pitfall #2: Compilation Timeout
 
-**Problem**: >30 configs causes compilation to exceed 5 minutes. CuTile compilation is heavier than Triton.
+**Problem**: >30 configs in the **final code** causes compilation to exceed 5 minutes. CuTile compilation is heavier than Triton.
 
 **Solution**:
-- Keep total search space ≤ 30 configs — apply arch filters, tile size filters, and pruning rules until you're under the limit
+- Keep the final code's search space ≤ 30 configs — apply arch filters, tile size filters, and pruning rules until you're under the limit
 - Use architecture-conditional yield to only generate relevant configs
-- Prune the search space using architecture-conditional yield and size filters until total configs ≤ 30
+- If the initial template configs don't beat baseline, use a temporary directed probe (30–100 configs, via bash, not written to file) to identify winning dimensions, then lock the final code to ≤ 8 top candidates (see Design Philosophy)
 
 **Real example**: Grouped GEMM expanded from 4 to 32 configs → all backward tests timed out. Reverted to occupancy-only (4 configs) with no performance loss.
 
@@ -549,7 +685,7 @@ After adding autotuning, the following kernel-level optimizations may yield addi
 
 ## Differences from Triton Autotune
 
-Key differences: Triton uses `@triton.autotune` decorator with `Config(...)` objects; CuTile uses `exhaustive_search()` with `SimpleNamespace` configs + separate cache + `ct.launch`. CuTile has no `num_warps`/`num_stages` (compiler decides) — only tile sizes + `occupancy` + `num_ctas`. CuTile compilation is heavier (keep ≤30 configs). CuTile cache is user-managed in-memory (no automatic persistence). CuTile separates `args_fn` (kernel args) from `hints_fn` (compiler hints).
+Key differences: Triton uses `@triton.autotune` decorator with `Config(...)` objects; CuTile uses `exhaustive_search()` with `SimpleNamespace` configs + separate cache + `ct.launch`. CuTile has no `num_warps`/`num_stages` (compiler decides) — only tile sizes + `occupancy` + `num_ctas`. CuTile compilation is heavier (keep ≤30 configs in final code). CuTile cache is user-managed in-memory (no automatic persistence). CuTile separates `args_fn` (kernel args) from `hints_fn` (compiler hints).
 
 ## Reference Documents
 

--- a/.agents/skills/cutile-autotuning/references/hardware-constraints.md
+++ b/.agents/skills/cutile-autotuning/references/hardware-constraints.md
@@ -4,16 +4,17 @@ Architecture-specific constraints that affect autotune parameter selection. All 
 
 ## Architecture Summary
 
-| Property | sm90 (H100) | sm100 (B200) | sm120 (5090) | sm80/sm86 (A100/A10) |
-|----------|-------------|-------------|-------------|----------------------|
-| Shared memory / SM | 228 KB | 228 KB | 128 KB | 164 KB (A100) |
-| Register file / SM | 256 KB | 256 KB | 256 KB | 256 KB |
-| Max CTAs / SM | 32* | 32* | 32* | 32* |
-| CGA support (num_ctas>1) | Yes | Yes | No (use num_ctas=1) | No (use num_ctas=1) |
-| TMA multicast | Yes | Yes | No | No |
-| Preferred tile size | Medium (64-128) | 64-256 (standard); 512 only in specific matmul | Small (64-128) | Small (64-128) |
-| Preferred num_ctas | 1-2 | 2-4 | 1 | 1 only |
-| Preferred occupancy | 2 | 1 | 1-4 | 1-2 |
+| Property | sm90 (H100) | sm100 (B200) | sm103 (GB300) | sm120 (5090) | sm80/sm86 (A100/A10) |
+|----------|-------------|-------------|--------------|-------------|----------------------|
+| Shared memory / SM | 228 KB | 228 KB | 228 KB | 128 KB | 164 KB (A100) |
+| Register file / SM | 256 KB | 256 KB | 256 KB | 256 KB | 256 KB |
+| SMs | 132 | 128 | 152 | 84 | 108 (A100) |
+| Max CTAs / SM | 32* | 32* | 32* | 32* | 32* |
+| CGA support (num_ctas>1) | Yes | Yes | Yes | No (use num_ctas=1) | No (use num_ctas=1) |
+| TMA multicast | Yes | Yes | Yes | No | No |
+| Preferred tile size | Medium (64-128) | 64-256 (standard); 512 only in specific matmul | same as sm100 | Small (64-128) | Small (64-128) |
+| Preferred num_ctas | 1-2 | 2-4 | 2-4 | 1 | 1 only |
+| Preferred occupancy | 2 | 1 | 1 | 1-4 | 1-2 |
 
 \* Max CTAs / SM is a practical CuTile scheduling limit that depends on shared memory allocation per CTA. The hardware maximum may be higher.
 
@@ -42,6 +43,12 @@ Grouped GEMM persistent kernel vs Triton (kernel-only via CUDAGraph):
 | (8, 128, 512, 512) | 8.9us | 5.4us | 0.60x (faster) |
 | (8, 256, 2048, 1024) | 92.6us | 29.8us | 0.32x |
 | (16, 128, 2048, 1024) | 147.4us | 37.8us | 0.26x |
+
+## sm103 (Blackwell GB300)
+
+sm_103 is a variant of sm_100 with 152 SMs (vs 128 on B200). SMEM, register file, CGA, and TMA multicast behavior are identical to sm_100. Use the same configs as sm_100 — `gpu_capability[0] >= 10` covers both. The extra SMs may shift the occupancy/num_ctas sweet spot slightly (more SMs → higher parallelism → `num_ctas=2` can be more beneficial), but the same template configs apply.
+
+Detect with: `torch.cuda.get_device_capability() == (10, 3)`
 
 ## sm120 (Blackwell 5090)
 
@@ -114,6 +121,7 @@ Key constraint: TILE_M/N ≤ 128 (larger tiles spill on sm80). TILE_K ∈ {32, 6
 |-------------|-------------------|-------|
 | sm90 (H100) | 1, 2, 4 | CGA support; TMA multicast with num_ctas > 1 |
 | sm100 (B200) | 1, 2, 4 | Full CGA; best TMA multicast |
+| sm103 (GB300) | 1, 2, 4 | Same as sm100; 152 SMs |
 | sm120 (5090) | 1 only | CGA hardware exists but multi-CTA yields no benefit in practice; always use num_ctas=1 |
 | sm80/sm86 (Ampere) | 1 only | No CGA support; >1 will error |
 
@@ -163,7 +171,7 @@ x = ct.gather(data, offsets, padding_value=0)
 
 ### Impact on Autotune
 
-FP8 GEMM ablation study (P5/task16, 5090, 1024x2048x1024):
+FP8 GEMM ablation study (5090, 1024x2048x1024):
 
 | Factor | Impact when removed |
 |--------|-------------------|
@@ -226,7 +234,7 @@ Each unique (tile_sizes + hints) combination triggers a full kernel recompilatio
 | 24 (block_m x occ x swap_ab) | 10-24s | ~0.5-1s |
 | 32 (full tile search) | >5min (TIMEOUT) | >10s for complex tiles |
 
-**Hard limit**: Keep total configs ≤ 30. Beyond this, compilation will timeout or take unacceptably long.
+**Hard limit**: Keep total configs in final code ≤ 30. Beyond this, compilation will timeout or take unacceptably long.
 
 ## Occupancy Guidelines per Kernel Type
 

--- a/.agents/skills/cutile-autotuning/references/kernel-type-templates.md
+++ b/.agents/skills/cutile-autotuning/references/kernel-type-templates.md
@@ -507,37 +507,29 @@ import math
 import torch
 from types import SimpleNamespace
 
-def _fmha_autotune_configs(head_dim=None, seq_len=None):
+def _fmha_autotune_configs(head_dim=None):
     """Internal build: architecture-conditional with num_ctas/occupancy.
     Release build uses head_dim-keyed tile configs (TILE_M/TILE_N only, no hints).
 
-    Sequence-length-dependent tile selection (from Flash Attention tuning):
-      SeqLen ≤ 2048  → 64×64 optimal (maximizes parallelism)
-      SeqLen = 4096   → 128×128 or 64×64 (balanced)
-      SeqLen ≥ 8192  → 256×128 optimal (memory efficiency)
-
-    When seq_len is provided, configs are pre-filtered to the most relevant tiles.
-    When seq_len is None, all tiles are included and exhaustive_search picks the best.
+    All configs are yielded unconditionally per arch — exhaustive_search picks the
+    best for the actual workload shape at runtime. No seq_len pre-filtering.
     """
     gpu_capability = torch.cuda.get_device_capability()
     if gpu_capability in [(12, 0), (12, 1)]:
-        # sm120
-        yield SimpleNamespace(TILE_M=64, TILE_N=64, num_ctas=1, occupancy=2)
-    elif gpu_capability[0] < 9:
-        # pre-Hopper
+        # sm120: limited tile support
         yield SimpleNamespace(TILE_M=64, TILE_N=64, num_ctas=1, occupancy=2)
         yield SimpleNamespace(TILE_M=128, TILE_N=64, num_ctas=1, occupancy=2)
+    elif gpu_capability[0] < 9:
+        # pre-Hopper: num_ctas=1 only, tiles ≤ 128
+        yield SimpleNamespace(TILE_M=64, TILE_N=64, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_M=128, TILE_N=64, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_M=128, TILE_N=128, num_ctas=1, occupancy=1)
     else:
-        # sm90 / sm100+ (Blackwell)
-        # Short sequences: small tiles maximize parallelism
-        if seq_len is None or seq_len <= 4096:
-            yield SimpleNamespace(TILE_M=128, TILE_N=128, num_ctas=1, occupancy=2)
-        # Medium/long sequences: large tiles improve memory efficiency
-        if seq_len is None or seq_len >= 2048:
-            yield SimpleNamespace(TILE_M=256, TILE_N=128, num_ctas=1, occupancy=1)
-            yield SimpleNamespace(TILE_M=256, TILE_N=128, num_ctas=1, occupancy=2)
-        if seq_len is None or seq_len >= 4096:
-            yield SimpleNamespace(TILE_M=256, TILE_N=128, num_ctas=2, occupancy=2)
+        # sm90 / sm100+ (Blackwell): all tiles + num_ctas variants
+        yield SimpleNamespace(TILE_M=128, TILE_N=128, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_M=256, TILE_N=128, num_ctas=1, occupancy=1)
+        yield SimpleNamespace(TILE_M=256, TILE_N=128, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_M=256, TILE_N=128, num_ctas=2, occupancy=2)
 ```
 
 ### exhaustive_search + cache + ct.launch
@@ -556,7 +548,7 @@ def cutile_autotune_fmha(stream, q, k, v, o, sm_scale, input_pos,
 
     cache_key = (batch_size, num_heads, q_len, hidden_size, is_causal, q.dtype, str(q.device))
     if cache_key not in _fmha_tune_cache:
-        configs = list(_fmha_autotune_configs(hidden_size, seq_len=q_len))
+        configs = list(_fmha_autotune_configs(hidden_size))
 
         if os.environ.get("DISABLE_AUTOTUNE", "0") == "1":
             # Skip search; use first config directly
@@ -961,10 +953,14 @@ def _attention_varlen_autotune_configs():
         yield SimpleNamespace(TILE_M=64,  TILE_N=64,  num_ctas=1, occupancy=2)
         yield SimpleNamespace(TILE_M=128, TILE_N=64,  num_ctas=1, occupancy=2)
         yield SimpleNamespace(TILE_M=128, TILE_N=128, num_ctas=1, occupancy=1)
+        yield SimpleNamespace(TILE_M=128, TILE_N=128, num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_M=64,  TILE_N=128, num_ctas=1, occupancy=2)
     else:
         # Pre-Hopper fallback: num_ctas=1 only
         yield SimpleNamespace(TILE_M=64,  TILE_N=64,  num_ctas=1, occupancy=2)
         yield SimpleNamespace(TILE_M=128, TILE_N=64,  num_ctas=1, occupancy=1)
+        yield SimpleNamespace(TILE_M=128, TILE_N=64,  num_ctas=1, occupancy=2)
+        yield SimpleNamespace(TILE_M=128, TILE_N=128, num_ctas=1, occupancy=1)
 ```
 
 ### Kernel Definition
@@ -1095,7 +1091,9 @@ def _dual_gemm_autotune_configs():
     gpu_capability = torch.cuda.get_device_capability()
 
     if gpu_capability[0] >= 10:
-        # sm100+ (Blackwell): 8 configs — occupancy={1,2}, low occupancy preferred
+        # sm100+ (Blackwell): 11 configs — occupancy={1,2}, num_ctas={1,2}
+        # occ=1 is preferred for most shapes due to 2× register/SHMEM pressure in dual-GEMM,
+        # but occ=2 + num_ctas=2 can win on certain shapes (e.g. sm_103 GB300 linear_gluact).
         yield SimpleNamespace(BLOCK_M=128, BLOCK_N=128, BLOCK_K=64, GROUP_M=8, num_ctas=1, occupancy=1)
         yield SimpleNamespace(BLOCK_M=128, BLOCK_N=128, BLOCK_K=64, GROUP_M=8, num_ctas=1, occupancy=2)
         yield SimpleNamespace(BLOCK_M=128, BLOCK_N=256, BLOCK_K=64, GROUP_M=8, num_ctas=1, occupancy=1)
@@ -1104,6 +1102,10 @@ def _dual_gemm_autotune_configs():
         yield SimpleNamespace(BLOCK_M=256, BLOCK_N=256, BLOCK_K=64, GROUP_M=8, num_ctas=1, occupancy=1)
         yield SimpleNamespace(BLOCK_M=256, BLOCK_N=256, BLOCK_K=64, GROUP_M=8, num_ctas=2, occupancy=1)
         yield SimpleNamespace(BLOCK_M=128, BLOCK_N=256, BLOCK_K=64, GROUP_M=8, num_ctas=2, occupancy=1)
+        # occ=2 + num_ctas=2 probes — multicast + higher occupancy can help on sm_103+
+        yield SimpleNamespace(BLOCK_M=256, BLOCK_N=128, BLOCK_K=64, GROUP_M=8, num_ctas=2, occupancy=2)
+        yield SimpleNamespace(BLOCK_M=128, BLOCK_N=128, BLOCK_K=64, GROUP_M=8, num_ctas=2, occupancy=2)
+        yield SimpleNamespace(BLOCK_M=256, BLOCK_N=256, BLOCK_K=64, GROUP_M=8, num_ctas=2, occupancy=2)
     elif gpu_capability[0] == 9:
         # sm90 (H100): num_ctas=1, occupancy={1,2}
         yield SimpleNamespace(BLOCK_M=64,  BLOCK_N=128, BLOCK_K=64, GROUP_M=8, num_ctas=1, occupancy=1)
@@ -1117,7 +1119,7 @@ def _dual_gemm_autotune_configs():
         yield SimpleNamespace(BLOCK_M=128, BLOCK_N=128, BLOCK_K=32, GROUP_M=8, num_ctas=1, occupancy=1)
 ```
 
-**Why occupancy is biased low**: With two weight tile loads and two accumulators per CTA, the per-CTA resource footprint is ~2× a standard GEMM. On sm100+, `occupancy=2` forces the SM to fit two of these heavy CTAs simultaneously, often causing register spilling to local memory and degrading performance. Eval data confirms `occupancy=1` consistently wins for this kernel type.
+**Why occupancy is biased low**: With two weight tile loads and two accumulators per CTA, the per-CTA resource footprint is ~2× a standard GEMM. On sm100+, `occupancy=2` forces the SM to fit two of these heavy CTAs simultaneously, often causing register spilling to local memory and degrading performance. Benchmarking data confirms `occupancy=1` consistently wins for this kernel type.
 
 ### Kernel Definition
 

--- a/.agents/skills/cutile-autotuning/references/parameter-space-design.md
+++ b/.agents/skills/cutile-autotuning/references/parameter-space-design.md
@@ -220,7 +220,7 @@ The per-architecture configs in the sections above are **starting points** deriv
 - **Problem size**: If `max_dim / TILE_SIZE < 16` for any tile dimension, parallelism is too low. Add smaller tile options (e.g., 64×64 instead of only 256×256) to ensure enough CTAs for full SM occupancy.
 - **Kernel complexity**: Kernels that fuse multiple operations (dual-GEMM, GEMM+activation) use more registers and shared memory per CTA. Use conservative (smaller) tile sizes compared to standalone matmul — e.g., start with 128×128 instead of 256×256.
 - **Non-standard shapes**: Tall-skinny matrices (M >> N or N >> M) benefit from asymmetric tiles (e.g., 256×64 instead of 256×256). Match the tile aspect ratio to the problem shape.
-- **When in doubt**: Start with the recommended configs, *run the test*, and check `speedup_over_fixed`. If it's < 1.0 or only marginally above 1.0, expand the search space with additional tile sizes and re-run. Iterating on test results is more reliable than guessing.
+- **When in doubt**: Start with the recommended configs, benchmark, and compare against the fixed-config baseline. If autotuning shows no improvement or regression, expand the search space with additional tile sizes and re-benchmark. Iterating on measured results is more reliable than guessing.
 
 ## Summary Table
 

--- a/.agents/skills/cutile-autotuning/references/search-strategies.md
+++ b/.agents/skills/cutile-autotuning/references/search-strategies.md
@@ -62,7 +62,7 @@ When autotune alone isn't enough -- use NCU profiling to understand why a kernel
 
 ```
 Step 1: Baseline profiling
-  -> DISABLE_AUTOTUNE=1 ncu --set full -o baseline.ncu-rep python test.py
+  -> DISABLE_AUTOTUNE=1 ncu --set full -o baseline.ncu-rep python my_benchmark.py
   -> Identify bottleneck: compute, memory, or latency
 
 Step 2: Classify bottleneck

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -131,7 +131,17 @@ jobs:
               f.write('\n'.join(deps))
           print('Auditing deps:\n' + '\n'.join(deps))
           EOF
-          pip-audit -r audit-requirements.txt --ignore-vuln CVE-2026-4539
+          # Temporary ignores for transformers==5.3.0 (no fix version yet); revisit when upstream releases a patched version.
+          pip-audit -r audit-requirements.txt \
+            --ignore-vuln CVE-2026-4539 \
+            --ignore-vuln PYSEC-2025-211 \
+            --ignore-vuln PYSEC-2025-212 \
+            --ignore-vuln PYSEC-2025-213 \
+            --ignore-vuln PYSEC-2025-214 \
+            --ignore-vuln PYSEC-2025-215 \
+            --ignore-vuln PYSEC-2025-216 \
+            --ignore-vuln PYSEC-2025-217 \
+            --ignore-vuln PYSEC-2025-218
 
       - name: Test import
         if: ${{ !inputs.skip-import-test }}

--- a/modeling/transformers/bench_olmoe.sh
+++ b/modeling/transformers/bench_olmoe.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# Benchmark script for OLMoE-1B-7B-0924 (sparse MoE) model
+# Compares PyTorch baseline vs TileGym CUTILE backend
+
+set -e
+
+MODEL_ID="allenai/OLMoE-1B-7B-0924"
+INPUT_FILE="sample_inputs/input_prompt_small.txt"
+OUTPUT_LENGTH=50
+LOG_DIR="${LOG_DIR:-/logs}"
+SUMMARY_FILE="${LOG_DIR}/olmoe_benchmark_summary.txt"
+
+echo "========================================"
+echo "  OLMoE-1B-7B-0924 Performance Benchmark"
+echo "========================================"
+echo ""
+echo "Model: ${MODEL_ID}"
+echo "Input: ${INPUT_FILE}"
+echo "Output length: ${OUTPUT_LENGTH} tokens"
+echo ""
+
+# Clean previous results
+rm -f ${SUMMARY_FILE}
+
+echo "Running PyTorch baseline..."
+python infer.py \
+    --model_id ${MODEL_ID} \
+    --profile \
+    --sentence_file ${INPUT_FILE} \
+    --output_length ${OUTPUT_LENGTH} \
+    --log_dir ${LOG_DIR} \
+    --summary_file ${SUMMARY_FILE}
+
+echo ""
+echo "Running TileGym CUTILE backend..."
+python infer.py \
+    --model_id ${MODEL_ID} \
+    --use_tilegym \
+    --use_cutile \
+    --use_attn \
+    --profile \
+    --sentence_file ${INPUT_FILE} \
+    --output_length ${OUTPUT_LENGTH} \
+    --log_dir ${LOG_DIR} \
+    --summary_file ${SUMMARY_FILE}
+
+echo ""
+echo "========================================"
+echo "  Benchmark Results"
+echo "========================================"
+if [ -f ${SUMMARY_FILE} ]; then
+    cat ${SUMMARY_FILE}
+else
+    echo "Summary file not found."
+fi
+echo "========================================"
+
+echo ""
+echo "========================================"
+echo "  TileGym Kernel Coverage"
+echo "========================================"
+python infer.py \
+    --model_id ${MODEL_ID} \
+    --use_tilegym \
+    --use_cutile \
+    --use_attn \
+    --report_kernel_coverage \
+    --sentence_file ${INPUT_FILE} \
+    --output_length ${OUTPUT_LENGTH} \
+    --log_dir ${LOG_DIR}
+echo "========================================"

--- a/modeling/transformers/infer.py
+++ b/modeling/transformers/infer.py
@@ -28,6 +28,7 @@ from tilegym.transformers import apply_tilegym_kernel_to_gpt_oss
 from tilegym.transformers import apply_tilegym_kernel_to_llama
 from tilegym.transformers import apply_tilegym_kernel_to_mistral
 from tilegym.transformers import apply_tilegym_kernel_to_olmo3
+from tilegym.transformers import apply_tilegym_kernel_to_olmoe
 from tilegym.transformers import apply_tilegym_kernel_to_phi3
 from tilegym.transformers import apply_tilegym_kernel_to_qwen2
 from tilegym.transformers import apply_tilegym_kernel_to_qwen3
@@ -279,6 +280,8 @@ def apply_tilegym_patch(model_id, use_attn=False, use_cutile=False):
         apply_tilegym_kernel_to_gemma3(rope=True, rms_norm=True, mlp=True, attn=use_attn, use_cutile=use_cutile)
     elif "phi-3" in model_name or "phi3" in model_name:
         apply_tilegym_kernel_to_phi3(rope=True, rms_norm=True, swiglu=True, attn=use_attn, use_cutile=use_cutile)
+    elif "olmoe" in model_name:
+        apply_tilegym_kernel_to_olmoe(rope=True, rms_norm=True, attn=use_attn, moe=True, use_cutile=use_cutile)
     elif "olmo-3" in model_name or "olmo3" in model_name:
         apply_tilegym_kernel_to_olmo3(rope=True, rms_norm=True, swiglu=True, attn=use_attn, use_cutile=use_cutile)
     else:
@@ -330,6 +333,9 @@ class KernelFilter:
             # Fused OLMo-3 cuTile kernels
             "_rms_norm_residual_add_kernel",
             "_dual_rms_norm_kernel",
+            # Fused OLMoE cuTile kernels
+            "_olmoe_residual_add_rms_norm_kernel",
+            "_olmoe_dual_rms_norm_kernel",
             # Reduce kernels
             "splitk_reduce_kernel",
             # GEMM kernels

--- a/src/tilegym/ops/cutile/experimental/nvfp4_quantize.py
+++ b/src/tilegym/ops/cutile/experimental/nvfp4_quantize.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 from functools import lru_cache
-from typing import Optional
 
 import cuda.tile as ct
 import numpy as np
@@ -130,7 +129,7 @@ def _make_nvfp4_kernel(occupancy: int):
 def tile_nvfp4_quantize(
     x: torch.Tensor,
     s_enc: float = 1.0,
-    occupancy: Optional[int] = None,
+    occupancy: int = 6,
     **kwargs,
 ):
     """
@@ -140,7 +139,7 @@ def tile_nvfp4_quantize(
         x:          bf16, fp16, or fp32 input tensor, shape (rows, cols).
                     cols must be divisible by 16.
         s_enc:      Global encoding scale (float, default 1.0).
-        occupancy:  CTA occupancy hint for the kernel (default: None, uses ct.kernel default).
+        occupancy:  CTA occupancy hint for the kernel (default: 6).
                     Different values compile to separate kernel variants.
 
     Returns:

--- a/src/tilegym/ops/cutile/recurrent_gated_delta_rule.py
+++ b/src/tilegym/ops/cutile/recurrent_gated_delta_rule.py
@@ -3,168 +3,425 @@
 # SPDX-License-Identifier: MIT
 
 import math
+import os
+from types import SimpleNamespace
 
 import cuda.tile as ct
 import torch
 
 from tilegym.backend import register_impl
-
-ConstInt = ct.Constant[int]
-ConstBool = ct.Constant[bool]
+from tilegym.ops.cutile.utils import next_power_of_2
 
 
-@ct.kernel
+# Naming conventions in cuda.tile DSL kernels:
+# - UPPER_CASE_SNAKE_NAMING: Compile-time constants
+# - CamelCaseNaming: Runtime vectors or tensors
+# - lower_case_snake_naming: Runtime scalars
+@ct.kernel(occupancy=2)
 def _recurrent_gated_delta_rule_fwd_kernel(
-    # Tensors — native (B, T, H, D) layout for Q/K/V; (B, T, H) for G/Beta
-    Q,
-    K,
-    V,
-    G,
-    Beta,
-    Output,  # (B, T, H, V)
-    InitState,  # (B, H, K, V) or dummy
-    FinalState,  # (B, H, K, V) or dummy
-    # Runtime scalars
+    Query,  # (B, T, H, QK)
+    Key,  # (B, T, H, QK)
+    Value,  # (B, T, HV, V)
+    Gate,  # (B, T, HV)
+    Beta,  # (B, T, HV)
+    Output,  # (B, T, HV, V)
+    StateIn,  # (B, HV, QK, V)
+    StateOut,  # (B, HV, QK, V)
     scale: float,
-    seq_len: int,
-    # Compile-time constants
-    NUM_HEADS: ConstInt,
-    HAS_INITIAL_STATE: ConstBool,
-    OUTPUT_FINAL_STATE: ConstBool,
-    USE_QK_L2NORM: ConstBool,
-    BLOCK_K: ConstInt,
-    BLOCK_V: ConstInt,
+    HAS_INITIAL_STATE: ct.Constant[bool],
+    OUTPUT_FINAL_STATE: ct.Constant[bool],
+    USE_QK_L2NORM: ct.Constant[bool],
+    T: ct.Constant[int],
+    BLOCK_K: ct.Constant[int],
+    BLOCK_V: ct.Constant[int],
+    SMALL_TILE_USE_TMA: ct.Constant[bool],
+    LARGE_TILE_USE_TMA: ct.Constant[bool],
 ):
-    """
-    Grid: (batch_size * num_heads, ceil(v_head_dim / BLOCK_V), 1)
+    """Grid: (B * Hv, ceil(V / BLOCK_V), 1)."""
+    idx_bhv = ct.bid(0)
+    idx_v = ct.bid(1)
 
-    Each program owns a (BLOCK_K, BLOCK_V) tile of recurrent state
-    and loops over timesteps sequentially.  Uses TMA for all loads/stores.
-    """
-    pid_bh = ct.bid(0)
-    pid_v = ct.bid(1)
+    H = Query.shape[2]
+    HV = Value.shape[2]
+    idx_b = idx_bhv // HV
+    idx_hv = idx_bhv % HV
+    idx_h = idx_hv // (HV // H)
 
-    b = pid_bh // NUM_HEADS
-    h = pid_bh % NUM_HEADS
-
-    _ZERO = ct.PaddingMode.ZERO
-
-    state = ct.zeros((BLOCK_K, BLOCK_V), dtype=ct.float32)
     if HAS_INITIAL_STATE:
-        state = ct.load(
-            InitState,
-            index=(b, h, 0, pid_v),
+        State = ct.load(
+            StateIn,
+            index=(idx_b, idx_hv, 0, idx_v),
             shape=(1, 1, BLOCK_K, BLOCK_V),
-            padding_mode=_ZERO,
+            padding_mode=ct.PaddingMode.ZERO,
+            allow_tma=LARGE_TILE_USE_TMA,
         ).reshape((BLOCK_K, BLOCK_V))
-        state = ct.astype(state, ct.float32)
+        State = ct.astype(State, ct.float32)
+    else:
+        State = ct.zeros((BLOCK_K, BLOCK_V), dtype=ct.float32)
 
-    for t in range(seq_len):
-        # Load q_t, k_t: (BLOCK_K,)
-        q_t = ct.load(
-            Q,
-            index=(b, t, h, 0),
+    for idx_t in range(T):
+        QueryT = ct.load(
+            Query,
+            index=(idx_b, idx_t, idx_h, 0),
             shape=(1, 1, 1, BLOCK_K),
-            padding_mode=_ZERO,
+            padding_mode=ct.PaddingMode.ZERO,
+            allow_tma=LARGE_TILE_USE_TMA,
         ).reshape((BLOCK_K,))
-        q_t = ct.astype(q_t, ct.float32)
+        QueryT = ct.astype(QueryT, ct.float32)
 
-        k_t = ct.load(
-            K,
-            index=(b, t, h, 0),
+        KeyT = ct.load(
+            Key,
+            index=(idx_b, idx_t, idx_h, 0),
             shape=(1, 1, 1, BLOCK_K),
-            padding_mode=_ZERO,
+            padding_mode=ct.PaddingMode.ZERO,
+            allow_tma=LARGE_TILE_USE_TMA,
         ).reshape((BLOCK_K,))
-        k_t = ct.astype(k_t, ct.float32)
+        KeyT = ct.astype(KeyT, ct.float32)
 
-        # Optional L2-normalize q and k
         if USE_QK_L2NORM:
-            q_t = q_t * ct.rsqrt(ct.sum(q_t * q_t, axis=0) + 1e-6)
-            k_t = k_t * ct.rsqrt(ct.sum(k_t * k_t, axis=0) + 1e-6)
+            QueryT = QueryT * ct.rsqrt(ct.sum(QueryT * QueryT, axis=0) + 1e-6)
+            KeyT = KeyT * ct.rsqrt(ct.sum(KeyT * KeyT, axis=0) + 1e-6)
+        QueryT = QueryT * scale
 
-        q_t = q_t * scale
-
-        # Load v_t: (BLOCK_V,)
-        v_t = ct.load(
-            V,
-            index=(b, t, h, pid_v),
+        ValueT = ct.load(
+            Value,
+            index=(idx_b, idx_t, idx_hv, idx_v),
             shape=(1, 1, 1, BLOCK_V),
-            padding_mode=_ZERO,
+            padding_mode=ct.PaddingMode.ZERO,
+            allow_tma=SMALL_TILE_USE_TMA,
         ).reshape((BLOCK_V,))
-        v_t = ct.astype(v_t, ct.float32)
+        ValueT = ct.astype(ValueT, ct.float32)
 
-        # Load g_t, beta_t: scalars
-        g_t = ct.astype(ct.load(G, index=(b, t, h), shape=(), padding_mode=_ZERO), ct.float32)
-        beta_t = ct.astype(ct.load(Beta, index=(b, t, h), shape=(), padding_mode=_ZERO), ct.float32)
+        gate_t = ct.astype(ct.gather(Gate, (idx_b, idx_t, idx_hv), check_bounds=False), ct.float32)
+        beta_t = ct.astype(ct.gather(Beta, (idx_b, idx_t, idx_hv), check_bounds=False), ct.float32)
 
-        # 1. Decay state
-        state = state * ct.exp(g_t)
+        State = State * ct.exp(gate_t)
+        KeyT = ct.expand_dims(KeyT, axis=1)
+        KvMemT = ct.sum(State * KeyT, axis=0)
+        DeltaT = (ValueT - KvMemT) * beta_t
+        State = State + KeyT * ct.expand_dims(DeltaT, axis=0)
+        OutT = ct.sum(State * ct.expand_dims(QueryT, axis=1), axis=0)
 
-        # 2. Retrieve from memory: kv_mem[v] = sum_k state[k,v] * k_t[k]
-        k_col = ct.expand_dims(k_t, axis=1)  # (BLOCK_K, 1)
-        kv_mem = ct.sum(state * k_col, axis=0)  # (BLOCK_V,)
-
-        # 3. Compute delta
-        delta = (v_t - kv_mem) * beta_t
-
-        # 4. Rank-1 state update: state += outer(k_t, delta)
-        state = state + k_col * ct.expand_dims(delta, axis=0)
-
-        # 5. Query: out_t[v] = sum_k state[k,v] * q_t[k]
-        out_t = ct.sum(state * ct.expand_dims(q_t, axis=1), axis=0)
-
-        # Store output (cast to output dtype)
-        out_tile = ct.astype(
-            ct.reshape(out_t, (1, 1, 1, BLOCK_V)),
-            Output.dtype,
+        ct.store(
+            Output,
+            index=(idx_b, idx_t, idx_hv, idx_v),
+            tile=ct.astype(ct.reshape(OutT, (1, 1, 1, BLOCK_V)), Output.dtype),
+            allow_tma=SMALL_TILE_USE_TMA,
         )
-        ct.store(Output, index=(b, t, h, pid_v), tile=out_tile)
 
     if OUTPUT_FINAL_STATE:
         ct.store(
-            FinalState,
-            index=(b, h, 0, pid_v),
-            tile=ct.reshape(state, (1, 1, BLOCK_K, BLOCK_V)),
+            StateOut,
+            index=(idx_b, idx_hv, 0, idx_v),
+            tile=ct.reshape(State, (1, 1, BLOCK_K, BLOCK_V)),
+            allow_tma=LARGE_TILE_USE_TMA,
         )
 
 
-class _RecurrentGatedDeltaRuleCuTile(torch.autograd.Function):
-    @staticmethod
-    def forward(ctx, query, key, value, g, beta, initial_state, output_final_state, use_qk_l2norm_in_kernel):
-        initial_dtype = query.dtype
-        B, T, H, K = query.shape
-        V = value.shape[-1]
-        scale = 1.0 / math.sqrt(K)
+@ct.kernel(occupancy=2)
+def _recurrent_gated_delta_rule_fwd_kernel_persistent(
+    Query,  # (B, T, H, QK)
+    Key,  # (B, T, H, QK)
+    Value,  # (B, T, HV, V)
+    Gate,  # (B, T, HV)
+    Beta,  # (B, T, HV)
+    Output,  # (B, T, HV, V)
+    StateIn,  # (B, HV, QK, V)
+    StateOut,  # (B, HV, QK, V)
+    scale: float,
+    HAS_INITIAL_STATE: ct.Constant[bool],
+    OUTPUT_FINAL_STATE: ct.Constant[bool],
+    USE_QK_L2NORM: ct.Constant[bool],
+    T: ct.Constant[int],
+    BLOCK_K: ct.Constant[int],
+    BLOCK_V: ct.Constant[int],
+    SMALL_TILE_USE_TMA: ct.Constant[bool],
+    LARGE_TILE_USE_TMA: ct.Constant[bool],
+):
+    """Grid: (min(NUM_SMS, B * HV * cdiv(V, BLOCK_V)),); grid-strides over (b, hv, pid_v)."""
+    idx_CGA = ct.bid(0)
+    num_CGAs = ct.num_blocks(0)
 
-        # Ensure contiguous for TMA
+    B = Query.shape[0]
+    H = Query.shape[2]
+    HV = Value.shape[2]
+    NUM_V_BLOCKS = ct.cdiv(Value.shape[3], BLOCK_V)
+    NUM_BLOCKS = B * HV * NUM_V_BLOCKS
+    H_PER_GROUP = HV // H
+
+    for idx_block in range(idx_CGA, NUM_BLOCKS, num_CGAs):
+        idx_bhv = idx_block // NUM_V_BLOCKS
+        idx_v = idx_block % NUM_V_BLOCKS
+        idx_b = idx_bhv // HV
+        idx_hv = idx_bhv % HV
+        idx_h = idx_hv // H_PER_GROUP
+
+        if HAS_INITIAL_STATE:
+            State = ct.load(
+                StateIn,
+                index=(idx_b, idx_hv, 0, idx_v),
+                shape=(1, 1, BLOCK_K, BLOCK_V),
+                padding_mode=ct.PaddingMode.ZERO,
+                allow_tma=LARGE_TILE_USE_TMA,
+            ).reshape((BLOCK_K, BLOCK_V))
+            State = ct.astype(State, ct.float32)
+        else:
+            State = ct.zeros((BLOCK_K, BLOCK_V), dtype=ct.float32)
+
+        for idx_t in range(T):
+            QueryT = ct.load(
+                Query,
+                index=(idx_b, idx_t, idx_h, 0),
+                shape=(1, 1, 1, BLOCK_K),
+                padding_mode=ct.PaddingMode.ZERO,
+                allow_tma=LARGE_TILE_USE_TMA,
+            ).reshape((BLOCK_K,))
+            QueryT = ct.astype(QueryT, ct.float32)
+
+            KeyT = ct.load(
+                Key,
+                index=(idx_b, idx_t, idx_h, 0),
+                shape=(1, 1, 1, BLOCK_K),
+                padding_mode=ct.PaddingMode.ZERO,
+                allow_tma=LARGE_TILE_USE_TMA,
+            ).reshape((BLOCK_K,))
+            KeyT = ct.astype(KeyT, ct.float32)
+
+            if USE_QK_L2NORM:
+                QueryT = QueryT * ct.rsqrt(ct.sum(QueryT * QueryT, axis=0) + 1e-6)
+                KeyT = KeyT * ct.rsqrt(ct.sum(KeyT * KeyT, axis=0) + 1e-6)
+            QueryT = QueryT * scale
+
+            ValueT = ct.load(
+                Value,
+                index=(idx_b, idx_t, idx_hv, idx_v),
+                shape=(1, 1, 1, BLOCK_V),
+                padding_mode=ct.PaddingMode.ZERO,
+                allow_tma=SMALL_TILE_USE_TMA,
+            ).reshape((BLOCK_V,))
+            ValueT = ct.astype(ValueT, ct.float32)
+
+            gate_t = ct.astype(ct.gather(Gate, (idx_b, idx_t, idx_hv), check_bounds=False), ct.float32)
+            beta_t = ct.astype(ct.gather(Beta, (idx_b, idx_t, idx_hv), check_bounds=False), ct.float32)
+
+            State = State * ct.exp(gate_t)
+            KeyT = ct.expand_dims(KeyT, axis=1)
+            KvMemT = ct.sum(State * KeyT, axis=0)
+            Delta = (ValueT - KvMemT) * beta_t
+            State = State + KeyT * ct.expand_dims(Delta, axis=0)
+            OutputT = ct.sum(State * ct.expand_dims(QueryT, axis=1), axis=0)
+
+            ct.store(
+                Output,
+                index=(idx_b, idx_t, idx_hv, idx_v),
+                tile=ct.astype(ct.reshape(OutputT, (1, 1, 1, BLOCK_V)), Output.dtype),
+                allow_tma=SMALL_TILE_USE_TMA,
+            )
+
+        if OUTPUT_FINAL_STATE:
+            ct.store(
+                StateOut,
+                index=(idx_b, idx_hv, 0, idx_v),
+                tile=ct.reshape(State, (1, 1, BLOCK_K, BLOCK_V)),
+                allow_tma=LARGE_TILE_USE_TMA,
+            )
+
+
+def _autotune_configs(V: int, B: int, Hv: int, num_sms: int):
+    # Work-aware BLOCK_V: aim for ~2x SM oversubscription on non-persistent grid
+    # (B * Hv * ceil(V / BLOCK_V)). Smaller B -> smaller BLOCK_V -> more V-blocks.
+    target_v_blocks = max(1, 2 * num_sms // max(1, B * Hv))
+    target_bv = 1 << (max(8, V // target_v_blocks) - 1).bit_length()
+    target_bv = min(V, target_bv)
+    block_v_candidates = sorted({max(8, target_bv // 2), target_bv, min(V, target_bv * 2)})
+    use_tma_small_large_resp = [(False, True), (True, True)]
+    for block_v in block_v_candidates:
+        for occupancy in (2, 3, 4, 6):
+            for small_tile_use_tma, large_tile_use_tma in use_tma_small_large_resp:
+                yield SimpleNamespace(
+                    BLOCK_V=block_v,
+                    occupancy=occupancy,
+                    SMALL_TILE_USE_TMA=small_tile_use_tma,
+                    LARGE_TILE_USE_TMA=large_tile_use_tma,
+                )
+
+
+def _grid(persistent, B, HV, V, BLOCK_V, device):
+    num_v_blocks = ct.cdiv(V, BLOCK_V)
+    if persistent:
+        num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+        return (min(num_sms, B * HV * num_v_blocks),)
+    return (B * HV, num_v_blocks, 1)
+
+
+def _autotune(
+    query,
+    key,
+    value,
+    g,
+    beta,
+    output,
+    initial_state,
+    final_state,
+    scale,
+    has_initial_state,
+    output_final_state,
+    use_qk_l2norm_in_kernel,
+    B,
+    T,
+    Hv,
+    V,
+    BLOCK_K,
+    persistent,
+):
+    dummy = torch.empty(1, 1, 1, 1, device=query.device, dtype=torch.float32)
+    device = query.device
+
+    def args_fn(cfg):
+        return (
+            query,
+            key,
+            value,
+            g,
+            beta,
+            output,
+            initial_state if has_initial_state else dummy,
+            final_state if output_final_state else dummy,
+            scale,
+            has_initial_state,
+            output_final_state,
+            use_qk_l2norm_in_kernel,
+            T,
+            BLOCK_K,
+            cfg.BLOCK_V,
+            cfg.SMALL_TILE_USE_TMA,
+            cfg.LARGE_TILE_USE_TMA,
+        )
+
+    def make_grid_fn(persistent):
+        return lambda cfg: _grid(persistent, B, Hv, V, cfg.BLOCK_V, device)
+
+    def hints_fn(cfg):
+        return {"occupancy": cfg.occupancy}
+
+    num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    kernel_candidates = {
+        False: _recurrent_gated_delta_rule_fwd_kernel,
+        True: _recurrent_gated_delta_rule_fwd_kernel_persistent,
+    }
+    if persistent is not None:
+        kernel_candidates = {persistent: kernel_candidates[persistent]}
+    best_kernel, best_config, best_is_persistent, best_time = None, None, None, float("inf")
+    for persistent, kernel in kernel_candidates.items():
+        result = ct.tune.exhaustive_search(
+            list(_autotune_configs(V, B, Hv, num_sms)),
+            torch.cuda.current_stream(),
+            make_grid_fn(persistent),
+            kernel,
+            args_fn,
+            hints_fn,
+            quiet=True,
+        )
+        if result.best.mean_us < best_time:
+            best_time = result.best.mean_us
+            best_kernel, best_config, best_is_persistent = kernel, result.best.config, persistent
+    assert best_kernel is not None
+    best_kernel = best_kernel.replace_hints(occupancy=best_config.occupancy)
+    return best_kernel, best_config, best_is_persistent
+
+
+class _RecurrentGatedDeltaRuleCuTile(torch.autograd.Function):
+    autotune_cache = {}
+
+    @staticmethod
+    def forward(
+        ctx, query, key, value, g, beta, initial_state, output_final_state, use_qk_l2norm_in_kernel, persistent
+    ):
+        B, T, H, QK = query.shape
+        HV, V = value.shape[-2:]
+        assert H <= HV and HV % H == 0
+        initial_dtype = query.dtype
+        device = query.device
+
         query = query.contiguous()
         key = key.contiguous()
         value = value.contiguous()
         g = g.contiguous()
         beta = beta.contiguous()
+        if has_initial_state := (initial_state is not None):
+            initial_state = initial_state.contiguous()
 
-        output = torch.empty(B, T, H, V, device=query.device, dtype=initial_dtype)
+        output = torch.empty(B, T, HV, V, device=device, dtype=initial_dtype)
+        final_state = torch.empty(B, HV, QK, V, device=device, dtype=torch.float32) if output_final_state else None
 
-        has_initial_state = initial_state is not None
-        if has_initial_state:
-            initial_state = initial_state.contiguous().float()
+        BLOCK_K = next_power_of_2(QK)
+        scale = 1.0 / math.sqrt(QK)
 
-        final_state = None
-        if output_final_state:
-            final_state = torch.empty(B, H, K, V, device=query.device, dtype=torch.float32)
+        if os.environ.get("DISABLE_AUTOTUNE", "0") == "1":
+            best_kernel = (
+                _recurrent_gated_delta_rule_fwd_kernel_persistent
+                if persistent
+                else _recurrent_gated_delta_rule_fwd_kernel
+            )
+            best_config = SimpleNamespace(
+                BLOCK_V=64,
+                occupancy=2,
+                SMALL_TILE_USE_TMA=True,
+                LARGE_TILE_USE_TMA=True,
+            )
+            best_is_persistent = bool(persistent)
+        else:
+            cache_key = (
+                B,
+                T,
+                H,
+                HV,
+                QK,
+                V,
+                initial_dtype,
+                has_initial_state,
+                output_final_state,
+                use_qk_l2norm_in_kernel,
+                persistent,
+                str(device),
+            )
+            if (cached := _RecurrentGatedDeltaRuleCuTile.autotune_cache.get(cache_key)) is None:
+                cached = _autotune(
+                    query,
+                    key,
+                    value,
+                    g,
+                    beta,
+                    output,
+                    initial_state,
+                    final_state,
+                    scale,
+                    has_initial_state,
+                    output_final_state,
+                    use_qk_l2norm_in_kernel,
+                    B,
+                    T,
+                    HV,
+                    V,
+                    BLOCK_K,
+                    persistent,
+                )
+                _RecurrentGatedDeltaRuleCuTile.autotune_cache[cache_key] = cached
+            best_kernel, best_config, best_is_persistent = cached
 
-        BLOCK_K = 1 << (K - 1).bit_length()
-        BLOCK_V = min(64, 1 << (V - 1).bit_length())
+        grid = _grid(best_is_persistent, B, HV, V, best_config.BLOCK_V, device)
 
-        grid = (B * H, (V + BLOCK_V - 1) // BLOCK_V, 1)
-
-        # cuTile cannot accept None — use dummy tensors for absent state
-        dummy = torch.empty(1, 1, 1, 1, device=query.device, dtype=torch.float32)
+        if has_initial_state and output_final_state:
+            init_arg, final_arg = initial_state, final_state
+        else:
+            dummy = torch.empty(1, 1, 1, 1, device=device, dtype=torch.float32)
+            init_arg = initial_state if has_initial_state else dummy
+            final_arg = final_state if output_final_state else dummy
 
         ct.launch(
             torch.cuda.current_stream(),
             grid,
-            _recurrent_gated_delta_rule_fwd_kernel,
+            best_kernel,
             (
                 query,
                 key,
@@ -172,16 +429,17 @@ class _RecurrentGatedDeltaRuleCuTile(torch.autograd.Function):
                 g,
                 beta,
                 output,
-                initial_state if has_initial_state else dummy,
-                final_state if output_final_state else dummy,
+                init_arg,
+                final_arg,
                 scale,
-                T,
-                H,
                 has_initial_state,
                 output_final_state,
                 use_qk_l2norm_in_kernel,
+                T,
                 BLOCK_K,
-                BLOCK_V,
+                best_config.BLOCK_V,
+                best_config.SMALL_TILE_USE_TMA,
+                best_config.LARGE_TILE_USE_TMA,
             ),
         )
 
@@ -194,7 +452,15 @@ class _RecurrentGatedDeltaRuleCuTile(torch.autograd.Function):
 
 @register_impl("recurrent_gated_delta_rule", backend="cutile")
 def recurrent_gated_delta_rule(
-    query, key, value, g, beta, initial_state=None, output_final_state=False, use_qk_l2norm_in_kernel=False, **kwargs
+    query,
+    key,
+    value,
+    g,
+    beta,
+    initial_state=None,
+    output_final_state=False,
+    use_qk_l2norm_in_kernel=False,
+    **kwargs,
 ):
     """Drop-in cuTile replacement for torch_recurrent_gated_delta_rule."""
     return _RecurrentGatedDeltaRuleCuTile.apply(
@@ -206,4 +472,5 @@ def recurrent_gated_delta_rule(
         initial_state,
         output_final_state,
         use_qk_l2norm_in_kernel,
+        kwargs.get("persistent"),
     )

--- a/src/tilegym/transformers/__init__.py
+++ b/src/tilegym/transformers/__init__.py
@@ -8,6 +8,7 @@ from tilegym.transformers.monkey_patch import apply_tilegym_kernel_to_gpt_oss
 from tilegym.transformers.monkey_patch import apply_tilegym_kernel_to_llama
 from tilegym.transformers.monkey_patch import apply_tilegym_kernel_to_mistral
 from tilegym.transformers.monkey_patch import apply_tilegym_kernel_to_olmo3
+from tilegym.transformers.monkey_patch import apply_tilegym_kernel_to_olmoe
 from tilegym.transformers.monkey_patch import apply_tilegym_kernel_to_phi3
 from tilegym.transformers.monkey_patch import apply_tilegym_kernel_to_qwen2
 from tilegym.transformers.monkey_patch import apply_tilegym_kernel_to_qwen3

--- a/src/tilegym/transformers/monkey_patch.py
+++ b/src/tilegym/transformers/monkey_patch.py
@@ -434,6 +434,64 @@ def apply_tilegym_kernel_to_phi3(
         ALL_ATTENTION_FUNCTIONS["sdpa"] = get_fmha_phi3_interface()
 
 
+def apply_tilegym_kernel_to_olmoe(
+    rope: bool = True,
+    rms_norm: bool = True,
+    attn: bool = True,
+    moe: bool = True,
+    model: PreTrainedModel = None,
+    use_cutile: bool = False,
+) -> None:
+    """
+    Apply TileGym kernels to replace original implementation in HuggingFace OLMoE models
+    (e.g. allenai/OLMoE-1B-7B-0924).
+
+    OLMoE is a sparse Mixture-of-Experts model with 64 experts and top-8 routing.
+    Per-layer compute:
+    - Llama-style RMSNorm at five sites (input/post-attn LN, Q/K-norm, model norm)
+    - Standard RoPE (full rotation, rope_theta=10000.0)
+    - Standard FMHA: 16 Q heads, 16 KV heads (no GQA), head_dim=128, causal
+    - OlmoeSparseMoeBlock with OlmoeTopKRouter (softmax-then-topk, norm_topk_prob=False)
+      and OlmoeExperts whose gate_up_proj (E, 2I, H) and down_proj (E, H, I) are already
+      stacked in the format TileGym's fused_moe expects.
+
+    Args:
+        rope (bool): Patch `apply_rotary_pos_emb`. Default True.
+        rms_norm (bool): Patch `OlmoeRMSNorm`. Default True.
+        attn (bool): Patch `ALL_ATTENTION_FUNCTIONS["sdpa"]` with FMHA. Default True.
+        moe (bool): Patch `OlmoeSparseMoeBlock` with the TileGym fused-MoE variant. Default True.
+        model (PreTrainedModel): Unused; present for API symmetry with sibling helpers.
+        use_cutile (bool): Switch the TileGym backend to cuTile. Default False.
+    """
+    logger.info("--------------------------------")
+    logger.info("apply_tilegym_kernel_to_olmoe")
+    logger.info("--------------------------------")
+    from transformers.models.olmoe import modeling_olmoe
+
+    if use_cutile:
+        set_backend("cutile")
+
+    if rope:
+        modeling_olmoe.apply_rotary_pos_emb = get_apply_rope_func(model="llama")
+    if rms_norm:
+        modeling_olmoe.OlmoeRMSNorm = get_rms_norm_module()
+    if attn:
+        from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+        ALL_ATTENTION_FUNCTIONS["sdpa"] = get_fmha_interface()
+    if moe:
+        from tilegym.transformers.olmoe.modeling_olmoe import OlmoeSparseMoeBlockTileGym
+
+        modeling_olmoe.OlmoeSparseMoeBlock = OlmoeSparseMoeBlockTileGym
+
+    if use_cutile:
+        from tilegym.transformers.olmoe.modeling_olmoe import _attention_forward_tilegym
+        from tilegym.transformers.olmoe.modeling_olmoe import _decoder_layer_forward_tilegym
+
+        modeling_olmoe.OlmoeAttention.forward = _attention_forward_tilegym
+        modeling_olmoe.OlmoeDecoderLayer.forward = _decoder_layer_forward_tilegym
+
+
 def apply_tilegym_kernel_to_olmo3(
     rope: bool = True,
     rms_norm: bool = True,
@@ -504,6 +562,7 @@ MODEL_TYPE_TO_APPLY_TILEGYM_FN = {
     "gemma3": apply_tilegym_kernel_to_gemma3,
     "phi3": apply_tilegym_kernel_to_phi3,
     "olmo3": apply_tilegym_kernel_to_olmo3,
+    "olmoe": apply_tilegym_kernel_to_olmoe,
 }
 
 

--- a/src/tilegym/transformers/olmoe/__init__.py
+++ b/src/tilegym/transformers/olmoe/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT

--- a/src/tilegym/transformers/olmoe/modeling_olmoe.py
+++ b/src/tilegym/transformers/olmoe/modeling_olmoe.py
@@ -1,0 +1,356 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""TileGym replacement modules for `transformers.models.olmoe.modeling_olmoe`.
+
+Only the MoE block is replaced here; RoPE / RMSNorm / attention are patched
+elsewhere via the registry-level / class-level monkey-patches.
+
+`OlmoeSparseMoeBlockTileGym` keeps the exact same nested-parameter layout as
+the stock `OlmoeSparseMoeBlock` (`self.gate = OlmoeTopKRouter(...)`,
+`self.experts = OlmoeExperts(...)`) so HuggingFace `state_dict` loading works
+unchanged. Forward replaces the per-expert Python loop in `OlmoeExperts` with
+TileGym's batched `fused_moe` kernel.
+
+Weight-layout compatibility notes (verified against HF OLMoE 5.x source):
+
+- HF `self.experts.gate_up_proj`: shape ``(E, 2*I, H)``. The first ``I`` rows
+  along axis 1 are the **gate** projection, the second ``I`` rows are the
+  **up** projection — confirmed by HF's
+  ``linear(x, gate_up_proj[e]).chunk(2, dim=-1)`` which produces
+  ``(gate, up)`` in that order.
+- HF `self.experts.down_proj`: shape ``(E, H, I)``.
+- TileGym `fused_moe(w1, w2)` expects:
+    * ``w1: (E, 2*I, H)`` and assumes the standard ``silu_and_mul`` ordering
+      ``silu(x[:, :I]) * x[:, I:]``, i.e. ``[gate, up]`` along the
+      output-feature axis — identical to HF.
+    * ``w2: (E, H, I)`` — identical to HF.
+  So we can pass the HF parameters directly with **no merge / no reorder**.
+
+Routing semantics:
+
+- HF `OlmoeTopKRouter` does ``softmax(logits, fp32).topk(k)`` with
+  ``norm_topk_prob=False`` for the real OLMoE-1B-7B-0924 checkpoint, so the
+  ``top_k`` weights sum to less than 1. TileGym's MoE kernel multiplies the
+  routed weights into the down-projection output regardless of whether they
+  sum to 1, so the un-normalized weights flow through correctly.
+"""
+
+import cuda.tile as ct
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from tilegym.ops import fused_moe
+from tilegym.ops import matmul as tilegym_matmul
+
+ConstInt = ct.Constant[int]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# cuTile kernel: fused residual add + (Llama-style) RMSNorm
+#
+# Computes both outputs the layer body needs:
+#   sum    = residual + x
+#   normed = sum * rsqrt(mean(sum**2) + eps) * weight
+#
+# OLMoE uses pre-norm with offset=0, so the multiplier is `weight` (not
+# `1 + weight` as in Gemma3/Qwen3.5). The kernel is structurally identical
+# to qwen3_5's `_residual_add_rms_norm_kernel` minus the offset.
+# ──────────────────────────────────────────────────────────────────────
+
+
+@ct.kernel
+def _olmoe_residual_add_rms_norm_kernel(
+    residual,  # (N, D)
+    x,  # (N, D)
+    weight,  # (D,)
+    sum_out,  # (N, D)
+    normed_out,  # (N, D)
+    eps: float,
+    D: ConstInt,
+    TILE_D: ConstInt,
+):
+    bid = ct.bid(0)
+    offs = ct.arange(TILE_D, dtype=ct.int32)
+
+    r = ct.astype(ct.gather(residual, (bid, offs), padding_value=0.0, check_bounds=True), ct.float32)
+    h = ct.astype(ct.gather(x, (bid, offs), padding_value=0.0, check_bounds=True), ct.float32)
+    w = ct.astype(ct.gather(weight, (offs,), padding_value=0.0, check_bounds=True), ct.float32)
+
+    s = r + h
+    variance = ct.sum(s * s) * ct.truediv(1.0, D)
+    normed = s * ct.rsqrt(variance + eps) * w
+
+    ct.scatter(sum_out, (bid, offs), ct.astype(s, sum_out.dtype), check_bounds=True)
+    ct.scatter(normed_out, (bid, offs), ct.astype(normed, normed_out.dtype), check_bounds=True)
+
+
+def residual_add_rms_norm_olmoe_cutile(
+    residual: torch.Tensor,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+):
+    """Fused residual add + Llama-style (offset=0) RMSNorm. Returns (sum, normed)."""
+    D = residual.shape[-1]
+    r_flat = residual.contiguous().view(-1, D)
+    x_flat = x.contiguous().view(-1, D)
+    N = r_flat.shape[0]
+    sum_out = torch.empty_like(r_flat)
+    normed_out = torch.empty_like(r_flat)
+    TILE_D = 1 << (D - 1).bit_length()
+    ct.launch(
+        torch.cuda.current_stream(),
+        (N,),
+        _olmoe_residual_add_rms_norm_kernel,
+        (r_flat, x_flat, weight, sum_out, normed_out, eps, D, TILE_D),
+    )
+    return sum_out.view(residual.shape), normed_out.view(residual.shape)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# cuTile kernel: fused dual RMSNorm over Q and K in one launch
+# ──────────────────────────────────────────────────────────────────────
+
+
+@ct.kernel
+def _olmoe_dual_rms_norm_kernel(
+    q,  # (N, D) — projected Q; normalized in-place
+    k,  # (N, D) — projected K; normalized in-place
+    q_weight,  # (D,)
+    k_weight,  # (D,)
+    eps: float,
+    D: ConstInt,
+    TILE_D: ConstInt,
+):
+    PAD = ct.PaddingMode.ZERO
+    bid = ct.bid(0)
+
+    q_h = ct.load(q, index=(bid, 0), shape=(1, TILE_D), padding_mode=PAD).reshape((TILE_D,)).astype(ct.float32)
+    q_w = ct.load(q_weight, index=(0,), shape=(TILE_D,), padding_mode=PAD).astype(ct.float32)
+    q_var = ct.sum(q_h * q_h) * ct.truediv(1.0, D)
+    q_normed = q_h * ct.rsqrt(q_var + eps) * q_w
+    ct.store(q, index=(bid, 0), tile=q_normed.reshape((1, TILE_D)).astype(q.dtype))
+
+    k_h = ct.load(k, index=(bid, 0), shape=(1, TILE_D), padding_mode=PAD).reshape((TILE_D,)).astype(ct.float32)
+    k_w = ct.load(k_weight, index=(0,), shape=(TILE_D,), padding_mode=PAD).astype(ct.float32)
+    k_var = ct.sum(k_h * k_h) * ct.truediv(1.0, D)
+    k_normed = k_h * ct.rsqrt(k_var + eps) * k_w
+    ct.store(k, index=(bid, 0), tile=k_normed.reshape((1, TILE_D)).astype(k.dtype))
+
+
+def dual_rms_norm_olmoe_cutile(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    q_weight: torch.Tensor,
+    k_weight: torch.Tensor,
+    eps: float,
+):
+    """Fused in-place RMSNorm on Q and K in a single kernel launch."""
+    D = q.shape[-1]
+    q_flat = q.contiguous().view(-1, D)
+    k_flat = k.contiguous().view(-1, D)
+    N = q_flat.shape[0]
+    TILE_D = 1 << (D - 1).bit_length()
+    ct.launch(
+        torch.cuda.current_stream(),
+        (N,),
+        _olmoe_dual_rms_norm_kernel,
+        (q_flat, k_flat, q_weight, k_weight, eps, D, TILE_D),
+    )
+    return q, k
+
+
+def _linear_cutile(self, attr_name: str, x: torch.Tensor) -> torch.Tensor:
+    """Run nn.Linear's matmul through cuTile, caching the transposed weight
+    once per Linear instance. Works on flattened (M, in_features) inputs;
+    reshape callers handle leading dims.
+    """
+    proj = getattr(self, attr_name)
+    cache_attr = f"_{attr_name}_weight_t"
+    wt = getattr(proj, cache_attr, None)
+    if wt is None:
+        wt = proj.weight.t().contiguous()
+        setattr(proj, cache_attr, wt)
+    return tilegym_matmul(x, wt)
+
+
+def _attention_forward_tilegym(
+    self,
+    hidden_states: torch.Tensor,
+    position_embeddings,
+    attention_mask=None,
+    past_key_values=None,
+    cache_position=None,
+    **kwargs,
+):
+    """Patched OlmoeAttention.forward that fuses Q/K RMSNorm into one kernel
+    and routes Q/K/V/O projections through cuTile matmul.
+
+    OLMoE has no clip_qkv (config.clip_qkv = None for the public checkpoint),
+    so this path also drops that conditional. Falls back to stock semantics
+    for everything else: same RoPE, same KV-cache update, same attention
+    interface dispatch.
+    """
+    from transformers.models.olmoe import modeling_olmoe
+
+    input_shape = hidden_states.shape[:-1]
+    hidden_shape = (*input_shape, -1, self.head_dim)
+    hidden_flat = hidden_states.reshape(-1, hidden_states.shape[-1])
+
+    query_states = _linear_cutile(self, "q_proj", hidden_flat).view(*input_shape, -1)
+    key_states = _linear_cutile(self, "k_proj", hidden_flat).view(*input_shape, -1)
+    value_states = _linear_cutile(self, "v_proj", hidden_flat).view(*input_shape, -1)
+
+    q_norm_eps = getattr(self.q_norm, "variance_epsilon", getattr(self.q_norm, "eps", 1e-5))
+    query_states, key_states = dual_rms_norm_olmoe_cutile(
+        query_states,
+        key_states,
+        self.q_norm.weight,
+        self.k_norm.weight,
+        q_norm_eps,
+    )
+
+    if self.config.clip_qkv is not None:
+        query_states.clamp_(min=-self.config.clip_qkv, max=self.config.clip_qkv)
+        key_states.clamp_(min=-self.config.clip_qkv, max=self.config.clip_qkv)
+        value_states.clamp_(min=-self.config.clip_qkv, max=self.config.clip_qkv)
+
+    query_states = query_states.view(*hidden_shape).transpose(1, 2)
+    key_states = key_states.view(*hidden_shape).transpose(1, 2)
+    value_states = value_states.view(*hidden_shape).transpose(1, 2)
+    cos, sin = position_embeddings
+    query_states, key_states = modeling_olmoe.apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+    if past_key_values is not None:
+        cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+        key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
+
+    attention_interface = modeling_olmoe.ALL_ATTENTION_FUNCTIONS.get_interface(
+        self.config._attn_implementation, modeling_olmoe.eager_attention_forward
+    )
+
+    attn_output, attn_weights = attention_interface(
+        self,
+        query_states,
+        key_states,
+        value_states,
+        attention_mask,
+        dropout=0.0 if not self.training else self.attention_dropout,
+        scaling=self.scaling,
+        sliding_window=getattr(self.config, "sliding_window", None),
+        **kwargs,
+    )
+
+    attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+    attn_flat = attn_output.reshape(-1, attn_output.shape[-1])
+    attn_output = _linear_cutile(self, "o_proj", attn_flat).view(*input_shape, -1)
+    return attn_output, attn_weights
+
+
+def _decoder_layer_forward_tilegym(
+    self,
+    hidden_states: torch.Tensor,
+    attention_mask=None,
+    position_ids=None,
+    past_key_values=None,
+    use_cache=None,
+    cache_position=None,
+    position_embeddings=None,
+    **kwargs,
+) -> torch.Tensor:
+    """Patched OlmoeDecoderLayer.forward that fuses the post-attention residual
+    add with the post-attention RMSNorm, mirroring qwen3_5's pattern.
+    """
+    residual = hidden_states
+    hidden_states = self.input_layernorm(hidden_states)
+    hidden_states, _ = self.self_attn(
+        hidden_states=hidden_states,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_values=past_key_values,
+        use_cache=use_cache,
+        cache_position=cache_position,
+        position_embeddings=position_embeddings,
+        **kwargs,
+    )
+
+    # Fused: hidden_states = residual + hidden_states; normed = post_attn_norm(hidden_states)
+    norm_mod = self.post_attention_layernorm
+    norm_eps = getattr(norm_mod, "variance_epsilon", getattr(norm_mod, "eps", 1e-5))
+    hidden_states, normed = residual_add_rms_norm_olmoe_cutile(residual, hidden_states, norm_mod.weight, norm_eps)
+
+    # MoE
+    residual = hidden_states
+    hidden_states = self.mlp(normed)
+    hidden_states = residual + hidden_states
+    return hidden_states
+
+
+class OlmoeSparseMoeBlockTileGym(nn.Module):
+    """Drop-in replacement for ``OlmoeSparseMoeBlock`` that routes the expert
+    compute through TileGym's batched ``fused_moe`` kernel.
+
+    The nested submodule layout (``self.gate``, ``self.experts``) is kept
+    identical to the stock class so the HuggingFace state_dict loads with
+    ``strict=True``.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        # Import here so the module import is cheap and doesn't run HF init
+        # at TileGym import time.
+        from transformers.models.olmoe.modeling_olmoe import OlmoeExperts
+        from transformers.models.olmoe.modeling_olmoe import OlmoeTopKRouter
+
+        self.gate = OlmoeTopKRouter(config)
+        self.experts = OlmoeExperts(config)
+        # Cache router metadata for convenience.
+        self.top_k = config.num_experts_per_tok
+        self.num_experts = config.num_experts
+        self.norm_topk_prob = config.norm_topk_prob
+        self.hidden_size = config.hidden_size
+
+    def _route(self, hidden_flat: torch.Tensor):
+        """Reproduce ``OlmoeTopKRouter.forward`` inline to avoid a redundant
+        reshape and to keep all routing tensors easy to track.
+
+        Returns ``(topk_weights, topk_indices)`` where:
+        - ``topk_weights`` is cast back to ``hidden_flat.dtype``
+        - ``topk_indices`` is ``torch.long`` (output of ``torch.topk``)
+        """
+        # Linear with the gate weight; HF stores as (num_experts, hidden_size).
+        # cuTile matmul doesn't support trans_b, so we materialize the transpose.
+        # gate.weight is small ((num_experts, hidden_size)) — transpose is cheap.
+        if not hasattr(self, "_gate_weight_t") or self._gate_weight_t.data_ptr() == 0:
+            self._gate_weight_t = self.gate.weight.t().contiguous()
+        router_logits = tilegym_matmul(hidden_flat, self._gate_weight_t)
+        router_probs = F.softmax(router_logits, dim=-1, dtype=torch.float32)
+        topk_values, topk_indices = torch.topk(router_probs, self.top_k, dim=-1)
+        if self.norm_topk_prob:
+            topk_values = topk_values / topk_values.sum(dim=-1, keepdim=True)
+        topk_weights = topk_values.to(hidden_flat.dtype)
+        return topk_weights, topk_indices
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_flat = hidden_states.reshape(-1, hidden_dim).contiguous()
+
+        topk_weights, topk_indices = self._route(hidden_flat)
+
+        # TileGym's fused_moe expects (M, H) input, (E, 2I, H) w1, (E, H, I) w2.
+        # ``topk_indices`` from torch.topk is int64; cast to int32 for the
+        # kernel which uses 32-bit indices internally.
+        out_flat = fused_moe(
+            hidden_flat,
+            w1=self.experts.gate_up_proj,
+            w2=self.experts.down_proj,
+            topk_weights=topk_weights,
+            topk_ids=topk_indices.to(torch.int32),
+        )
+
+        # Match the dtype contract of the stock block.
+        out_flat = out_flat.to(hidden_states.dtype)
+        return out_flat.view(batch_size, sequence_length, hidden_dim)


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->

Update codes.

This PR contains **4** new commit(s).

### Commits included:

```
7c22417 Feat(transformers): add OLMoE TileGym integration
56bedec feat(skill): add multi-arch autotune guidance and eval samples for cutile-autotuning
f57dfde perf(ops/nvfp4): default cuTile nvfp4_quantize to occupancy=6 (fixes 2.3x B200 regression)
a6f1c5b cutile recurrent_gated_delta_rule: autotune + persistent variant
```

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: ["ops" and "benchmark"]
```

## Checklist
- [ ] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

