### PR TITLE
Evals: monkey-patch-kernels-to-transformers

### DIFF
--- a/skills/tilegym-monkey-patch-kernels-to-transformers/evals/config.yml
+++ b/skills/tilegym-monkey-patch-kernels-to-transformers/evals/config.yml
@@ -1,0 +1,19 @@
+schema_version: 1
+
+harbor:
+  task_source: evals_json
+  custom_dockerfile_mode: rebase
+  base_image_mode: reuse
+  n_attempts: 1
+  pass_threshold: 0.50
+  stop_on_pass: true
+  n_concurrent: 4
+  max_agents: 2
+  timeout_multiplier: 1.0
+
+skill_workspace:
+  mode: isolated
+  include: []
+
+grading:
+  mode: aces_default

--- a/skills/tilegym-monkey-patch-kernels-to-transformers/evals/evals.json
+++ b/skills/tilegym-monkey-patch-kernels-to-transformers/evals/evals.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "01-integrate-rmsnorm-into-llama",
+    "question": "Integrate TileGym's cuTile RMSNorm kernel into the Hugging Face `transformers` Llama 3 implementation, using the monkey-patch (non-intrusive) approach. The target class is `transformers.models.llama.modeling_llama.LlamaRMSNorm`. We should replace its `forward` method (and `__init__` if needed) so that, at instantiation time, the model invokes TileGym's RMSNorm under the hood. Verify by loading a small Llama checkpoint and comparing logits before/after the patch on a fixed input.",
+    "expected_skill": "monkey-patch-kernels-to-transformers",
+    "expected_script": null,
+    "ground_truth": "Agent follows the 4-step workflow: (1) prepare experiment environment via `references/environment-setup.md`; (2) write a monkey-patch module that replaces `LlamaRMSNorm.forward` (and possibly `__init__`) to call TileGym's cuTile RMSNorm via `tilegym.ops.rms_norm`; (3) apply the patch BEFORE `AutoModelForCausalLM.from_pretrained(...)`; (4) run a logit-comparison test on a fixed input (e.g. `torch.allclose(orig_logits, patched_logits, atol=1e-2, rtol=1e-2)`). Agent does NOT modify `transformers` source code.",
+    "expected_behavior": [
+      "Agent reads the monkey-patch-kernels-to-transformers SKILL.md and the linked `references/environment-setup.md` + `references/kernel-integration.md`",
+      "Agent writes a non-intrusive monkey-patch module (does NOT modify `transformers` source code in place)",
+      "Agent replaces `LlamaRMSNorm.forward` (and `__init__` if needed) to call `tilegym.ops.rms_norm` (or the public TileGym dispatch)",
+      "Agent applies the patch BEFORE the model is instantiated (`from_pretrained`), so loaded weights and replaced modules align",
+      "Agent verifies correctness by comparing original vs patched model logits on a fixed input using `torch.allclose` with reasonable tolerance",
+      "Agent does NOT touch the `transformers` package source under `site-packages/`"
+    ]
+  },
+  {
+    "id": "02-integrate-softmax-into-gemma",
+    "question": "Integrate TileGym's cuTile softmax kernel into the Hugging Face `transformers` Gemma 2 implementation using monkey-patching. Target the attention softmax computation. Apply the patch before model instantiation and verify by comparing logits on a fixed input.",
+    "expected_skill": "monkey-patch-kernels-to-transformers",
+    "expected_script": null,
+    "ground_truth": "Agent follows the monkey-patch workflow: researches Gemma2 attention in transformers source, identifies the softmax computation, writes a monkey-patch module that replaces the relevant softmax call with `tilegym.ops.softmax`, applies it BEFORE `from_pretrained`, and verifies logits match within tolerance.",
+    "expected_behavior": [
+      "Agent reads the monkey-patch-kernels-to-transformers SKILL.md",
+      "Agent researches the Gemma 2 model architecture in transformers to identify the softmax target",
+      "Agent writes a non-intrusive monkey-patch (does NOT modify `transformers` source code)",
+      "Agent applies the patch BEFORE model instantiation",
+      "Agent uses the public TileGym dispatch interface (`tilegym.ops.softmax`)",
+      "Agent verifies correctness by comparing original vs patched model outputs"
+    ]
+  },
+  {
+    "id": "03-aws-vpc-negative",
+    "question": "I'm setting up a new AWS VPC with public and private subnets across two availability zones. What's the recommended CIDR block sizing, and how should I lay out the NAT gateways and route tables to be HA but cost-effective?",
+    "expected_skill": null,
+    "expected_script": null,
+    "should_trigger": false,
+    "ground_truth": "Agent provides AWS VPC guidance: `/16` VPC CIDR with `/24` subnets, one NAT gateway per AZ for HA (or one shared NAT for cost), separate route tables per subnet type. The monkey-patch-kernels-to-transformers skill is NOT activated.",
+    "expected_behavior": [
+      "The monkey-patch-kernels-to-transformers skill is NOT loaded",
+      "Agent provides AWS VPC sizing and HA guidance",
+      "Agent does not mention TileGym, transformers, monkey-patching, or cuTile",
+      "Agent does not run destructive commands"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- Add evals.json + config.yml for `tilegym-monkey-patch-kernels-to-transformers`
- Batch C of parallel eval validation (split from #140 to fit 1h CI timeout)

## Test plan
- [ ] `/nvskills-ci` passes for the skill
- [ ] Both agents (claude-code, codex) show zero or positive lift on all ACES dimensions