### PR TITLE
ci: add request-nvskills-ci.yml workflow

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+name: Request NVSkills CI
+
+on:
+  issue_comment:
+    types: [created]
+  push:
+
+jobs:
+  request:
+    if: >
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/nvskills-ci')) ||
+      (github.event_name == 'push' &&
+        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
+        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: NVIDIA/skills/.github/workflows/team-request.yml@main
+    secrets:
+      NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary

Add `.github/workflows/request-nvskills-ci.yml` — the trigger workflow used by nvskills-ci.

## What it does

The workflow fires under two conditions:

- A maintainer/admin comments `/nvskills-ci` on a pull request.
- `nv-skills-ci[bot]` pushes a commit titled "Attach NVSkills validation signatures" (follow-up verification path).

In both cases it calls the central reusable workflow which validates the request, then dispatches to the downstream signing pipeline.

## Why a separate PR

`issue_comment`-triggered workflows must already exist on the default branch before GitHub will fire them. Landing this small standalone PR first lets the next content PR (#132 — `skills/` path migration) be the one that exercises `/nvskills-ci` end to end.

## Follow-up (separate from this PR)

- `NVSKILLS_CI_DISPATCH_TOKEN` to be added to repo secrets.
- `NVSKILLS_SIGNATURE_PUSH_ACTOR` repo variable to be set to `nv-skills-ci[bot]`.
- TileGym to be onboarded by the NVSkills CI maintainers.

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: false
  # valid options are "ops", "benchmark", and "sanity"
  test: []
```
