### PR TITLE
ci: add transformer inventory runtime test to GitHub CI

### DIFF
--- a/.github/workflows/tilegym-ci.yml
+++ b/.github/workflows/tilegym-ci.yml
@@ -367,6 +367,70 @@ jobs:
           check_name: Ops Test Results (shard ${{ matrix.shard }})
           comment_mode: off
 
+  test-transformer-kernel-inventory:
+    name: test-transformer-kernel-inventory
+    needs: [config, build]
+    timeout-minutes: 60
+    if: |
+      always() &&
+      needs.config.outputs.run_ops == 'true' &&
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
+    runs-on: linux-amd64-gpu-rtxpro6000-latest-1
+    steps:
+      - name: Checkout code (sparse - transformer kernel inventory tests)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            tests/transformers
+          sparse-checkout-cone-mode: false
+
+      - name: Create test results directory
+        run: mkdir -p ${{ github.workspace }}/test-results
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run transformer kernel inventory tests
+        timeout-minutes: 50
+        run: |
+          OWNER_LOWER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')
+          IMAGE="ghcr.io/${OWNER_LOWER}/${{ needs.config.outputs.image_name }}:${{ needs.config.outputs.image_tag }}"
+
+          docker pull ${IMAGE}
+          docker run --rm \
+            --gpus all \
+            -v ${{ github.workspace }}/tests/transformers:/workspace/tilegym/tests/transformers \
+            -v ${{ github.workspace }}/test-results:/test-results \
+            -w /workspace/tilegym/modeling/transformers \
+            ${IMAGE} \
+            uv run --locked --no-sync python -m pytest \
+                /workspace/tilegym/tests/transformers/test_kernel_inventory.py \
+                /workspace/tilegym/tests/transformers/test_kernel_definition_solution_runtime.py \
+                -v \
+                --junitxml=/test-results/transformer-kernel-inventory-results.xml \
+                --html=/test-results/transformer-kernel-inventory-report.html \
+                --self-contained-html
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: transformer-kernel-inventory-test-results
+          path: test-results/transformer-kernel-inventory-*
+          retention-days: 30
+
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: test-results/transformer-kernel-inventory-results.xml
+          check_name: Transformer Kernel Inventory Test Results
+          comment_mode: off
+
   update-test-durations:
     name: update-test-durations
     needs: [config, test-ops]
@@ -798,12 +862,13 @@ jobs:
 
   publish-wheel:
     name: publish-verified-wheel
-    needs: [config, build-wheel, sanity-check, test-ops, test-benchmark]
+    needs: [config, build-wheel, sanity-check, test-ops, test-transformer-kernel-inventory, test-benchmark]
     if: |
       always() &&
       needs.build-wheel.result == 'success' &&
       needs.sanity-check.result == 'success' &&
       needs.test-ops.result == 'success' &&
+      needs.test-transformer-kernel-inventory.result == 'success' &&
       needs.test-benchmark.result == 'success'
     # Note: Only marks the py310-x86_64 wheel as "verified" because that's the wheel
     # actually tested in Docker. Other wheels (py311, py312, arm64) are available but unverified.
@@ -817,13 +882,14 @@ jobs:
 
   promote-to-latest:
     name: promote-to-latest
-    needs: [config, build, sanity-check, test-ops, test-benchmark]
+    needs: [config, build, sanity-check, test-ops, test-transformer-kernel-inventory, test-benchmark]
     if: |
       always() &&
       needs.config.outputs.is_pr == 'false' &&
       needs.build.result == 'success' &&
       needs.sanity-check.result == 'success' &&
       needs.test-ops.result == 'success' &&
+      needs.test-transformer-kernel-inventory.result == 'success' &&
       needs.test-benchmark.result == 'success'
     runs-on: ubuntu-latest
     steps:

--- a/src/tilegym/transformers/olmo3/kernel_solutions/olmo3_dual_rms_norm.json
+++ b/src/tilegym/transformers/olmo3/kernel_solutions/olmo3_dual_rms_norm.json
@@ -17,7 +17,8 @@
     "entry_point": "src/tilegym/transformers/olmo3/kernels/dual_rms_norm.py::dual_rms_norm_cutile",
     "language": "cuda-tile",
     "target_hardware": [
-      "NVIDIA_B200"
+      "NVIDIA_B200",
+      "NVIDIA_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"
     ]
   }
 }

--- a/src/tilegym/transformers/olmo3/kernel_solutions/olmo3_rms_norm_residual_add.json
+++ b/src/tilegym/transformers/olmo3/kernel_solutions/olmo3_rms_norm_residual_add.json
@@ -18,7 +18,8 @@
     "language": "cuda-tile",
     "target_hardware": [
       "NVIDIA_B200",
-      "NVIDIA_GB300"
+      "NVIDIA_GB300",
+      "NVIDIA_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"
     ]
   }
 }

--- a/src/tilegym/transformers/olmoe/kernel_solutions/olmoe_dual_rms_norm.json
+++ b/src/tilegym/transformers/olmoe/kernel_solutions/olmoe_dual_rms_norm.json
@@ -17,7 +17,8 @@
     "entry_point": "src/tilegym/transformers/olmoe/kernels/dual_rms_norm.py::dual_rms_norm_olmoe_cutile",
     "language": "cuda-tile",
     "target_hardware": [
-      "NVIDIA_B200"
+      "NVIDIA_B200",
+      "NVIDIA_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"
     ]
   }
 }

--- a/src/tilegym/transformers/olmoe/kernel_solutions/olmoe_residual_add_rms_norm.json
+++ b/src/tilegym/transformers/olmoe/kernel_solutions/olmoe_residual_add_rms_norm.json
@@ -18,7 +18,8 @@
     "language": "cuda-tile",
     "target_hardware": [
       "NVIDIA_B200",
-      "NVIDIA_GB300"
+      "NVIDIA_GB300",
+      "NVIDIA_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"
     ]
   }
 }

--- a/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_causal_conv1d_prefill_silu.json
+++ b/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_causal_conv1d_prefill_silu.json
@@ -18,7 +18,8 @@
     "language": "cuda-tile",
     "target_hardware": [
       "NVIDIA_B200",
-      "NVIDIA_GB300"
+      "NVIDIA_GB300",
+      "NVIDIA_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"
     ]
   }
 }

--- a/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_causal_conv1d_update_silu.json
+++ b/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_causal_conv1d_update_silu.json
@@ -18,7 +18,8 @@
     "language": "cuda-tile",
     "target_hardware": [
       "NVIDIA_B200",
-      "NVIDIA_GB300"
+      "NVIDIA_GB300",
+      "NVIDIA_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"
     ]
   }
 }

--- a/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_gdr_preprocess.json
+++ b/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_gdr_preprocess.json
@@ -18,7 +18,8 @@
     "language": "cuda-tile",
     "target_hardware": [
       "NVIDIA_B200",
-      "NVIDIA_GB300"
+      "NVIDIA_GB300",
+      "NVIDIA_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"
     ]
   }
 }

--- a/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_residual_add_gemma_rms_norm.json
+++ b/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_residual_add_gemma_rms_norm.json
@@ -18,7 +18,8 @@
     "language": "cuda-tile",
     "target_hardware": [
       "NVIDIA_B200",
-      "NVIDIA_GB300"
+      "NVIDIA_GB300",
+      "NVIDIA_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"
     ]
   }
 }

--- a/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_rms_norm_gated_silu.json
+++ b/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_rms_norm_gated_silu.json
@@ -18,7 +18,8 @@
     "language": "cuda-tile",
     "target_hardware": [
       "NVIDIA_B200",
-      "NVIDIA_GB300"
+      "NVIDIA_GB300",
+      "NVIDIA_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"
     ]
   }
 }

--- a/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_sigmoid_mul.json
+++ b/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_sigmoid_mul.json
@@ -18,7 +18,8 @@
     "language": "cuda-tile",
     "target_hardware": [
       "NVIDIA_B200",
-      "NVIDIA_GB300"
+      "NVIDIA_GB300",
+      "NVIDIA_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"
     ]
   }
 }

--- a/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_silu_and_mul_separate.json
+++ b/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_silu_and_mul_separate.json
@@ -18,7 +18,8 @@
     "language": "cuda-tile",
     "target_hardware": [
       "NVIDIA_B200",
-      "NVIDIA_GB300"
+      "NVIDIA_GB300",
+      "NVIDIA_RTX_PRO_6000_BLACKWELL_SERVER_EDITION"
     ]
   }
 }


### PR DESCRIPTION
## Description

Add a dedicated GitHub Actions GPU job for the transformer kernel inventory.
The job uses the `tilegym-hf-bench` uv environment prepared in the source image,
then runs the comprehensive schema and Definition/Solution runtime test files.

Verified-wheel publishing and promotion to `latest` now require this check to pass.

The 11 current Solutions now support
`NVIDIA_RTX_PRO_6000_BLACKWELL_SERVER_EDITION`. On an RTX PRO 6000 Blackwell
Server Edition, the complete schema and runtime suite passed: all 11 Solution
entry points compiled, ran, and matched their Definition references (`38 passed`).

## CI Configuration

```yaml
config:
  build: true
  # valid options are "ops", "benchmark", and "sanity"
  test: ["ops"]
```

## Checklist

- [x] Code formatted and imports sorted via repo specifications (`./format.sh`) — targeted pre-commit runs passed
- [x] Documentation updated (if needed) — N/A; the workflow and Solution metadata are self-describing
- [x] CI configuration reviewed
