### PR TITLE
perf(flashinfer/cutile): restore two-loop causal split in prefill-ragged body & other updates

### DIFF
--- a/modeling/transformers/pyproject.toml
+++ b/modeling/transformers/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+  # cutile-rs kernel-inventory Solutions bind their FFI cdylib through cffi.
+  "cffi",
   "flashinfer-bench==0.1.2",
   "pytest-html",
   "pytest-split",

--- a/modeling/transformers/pyproject.toml
+++ b/modeling/transformers/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "accelerate==1.13.0",
   "cuda-bindings>=13.2.0",
   "cuda-core>=0.7.0",
-  "cuda-tile[tileiras]>=1.3.0",
+  "cuda-tile[tileiras]>=1.5.0",
   "filelock>=3.20.3",
   "huggingface-hub",
   "matplotlib",

--- a/modeling/transformers/uv.lock
+++ b/modeling/transformers/uv.lock
@@ -315,6 +315,116 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/e9/6d7724983b3d5a0908dbf74f64038ade77c18646ff6636ec7894fd392ce1/cffi-2.1.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:b65f590ef2a44640f9a05dbb548a429b4ade77913ce683ac8b1480777658a6c0", size = 183837, upload-time = "2026-07-06T21:32:09.655Z" },
+    { url = "https://files.pythonhosted.org/packages/69/aa/24580a278de21fd7322635556334d9b535f1cbc00b0a3919447cdf464c65/cffi-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:164bff1657b2a74f0b6d54e11c9b375bc97b931f2ca9c43fcf875838da1570dd", size = 184226, upload-time = "2026-07-06T21:32:11.196Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a9/02cae418ec4beb282ace11958d9d4737793439d561fadc7e6d56f2e2b354/cffi-2.1.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:c941bb58d5a6e1c3892d86e42927ed6c180302f07e6d395d08c416e594b98b46", size = 211107, upload-time = "2026-07-06T21:32:12.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/30/c806937ed5e4c2c7ac30d9d6b76b5dc57ff8b75d83800d9bb11a8253cf2a/cffi-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a016194dbe13d14ee9556e734b772d8d67b947092b268d757fd4290e3ba2dfc2", size = 218733, upload-time = "2026-07-06T21:32:13.67Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/cf/398272b8bbfd58aa314fda5a7f1cdbb26d1d78ae324a11211521315dd1f0/cffi-2.1.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:03e9810d18c646077e501f661b682fbf5dee4676048527ca3cffe66faa9960dd", size = 205543, upload-time = "2026-07-06T21:32:15.148Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ca/f91641185cdd90c36d317a9dc7f85e88ef8682d8b300977baff5e23c35d8/cffi-2.1.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:19c54ac121cad98450b4896fa9a43ee0180d57bc4bc911a33db6cab1efab6cd3", size = 205460, upload-time = "2026-07-06T21:32:16.479Z" },
+    { url = "https://files.pythonhosted.org/packages/38/66/04781a77b411f0bb5b234d62c1814754ab75ebe455ccff1b08e8d7aae98f/cffi-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d433a51f1870e43a13b6732f92aaf540ff77c2015097c78556f75a2d6c030e0", size = 218760, upload-time = "2026-07-06T21:32:17.98Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9a/bb1d5ed9c3fcae158e9f6391bf309c95d98c2ac37ed56573228471d0af5e/cffi-2.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3d7f118b5adbfdfead90c25822690b02bc8074fba949bb7858bec4ebd55adb43", size = 221230, upload-time = "2026-07-06T21:32:19.407Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/3c1409cdd26094efacd1c36c66e0a6eb9d4296e4fd4f9901b8b2042f4323/cffi-2.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c5f5df567f6eb216de69be06ce55c8b714090fae02b18a3b40da8163b8c5fa9c", size = 213524, upload-time = "2026-07-06T21:32:20.828Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/75/74dfb7c3fc6ebbd408038476bd4c1d7e925c62614e7b9c534ecc34218288/cffi-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:11b3fb55f4f8ad92274ed26705f65d8f91457de71f5380061eb6d125a768fecd", size = 220341, upload-time = "2026-07-06T21:32:21.9Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b6/9003c33a3e7d2c1306f5962e646457dcfe5a8cd8fce6bbe02d7af25db783/cffi-2.1.0-cp310-cp310-win32.whl", hash = "sha256:9d72af0cf10a76a600a9690078fe31c63b9588c8e86bf9fd353f713c84b5db0f", size = 174578, upload-time = "2026-07-06T21:32:23.073Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/26/710688310447531c7a22f857c7f79d9855ec18b03e04494ced723fb37e2f/cffi-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb62edb5bb52cca65fab91a63afa7561607120d26090a7e8fda6fb9f064726da", size = 185071, upload-time = "2026-07-06T21:32:24.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/67/85c89a59ba36a671e79638f44d466749f08179266a57e4f2ffdf92174072/cffi-2.1.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc", size = 183845, upload-time = "2026-07-06T21:32:26.32Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dd/e3b0baa2d3d6a857ac72b7efbf18e32e487c9cdafcc13049ad765495b15e/cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5bce581e6b8c235e566a14768a943b172ada3ed73537bb0c0be1edee312d4e7", size = 184186, upload-time = "2026-07-06T21:32:28.025Z" },
+    { url = "https://files.pythonhosted.org/packages/65/68/9f3ef890cf3c6ab97bd531c5677f67613d302165d16f8142b2811782a614/cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93", size = 211892, upload-time = "2026-07-06T21:32:29.565Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d7/1a74539db16d8bfd839ff1515948948efbb162e574650fd3d846896eea95/cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88023dfe18799507b73f1dbb0d14326a17465de1bc9c9c7655c22845e9ddc3a2", size = 218793, upload-time = "2026-07-06T21:32:30.951Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/d1/9a5b7169499e8e8d8e636de70b97ac7c9447104d2ff1a2cd94790cea5162/cffi-2.1.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:0a96b74cda968eebbad56d973efe5098974f0a9fb323865bf99ea1fd24e3e64c", size = 205737, upload-time = "2026-07-06T21:32:32.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b0/e131a9c41f10607926278453d9596163594fe1c4ebc46efe3b5e5b34eb84/cffi-2.1.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a5781494d4d400a3f47f8f1da94b324f6e6b440a53387774002890a2a2f4b50f", size = 204909, upload-time = "2026-07-06T21:32:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d2/4398416cd699b35167947c6e22aca52c47e69ad5695073c9f1f2c52e04aa/cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa7a1b53a2a4452ada2d1b5dade9960b2522f1e61293a811a077439e39029565", size = 217883, upload-time = "2026-07-06T21:32:35.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a5/d4fe77b589e5e82d43ebc809bf2e6474afe8e48e32ea050b9357645b6471/cffi-2.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d8272c0e483b024e1b9ad029821470ed8ec65631dbd90217469da0e7cd89f1c", size = 221251, upload-time = "2026-07-06T21:32:36.527Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f0/a2fc43084c0433caf7f461bccc013e28f848d04ee1c5ed7fce71423cf4d9/cffi-2.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7762faa47e8ff7eb80bd261d9a7d8eea2d8baa69de5e95b70c1f338bbe712f02", size = 214250, upload-time = "2026-07-06T21:32:37.852Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8c/b925975448cf20634a9fbd5efceb807219db452653648d2897c0989cab2d/cffi-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89095c1968b4ba8285840e131bf2891b09ae137fe2146905acae0354fbce1b5e", size = 219441, upload-time = "2026-07-06T21:32:39.146Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/da/5c4918a2d61d86fa927d716cb3d8e4626ef8dc8f605a599d32f33897f59a/cffi-2.1.0-cp311-cp311-win32.whl", hash = "sha256:64c753a0f87a256020004f37a1c8c02c480e725f910f0b2a0f3f07debd1b2479", size = 174496, upload-time = "2026-07-06T21:32:40.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c8/6c2de1d55cf35ef8b92885d5ef280790f0fb9634d87ea1cc315176aecd61/cffi-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:4f26194e3d95e06501b942642855aed4f953d55e95d7d01b7c4483db3ecff458", size = 185113, upload-time = "2026-07-06T21:32:41.761Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4e/e8d7cb5783f1841a3c8fb3a7735838d7484d08ec08c9f984b14cac1ac0e9/cffi-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:35aaea0c7ee0e58a5cd8c2fd1a48fdf7ece0d2699b7ecdda08194e9ce5dd9b3d", size = 179927, upload-time = "2026-07-06T21:32:42.961Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f", size = 184829, upload-time = "2026-07-06T21:32:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde", size = 184728, upload-time = "2026-07-06T21:32:45.683Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d", size = 214815, upload-time = "2026-07-06T21:32:48.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7", size = 222429, upload-time = "2026-07-06T21:32:49.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b", size = 210315, upload-time = "2026-07-06T21:32:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7", size = 208859, upload-time = "2026-07-06T21:32:52.512Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66", size = 221844, upload-time = "2026-07-06T21:32:53.704Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe", size = 225287, upload-time = "2026-07-06T21:32:54.907Z" },
+    { url = "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b", size = 223681, upload-time = "2026-07-06T21:32:56.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/c138990aa2a70b1a269f6e06348729836d733d6f970867943f61d367f8cc/cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a", size = 175269, upload-time = "2026-07-06T21:32:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/eb/f636456ff21a83fc13c032b58cc5dde061691546ac79efa284b2989b7982/cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384", size = 185881, upload-time = "2026-07-06T21:32:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/400ea43e721727dca8a65c4521390e9196757caba4a45643acb2b63271b8/cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6", size = 180088, upload-time = "2026-07-06T21:33:02.278Z" },
+    { url = "https://files.pythonhosted.org/packages/96/88/a996879e2eeccb815f6e3a5967b12a308257412acec882039d386bd2aa7b/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda", size = 194331, upload-time = "2026-07-06T21:33:03.697Z" },
+    { url = "https://files.pythonhosted.org/packages/58/85/7ae00d5c8dd6266f4e944c3db630f3c5c9a98b61d469c714d848b1d8138a/cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b", size = 196966, upload-time = "2026-07-06T21:33:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a", size = 184795, upload-time = "2026-07-06T21:33:06.699Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea", size = 184746, upload-time = "2026-07-06T21:33:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1c/4ed5a0e5bdca6cbc275556de3328dd1b76fd0c11cc13c88fe66d1d8715f2/cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db", size = 214747, upload-time = "2026-07-06T21:33:09.671Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f", size = 222392, upload-time = "2026-07-06T21:33:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f6/01890cfd63c08f8eb96a8319b0443690197d240a8bd6346048cf7bde9190/cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d", size = 210285, upload-time = "2026-07-06T21:33:12.251Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cf/2b684132056f438567b61e19d690dd31cd0921ace051e0a458be6074369e/cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0", size = 208801, upload-time = "2026-07-06T21:33:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224", size = 221808, upload-time = "2026-07-06T21:33:15.466Z" },
+    { url = "https://files.pythonhosted.org/packages/38/37/04f54b8e63a02f3d908332c9effbf8c366167c6f733ed8a3d4f79b7e2a1e/cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c", size = 225241, upload-time = "2026-07-06T21:33:16.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d6/c72eecca433cd3e681c65ed313ab4835d9d4a379704d0f628a6a05f51c2e/cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a", size = 223588, upload-time = "2026-07-06T21:33:18.239Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4b/e706f67279140f92939da3475ad610df18bfd52d50f14953a8e5fede71d5/cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2", size = 175248, upload-time = "2026-07-06T21:33:19.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512", size = 185717, upload-time = "2026-07-06T21:33:21.47Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/af/34fee85c48f8d94efc8597bc09470c9dd274c145f1c12e0fbc6ab6d38d74/cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f", size = 180114, upload-time = "2026-07-06T21:33:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/81478e482afa03f6d18dc8f2afb5edc45b3080853b634b5ed91961be0998/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a", size = 194142, upload-time = "2026-07-06T21:33:23.657Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/95/8de304305cd9204974b0ca051b86d307cafca13aa575a0ef1b44d92c0d8c/cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3", size = 196819, upload-time = "2026-07-06T21:33:25.007Z" },
+    { url = "https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d", size = 184965, upload-time = "2026-07-06T21:33:26.605Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac", size = 184952, upload-time = "2026-07-06T21:33:27.823Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6", size = 222353, upload-time = "2026-07-06T21:33:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a5/e8bbb1ce5b3ac2f53ad6a10bde44318a5a8d99d4f4a000d44a6e39aeb3e4/cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913", size = 210051, upload-time = "2026-07-06T21:33:30.534Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ed/c127d3ac36e899c965e3361357c3befacd6578c03f40125183e41c3b219e/cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d", size = 208630, upload-time = "2026-07-06T21:33:31.753Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5", size = 221593, upload-time = "2026-07-06T21:33:33.044Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/27/93195977168ee63aed233a1a0993a2178798654d1f4bddcdd321d6fd3b21/cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce", size = 225146, upload-time = "2026-07-06T21:33:34.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/c1/6dbd291ee2ae5a50a034aa057207081f545923bbf15dad4511e985aafff5/cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326", size = 223240, upload-time = "2026-07-06T21:33:35.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6f/ade5ce9863a57992a6ea3d0d10d7e29b8749fc127204b3d493d667b2815f/cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd", size = 177723, upload-time = "2026-07-06T21:33:51.626Z" },
+    { url = "https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb", size = 187937, upload-time = "2026-07-06T21:33:53.403Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/cc6ae6c2913a03aab8898eee57963cf1035b8df5872ed8b9115fcc7e2be8/cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804", size = 183001, upload-time = "2026-07-06T21:33:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f0/134c00ce0779ec86dea2aa1aac69339c2741a8045072676763512363a2ea/cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714", size = 188538, upload-time = "2026-07-06T21:33:36.792Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/3b86aba791cb610d24e8a3e1b2cd529e71fa15096b04e4d4e360049d4a4c/cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376", size = 188230, upload-time = "2026-07-06T21:33:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d0/117dcd9209255ad8571fbc8c92ef32593a1d294dcec91ddc4e4db50606f2/cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98", size = 223899, upload-time = "2026-07-06T21:33:39.514Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3d/f20f8b886b254e3ad10e15cd4186d3aed49f3e6a35ab37aab9f8f25f7c03/cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13", size = 211652, upload-time = "2026-07-06T21:33:40.851Z" },
+    { url = "https://files.pythonhosted.org/packages/28/3b/fad54de07260b93ddeef4b96d0131d57ea900675df1d410ae1deee52d7a6/cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d", size = 210755, upload-time = "2026-07-06T21:33:42.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/3d5c705acb7abbba9bbd7d79b8e62e0f25b6120eb7ae6ac49f1b721722fe/cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056", size = 223933, upload-time = "2026-07-06T21:33:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d0/47e338384ab6b1004241002fa616301020cea4fc95f283506565d252f276/cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4", size = 226749, upload-time = "2026-07-06T21:33:45.046Z" },
+    { url = "https://files.pythonhosted.org/packages/70/25/65bd5b58ea4bfdfc15cde02cb5365f89ef8ab8b2adfb8fe5c4bd4233382f/cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94", size = 225703, upload-time = "2026-07-06T21:33:46.374Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/78/aa01ac599a8a4322533d45a1f9bc93b338276d2d59dabbe7c6d92a775c81/cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76", size = 182857, upload-time = "2026-07-06T21:33:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/d00496b22de4d4228f32dde94ad996f350c8aad676d63bcca0743c8dea4d/cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5", size = 194065, upload-time = "2026-07-06T21:33:48.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dd/0c7dbf815a579ff005008a2d815a55d6bb047c349eef536d9dc53d3f0a8d/cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8", size = 186404, upload-time = "2026-07-06T21:33:50.309Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/8c8c50cb11c6750051daf12164098a9a6f027ac4356967fd4d800a07f242/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c", size = 194121, upload-time = "2026-07-06T21:33:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e2/67680bf19a6b60d2bb7ff83baefa2a4c3d2d7dc0f3277034b802e1fc504c/cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001", size = 196820, upload-time = "2026-07-06T21:33:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/da/4bbe583a3b3a5c8c60892124fe17f3fa3656523faf0d3484eae90f091853/cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3", size = 184936, upload-time = "2026-07-06T21:33:58.765Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4b/1f4c36ab273980d7aa75bb126ea4f8971f24a96108acad3a0a084028c57b/cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc", size = 185045, upload-time = "2026-07-06T21:34:00.085Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c3/ad299dc38f3583f8d916b299f028af418a9ec98bc695fcbebeae7420691c/cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699", size = 222342, upload-time = "2026-07-06T21:34:01.814Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d8/df4543cc087245044ed02ef3ad8e0a26619d0075ac7a77a12dc81177851b/cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022", size = 210073, upload-time = "2026-07-06T21:34:03.255Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/fac738d73728c6cea2a88a2883dca54892496cbba88a1dc1f2909cb8a6f5/cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0", size = 208551, upload-time = "2026-07-06T21:34:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3f/0b04a700dd64f465c93020253a793a82c9b4dff9961f48facd0df945d9b8/cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1", size = 221649, upload-time = "2026-07-06T21:34:06.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/b7379a5704c79eda57ce075869ba70a0368d1c850f803b3c0d078d39dcaf/cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28", size = 225203, upload-time = "2026-07-06T21:34:07.489Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/02/d5e6c43ea85c41bda2a184a3418f195fe7cf602967a8d2b94e085b83deef/cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629", size = 223263, upload-time = "2026-07-06T21:34:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d8/772b8259bf75749adffb1c546828978381fb516f60cf701f6c83daf60c85/cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6", size = 177696, upload-time = "2026-07-06T21:34:26.355Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dd/afa2191fc6d57fedd26e5844a2fe2fcc0bbfa00961bbaa5a41e4921e7cca/cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853", size = 187914, upload-time = "2026-07-06T21:34:27.58Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ef/6cd4f8c671517162379dc79cfae5aea9106bc38abb89628d5c16adf6a838/cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda", size = 183004, upload-time = "2026-07-06T21:34:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b6/12fc55092817a5faa26fb8c40c7f9d662e11a46ee248c137aafc42517d92/cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc", size = 188378, upload-time = "2026-07-06T21:34:09.926Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2e/cdac88979f295fde5daa69622c7d2111e56e7ceb94f211357fbe452339e4/cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca", size = 188319, upload-time = "2026-07-06T21:34:11.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/27/1d0b408497e41a74795af122d7b603c418c5fed0171450f899afd04e594f/cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d", size = 223904, upload-time = "2026-07-06T21:34:12.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/31/e115c985105dd7ffb32444505f18ceb874bb42d992af05d5dced7ecf1980/cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8", size = 211554, upload-time = "2026-07-06T21:34:13.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/9e6e09409336d9e515c58367e7cfcf4f89df06ad25252675595a58eb59d5/cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd", size = 210795, upload-time = "2026-07-06T21:34:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e5/d3cc82a4a0be7902af279c04181ad038449c096734464a5ae1de3e1401bd/cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f", size = 223843, upload-time = "2026-07-06T21:34:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/b434abc97ce7cecc2c640fde160507c0ecc7e21544b483ba3325d2e2ea17/cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc", size = 226773, upload-time = "2026-07-06T21:34:19.05Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/9f/d4dc66ca651eb1145a133314cda721abf13cfac3d28c4a0402263ae6ad75/cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9", size = 225719, upload-time = "2026-07-06T21:34:20.576Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5a/e536c528bc8057496c360c0978559a2dc45653f89dd6151078aa7d8fca1a/cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b", size = 182760, upload-time = "2026-07-06T21:34:22.059Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/0ffe8b82d3875bced5fa1e7986a7a46b748262a40ab7f60b475eb9fb1bb3/cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5", size = 193769, upload-time = "2026-07-06T21:34:23.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/17/1073b53b68c9b5ca6914adf5f8bf55aacc2d3be102418c90700160ea8605/cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210", size = 186405, upload-time = "2026-07-06T21:34:24.857Z" },
+]
+
+[[package]]
 name = "chardet"
 version = "6.0.0.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -696,30 +806,30 @@ wheels = [
 
 [[package]]
 name = "cuda-tile"
-version = "1.4.0"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/df/0bb510403487484bed0a844793a1e8a043e3c4fe35f92f6e1cb5de3bd35e/cuda_tile-1.4.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:8758454ae3971cd8dc195a61210e42ad3696528a9da6a4a429da4cdbbf305d80", size = 281176, upload-time = "2026-05-27T17:45:03.394Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/6f/a20b815a20b578c42bd056e40749477efc33dc098cb04dc3c7a3417b17b3/cuda_tile-1.4.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:63fc9edd9376a196870ff9dcd9cdb9a7e4d2f2271a4e531c390b232bc60ee0f0", size = 282606, upload-time = "2026-05-27T17:44:58.828Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/c2/bbf50ef77786c8b4d5160786d4ab205f567eec0e80dc93906b3340bd7edd/cuda_tile-1.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:bbfaa33f86d93c7a0ae1f82b626a9f442cd6ff5f991c8a4e7214abd170cf3d21", size = 269764, upload-time = "2026-05-27T17:46:35.832Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/d4/a5849ee8ee58d0275c9e7738aa5b16d1ad669ed5aa4d1b26af683eda065e/cuda_tile-1.4.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:da2649de97cbaf886d564a9f75b3bd2fb112999c99c58a27c817a46bb8725f29", size = 280897, upload-time = "2026-05-27T17:44:57.197Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/1b/575207f424c75e7b1608e056a89c15bfc3750f6178e5c659f693a7e822b1/cuda_tile-1.4.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:5741a789aaff85e3b2417b8611f0d11f967b9bac567432f0057b2b8bf72259ac", size = 282060, upload-time = "2026-05-27T17:44:58.877Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/c9/1b8df78c55f7ef544e7b7aab381a99495650d49c65e3ba85189e888b89b7/cuda_tile-1.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:9825202c1175dcac6c2daafd176da4444801e13049b4e2688d92f5b582f6ea6d", size = 269373, upload-time = "2026-05-27T17:46:43.531Z" },
-    { url = "https://files.pythonhosted.org/packages/42/93/64ef40d3982dcda7a97ebfa3e3bb9045b573d4eb3877fa5d1fa3cd2541d3/cuda_tile-1.4.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:9e358a85a153820aa0a51d0e09346d884a3c14b88c0313d20d0fb9f53952abae", size = 280953, upload-time = "2026-05-27T17:46:53.03Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/9a/7fbdbdb30c375f80818941165adfc4f1dc6cebaf937c6a9081a02d5871f0/cuda_tile-1.4.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:1d9d99b6fa57366af3f8707ac4fd91411275af2ee736996a60620240fcf92070", size = 282503, upload-time = "2026-05-27T17:45:05.543Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/bb/4152dc08a8de5bcdc4b9d80b6917216289526f6e786b09ee80d4df27bcfb/cuda_tile-1.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:616f13cbc7af6caa7b92430b85ba0a429d1f96ca9e7e04a29d89114cfe859663", size = 269813, upload-time = "2026-05-27T17:46:20.583Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/ad/42f0655e6aee5c59015634b46d7f13bc22e74af28d10fb2008a062b37349/cuda_tile-1.4.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:fc74185efd81f6153af0a19549d111dec6861ee9b9bc27927a2cef6e19173eb5", size = 280958, upload-time = "2026-05-27T17:46:53.061Z" },
-    { url = "https://files.pythonhosted.org/packages/11/0b/4770f9e36b8108ce8c9078f71eb21c65e594d79c0770dd38daa045cfbd6c/cuda_tile-1.4.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:45be74f6568c440446f510bc7799b953858e64c6abf26e96f2c9598a79084860", size = 282508, upload-time = "2026-05-27T17:45:18.515Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/67/41f1acdf21bf6214a3a1c3b46d39b8eb0f9eba7aecc6b57005db35d56f9a/cuda_tile-1.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:edd1df4d7955032c7be2a26c6d7e47261415ba7c87587705e0f4f1fd0d61650a", size = 269783, upload-time = "2026-05-27T17:47:16.631Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/c6/46a329f4c56ce54471784366394e235804423df2531307e14112e4636c76/cuda_tile-1.4.0-cp314-cp314-manylinux2014_aarch64.whl", hash = "sha256:738593650784ebb3c601486914b563e7569144fe596048766ea9e12280ac3bb9", size = 281208, upload-time = "2026-05-27T17:46:48.325Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/fb/bf3849ad68b1858ba50e6992863d266892d7d7db02d11c485c26cd090a1b/cuda_tile-1.4.0-cp314-cp314-manylinux2014_x86_64.whl", hash = "sha256:4b1a591c26836a550c2bf87c22d31c4716e5f83d24d255f843d9429625cca973", size = 282630, upload-time = "2026-05-27T17:45:10.789Z" },
-    { url = "https://files.pythonhosted.org/packages/61/bb/211c0d5121230ee76cfc1a9ee107ec28aaae9e6ffb43a04aa172d0d4f4dc/cuda_tile-1.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19e10fe70ba92709b6ca446d1c52a8a346b56f4f8ad7c8941736f60e32f3c87", size = 270644, upload-time = "2026-05-27T17:45:01.914Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/df/f7f1dfa4d1ee7cc5b69e11d756be6ffec1561a5c7e3836fd0f71ca49adcf/cuda_tile-1.4.0-cp314-cp314t-manylinux2014_aarch64.whl", hash = "sha256:b3cbeffbe0fedac4936edcf00b6ba13ab5ddb74d3b7ce4a287dfc04491b5f6af", size = 283249, upload-time = "2026-05-27T17:46:12.032Z" },
-    { url = "https://files.pythonhosted.org/packages/18/c0/fee527a085fca414fc993769912eb8ba2e15ce388f3168b868706e6d4c61/cuda_tile-1.4.0-cp314-cp314t-manylinux2014_x86_64.whl", hash = "sha256:675b2afff62af5d4e72c34bc72d0be27b0933a44933b8a449f590fbded8c1107", size = 284336, upload-time = "2026-05-27T17:44:59.489Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/ab/0883194457932150a5ad334d609ac17bd704345974d21c8bae6ea251e7ed/cuda_tile-1.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3f58eac5577ea3ed7c17bfcab015a506fd2cf61f8848407c5b403f1bf46c55ca", size = 275861, upload-time = "2026-05-27T17:46:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/78/1d/03499651b6957b31ab70c875d91f23220da5f8f84cbad1fb7cba2d7dd435/cuda_tile-1.5.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:27da6113d3469de0b2f75dd269904e730b6d2bc81336addbd299c593d6a125c4", size = 322958, upload-time = "2026-07-08T01:49:22.702Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/aa/8af16bde9b0c41cda286791749a246195716a15eea7f0dc79a99d37d8686/cuda_tile-1.5.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:cc390ac00d2ecd5f7c2e26198b410787fa39baf3737c6abceac9bda3ca9fccef", size = 324757, upload-time = "2026-07-08T01:49:17.497Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ed/e98669f59bdea9d5f698cb22aab3bbc6ed10eadef640a79bf2d7e5a3c4cc/cuda_tile-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:d808355e4cb6a850c7e3e82a5cd656c0062c33225fce69a8fd40290bc5b0bcaa", size = 305184, upload-time = "2026-07-08T01:49:28.779Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/4d/e07fd65640c26c1f990ee621af11f073672e8d96501663026c7e1978f5b8/cuda_tile-1.5.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:81b8a93e757258260bd05dbbe6eec8bb50655ee1a88d5ebbc8412c526d3c0ed4", size = 322684, upload-time = "2026-07-08T01:49:21.318Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/981c2eb351f15a4b75b5913e35d2ef16cee32a45c950d0e16f85e626dd05/cuda_tile-1.5.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:9494170237d34bbbce83f2ada005d2dabb704f1f8c6a0af59088c180bd1bf028", size = 324278, upload-time = "2026-07-08T01:49:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b2/a863d460f6b70431869be5a18f82b1a1af91b5d7629e914c204e3545cac2/cuda_tile-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:bda5f1721a6daa45124033f031685d1b30439ea9dbb07e0d46ec2355cfde0657", size = 304926, upload-time = "2026-07-08T01:49:16.158Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/6d/cc2fb5a25689a501564a2eced4acf654f307e801a2c1506be97c0d100491/cuda_tile-1.5.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:87652483baa9c81a9a24e4450f016e4ee78fd205d8422dad8996571bd1f2622e", size = 322641, upload-time = "2026-07-08T01:49:23.388Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f5/b4ba9d0fc71198d939ebf9a090228179995d8411ee9def8f638a0e3ccdc5/cuda_tile-1.5.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:cef6d30acc37557643ece0de3770fc4c33497c4af40209e424f72fbfcbe6ea5a", size = 324990, upload-time = "2026-07-08T01:49:17.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/7a60f317c503580ab7946dbb7fd080438fe953d0ddfdc81904beb9a1fab7/cuda_tile-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:16d97a60ed1d33388abbca85ea08cdae6325cc700476b3135f190d0fb50329f4", size = 304817, upload-time = "2026-07-08T01:49:38.853Z" },
+    { url = "https://files.pythonhosted.org/packages/00/46/60aea981ee7cc0b159eb08c42b795e8e95ae8a7fb451e4565cad0f43cca0/cuda_tile-1.5.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:cfa4a5ef920d9c1fee702611b25bde449915f12bf929c1b8a3faee0c9b03f750", size = 322643, upload-time = "2026-07-08T01:49:26.107Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d5/ae03d2b70ed8d6c21ca809ddc98227ad07988e7fe67e7e41d888c0b13d32/cuda_tile-1.5.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:e7cb56186b0cc98166b72c7e5a3764c236151aa8d53e0b37a153766b79ea005a", size = 324995, upload-time = "2026-07-08T01:49:19.931Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a6/e3f6e9aefcc94d548e5d69f01a02ba5da7c5e200702eba3eb7a4f572a883/cuda_tile-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:c400918faa8492d84c4da3da81ce01ed30d81ed780f9ddbc1a9bdd588058b776", size = 304825, upload-time = "2026-07-08T01:49:37.749Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f2/861000a1cc2204be90295c980c488670600e89c638138192c61bf79949f1/cuda_tile-1.5.0-cp314-cp314-manylinux2014_aarch64.whl", hash = "sha256:b88d7a3ea0cb30a962c0ff9cb01e2b2b87c6ef816fd53dd92ead3bcff3449e37", size = 322775, upload-time = "2026-07-08T01:49:25.897Z" },
+    { url = "https://files.pythonhosted.org/packages/65/38/165499cbfb7c1ada110592fa9224e20851125b337bbe2e656b5d56c676f0/cuda_tile-1.5.0-cp314-cp314-manylinux2014_x86_64.whl", hash = "sha256:d4054dc12b6d35d69cb07fcc224183b84f3ad1a0e85ec4414cf660144b8467b0", size = 325052, upload-time = "2026-07-08T01:49:20.082Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/76/4f0b7bd3ac2d8383b3cc166ce67c528653b51a761ebc0fc6c132e57ef19b/cuda_tile-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:b3c5e0a5af1347b6326fe7a49e44b15ea01ae2d8ed138617c8331b6aba311d16", size = 305719, upload-time = "2026-07-08T01:50:05.793Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/53/e5947ebd44774183f72c317907d803648d8cd87e8a571bb0a4e89a578309/cuda_tile-1.5.0-cp314-cp314t-manylinux2014_aarch64.whl", hash = "sha256:a4ede5529bd5e13318ec9bbf3f79abaf23b6368c58d247eaf2e5eb5ccae3fa73", size = 324979, upload-time = "2026-07-08T01:49:29.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b8/6260d8089287dd8e8f5e456a60391537520b20cd90287eacaac4c71fd140/cuda_tile-1.5.0-cp314-cp314t-manylinux2014_x86_64.whl", hash = "sha256:1088a3ebb5622c24ec32034d0d451bab9c1b85ae67fcdc647464951ec1d1b6ad", size = 326849, upload-time = "2026-07-08T01:49:23.211Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ea/104cd115a15768ed3e6d58ce658744784e3376dcf9ca5f1402c6ddab61f5/cuda_tile-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70ecc0e4be063317b5216dc620085be8021f78092a81613268129693cf63e179", size = 313357, upload-time = "2026-07-08T01:50:02.713Z" },
 ]
 
 [package.optional-dependencies]
@@ -2299,9 +2409,9 @@ name = "nvidia-cuda-nvcc"
 version = "13.3.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-crt" },
-    { name = "nvidia-cuda-runtime" },
-    { name = "nvidia-nvvm" },
+    { name = "nvidia-cuda-crt", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
+    { name = "nvidia-cuda-runtime", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
+    { name = "nvidia-nvvm", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/b6/bb07a3a63b5b7b55516366747892abbf3ee62d616684c40bb51e6cbfe956/nvidia_cuda_nvcc-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c348623b1434aebd234da9ec1f81022587ae4995d65c3dc8a7743245cc441f7", size = 39515074, upload-time = "2026-05-26T16:34:28.489Z" },
@@ -2333,9 +2443,9 @@ name = "nvidia-cuda-tileiras"
 version = "13.3.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvcc" },
-    { name = "nvidia-nvjitlink" },
-    { name = "nvidia-nvvm" },
+    { name = "nvidia-cuda-nvcc", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
+    { name = "nvidia-nvvm", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/bd/89c65b2067a2a707cc92fad6d34e96ae53a495805f563642244649f9cee2/nvidia_cuda_tileiras-13.3.36-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:91510f8f9b4f4b3f3a365c43218b62873b5ae1474db6b32eb3ece7f0934496af", size = 36181023, upload-time = "2026-05-26T16:41:51.373Z" },
@@ -2348,7 +2458,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.13.0.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/9c/9e99c00dc23db324244ec257d1e84d79539202ee2f185dee2c1fa97c9549/nvidia_cudnn_cu13-9.13.0.50-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:33f0aa0b64230101b348648fd0693342188071d3f8a137c0cf50051c24b3584b", size = 412337597, upload-time = "2025-09-04T20:22:31.535Z" },
@@ -2385,7 +2495,7 @@ name = "nvidia-cufft"
 version = "12.0.0.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/e9/4e49b1baf6899e42eeec324a49d7aa2219fec42076327c4e468000dd375a/nvidia_cufft-12.0.0.15-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1885731254835797572ff075f3daf43a2a0a2801210dea26971940dae7e1a367", size = 214053580, upload-time = "2025-08-04T10:20:45.781Z" },
@@ -2415,9 +2525,9 @@ name = "nvidia-cusolver"
 version = "12.0.3.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/bb/2e60de9bb1f0c3395eabd91ccad00f4ba3ef736dc9190a158a9d268419f5/nvidia_cusolver-12.0.3.29-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:3bb6e65ce0beaeafdd069b320246e8f17c1cd30ddb27a0539143a3706733a4d8", size = 193104180, upload-time = "2025-08-04T10:22:19.821Z" },
@@ -2429,7 +2539,7 @@ name = "nvidia-cusparse"
 version = "12.6.2.49"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/30/f32023427f2ef4ec27e8293dfddb5068de566912cd0a45eccfd400017a62/nvidia_cusparse-12.6.2.49-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5d3269c19283a0057fb5ebfb003ae2a10c97a28a6958f4238354826b055827c7", size = 155888587, upload-time = "2025-08-04T10:23:04.091Z" },
@@ -3056,6 +3166,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
     { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
     { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -4155,6 +4274,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "cffi" },
     { name = "flashinfer-bench" },
     { name = "pytest-html" },
     { name = "pytest-split" },
@@ -4172,9 +4292,10 @@ liger = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", specifier = "==1.13.0" },
+    { name = "cffi", marker = "extra == 'dev'" },
     { name = "cuda-bindings", specifier = ">=13.2.0" },
     { name = "cuda-core", specifier = ">=0.7.0" },
-    { name = "cuda-tile", extras = ["tileiras"], specifier = ">=1.3.0" },
+    { name = "cuda-tile", extras = ["tileiras"], specifier = ">=1.5.0" },
     { name = "filelock", specifier = ">=3.20.3" },
     { name = "flashinfer-bench", marker = "extra == 'dev'", specifier = "==0.1.2" },
     { name = "huggingface-hub" },

--- a/src/tilegym/__init__.py
+++ b/src/tilegym/__init__.py
@@ -39,7 +39,6 @@ from .backend import is_backend_available
 from .backend import print_registry_info
 from .backend import set_backend
 
-# Setup cutile integration
 if is_backend_available("cutile"):
     # Apply experimental kernel tracking patch
     from .experimental import _apply_patch as _apply_experimental_patch

--- a/src/tilegym/backend/cutile_rs/utils.py
+++ b/src/tilegym/backend/cutile_rs/utils.py
@@ -69,9 +69,9 @@ def _ops_src_root() -> str:
     return os.path.join(os.path.dirname(__file__), "..", "..", "ops", "cutile_rs")
 
 
-def _shared_so_path(crate_dir: str, profile: str = "release") -> str:
-    """The one cdylib for all ops: <crate>/target/<profile>/libcutile_kernels.so."""
-    return os.path.join(crate_dir, "target", profile, "libcutile_kernels.so")
+def _shared_so_path(crate_dir: str, profile: str = "release", so_name: str = "libcutile_kernels.so") -> str:
+    """The one cdylib for all ops: <crate>/target/<profile>/<so_name>."""
+    return os.path.join(crate_dir, "target", profile, so_name)
 
 
 # ── Auto-build on stale source (default ON; opt-out via CUTILE_RS_AUTOBUILD=0) ─
@@ -82,19 +82,27 @@ def _autobuild_enabled() -> bool:
     return os.environ.get("CUTILE_RS_AUTOBUILD", "1").lower() not in ("0", "false", "no")
 
 
-def _so_stale(so_path: str) -> bool:
-    """Stale if the .so is missing or older than any .rs/.toml under
-    ops/cutile_rs/ (the crate src + every <op>_kernel/ source). target/ skipped.
+def _so_stale(so_path: str, src_roots: str | tuple[str, ...] | None = None) -> bool:
+    """Stale if the .so is missing or older than any .rs/.toml under the
+    ``src_roots`` dir(s) (default ops/cutile_rs/ — the crate src + every
+    <op>_kernel/ source). target/ skipped. Suites with their own kernels crate
+    pass their cutile_rs/ source root (plus ops/cutile_rs/ for the shared
+    ffi_util.rs they include).
     """
     if not os.path.isfile(so_path):
         return True
     so_mtime = os.path.getmtime(so_path)
-    for root, _, files in os.walk(_ops_src_root()):
-        if "target" in root.split(os.sep):
-            continue
-        for f in files:
-            if f.endswith((".rs", ".toml")) and os.path.getmtime(os.path.join(root, f)) > so_mtime:
-                return True
+    if src_roots is None:
+        src_roots = (_ops_src_root(),)
+    elif isinstance(src_roots, str):
+        src_roots = (src_roots,)
+    for src_root in src_roots:
+        for root, _, files in os.walk(src_root):
+            if "target" in root.split(os.sep):
+                continue
+            for f in files:
+                if f.endswith((".rs", ".toml")) and os.path.getmtime(os.path.join(root, f)) > so_mtime:
+                    return True
     return False
 
 
@@ -112,22 +120,27 @@ _BUILD_ENV_KEYS_KERNEL = (
     "RUSTFLAGS",
     "CUDA_TOOLKIT_PATH",
     "LIBCLANG_PATH",
+    "BINDGEN_EXTRA_CLANG_ARGS",
 )
 
 
-def _build_kernels(crate_dir: str) -> None:
-    """``cargo build --release`` the single cutile_kernels crate into its own
+def _build_kernels(
+    crate_dir: str,
+    src_roots: str | tuple[str, ...] | None = None,
+    so_name: str = "libcutile_kernels.so",
+) -> None:
+    """``cargo build --release`` a single kernels crate into its own
     target/ (crates.io deps; no cutile-rs checkout). File-locked + re-checks
     staleness inside the lock so concurrent callers don't rebuild redundantly.
     """
     import fcntl
 
-    so_path = _shared_so_path(crate_dir)
+    so_path = _shared_so_path(crate_dir, so_name=so_name)
     os.makedirs(os.path.dirname(so_path), exist_ok=True)
     lock_path = os.path.join(crate_dir, ".build.lock")
     with open(lock_path, "w") as lock_f:
         fcntl.flock(lock_f, fcntl.LOCK_EX)
-        if not _so_stale(so_path):
+        if not _so_stale(so_path, src_roots):
             return
         logger.info(f"cutile-rs: building libcutile_kernels.so (cargo build --release) in {crate_dir} ...")
         t0 = time.time()
@@ -175,22 +188,30 @@ def _build_kernels(crate_dir: str) -> None:
         logger.info(f"cutile-rs: built libcutile_kernels.so in {time.time() - t0:.1f}s")
 
 
-def _ensure_built_and_path() -> str:
+def _ensure_built_and_path(
+    crate_dir: str | None = None,
+    src_roots: str | tuple[str, ...] | None = None,
+    so_name: str = "libcutile_kernels.so",
+) -> str:
     """Resolve the shared .so path, autobuilding if enabled+stale.
+
+    Defaults to the ops crate (ops/cutile_rs/cutile_kernels/); suites with
+    their own kernels crate pass crate_dir/src_roots/so_name explicitly.
 
     The staleness check runs before the first load, so each process builds (when
     needed) and then loads current kernels. The cffi handle cache is dropped on a rebuild, but note this does NOT hot-reload within a live process
     that has already dlopen'd the .so: re-loading the same path reuses the OS
     dlopen mapping, so an in-place rebuild only takes effect in the next process.
     """
-    crate_dir = _kernels_crate_dir()
+    if crate_dir is None:
+        crate_dir = _kernels_crate_dir()
     if crate_dir is None:
         raise RuntimeError(
             "cutile-rs kernels crate not found (expected ops/cutile_rs/cutile_kernels/ with a Cargo.toml)."
         )
-    so_path = _shared_so_path(crate_dir)
-    if _autobuild_enabled() and _so_stale(so_path):
-        _build_kernels(crate_dir)
+    so_path = _shared_so_path(crate_dir, so_name=so_name)
+    if _autobuild_enabled() and _so_stale(so_path, src_roots):
+        _build_kernels(crate_dir, src_roots, so_name)
         _cffi_kernel_libs.clear()
     if not os.path.isfile(so_path):
         raise RuntimeError(
@@ -214,8 +235,8 @@ _cffi_kernel_libs: dict[str, tuple] = {}
 # Generic C-ABI tensor descriptor shared by all cutile-rs ops (the "packer"
 # side). MUST stay in sync with `TensorDesc` in ops/cutile_rs/ffi_util.rs
 # (#[repr(C)], MAX_DIMS=5, strides in ELEMENTS, dtype: 0=f32/1=f16/2=bf16/3=i32/
-# 4=i64/5=f8e5m2). It is prepended to every op's cdef in bind_kernel_function_cffi,
-# so an op signature can just take `const TensorDesc*` args.
+# 4=i64/5=f8e5m2/6=f4e2m1fnx2/7=f8e4m3fn). It is prepended to every op's cdef in
+# bind_kernel_function_cffi, so an op signature can just take `const TensorDesc*` args.
 _TENSORDESC_MAX_DIMS = 5
 _TENSORDESC_CDEF = """
 typedef struct {
@@ -229,7 +250,9 @@ typedef struct {
 
 # torch.dtype -> TensorDesc.dtype code. Keep in sync with ffi_util::dtype_str.
 # int32 (code 3) / int64 (code 4) are integer tensors (index / descriptor-table
-# entries); float8_e5m2 (code 5) is a low-precision element type.
+# entries); float8_e5m2 (code 5) is a low-precision element type. uint8 (code 6)
+# carries packed NVFP4 pairs (cutile f4e2m1fnx2: two E2M1 nibbles per byte, low
+# nibble = even element); float8_e4m3fn (code 7) carries NVFP4 block scales.
 _DTYPE_CODE = {
     "torch.float32": 0,
     "torch.float16": 1,
@@ -237,6 +260,8 @@ _DTYPE_CODE = {
     "torch.int32": 3,
     "torch.int64": 4,
     "torch.float8_e5m2": 5,
+    "torch.uint8": 6,
+    "torch.float8_e4m3fn": 7,
 }
 
 
@@ -265,12 +290,23 @@ def make_tensor_desc(ffi, t):
     return d
 
 
-def bind_kernel_function_cffi(kernel: str, cdef: str):
+def bind_kernel_function_cffi(
+    kernel: str,
+    cdef: str,
+    crate_dir: str | None = None,
+    src_roots: str | tuple[str, ...] | None = None,
+    so_name: str = "libcutile_kernels.so",
+):
     """cffi ABI-mode loader. Returns ``(ffi, lib)``; call ``lib.cutile_<op>(...)``
     (returns a plain int rc — feed to :func:`check_rc`). Loads the shared
     libcutile_kernels.so and cdefs this op's signature. The shared TensorDesc
     typedef is prepended automatically, so ops can take ``const TensorDesc*``
     args and pack tensors via :func:`make_tensor_desc`.
+
+    Suites with their own kernels crate pass ``crate_dir`` / ``src_roots`` /
+    ``so_name`` explicitly; the defaults bind against the ops crate.
+    ``kernel`` keys the cffi handle cache, so it must be unique across all
+    crates.
 
     Usage::
         ffi, lib = bind_kernel_function_cffi("matmul", _FFI_CDEF)
@@ -282,7 +318,7 @@ def bind_kernel_function_cffi(kernel: str, cdef: str):
 
     if kernel in _cffi_kernel_libs:
         return _cffi_kernel_libs[kernel]
-    so_path = _ensure_built_and_path()
+    so_path = _ensure_built_and_path(crate_dir, src_roots, so_name)
     ffi = FFI()
     ffi.cdef(_TENSORDESC_CDEF + cdef)
     lib = ffi.dlopen(so_path)

--- a/src/tilegym/kernel_inventory/__init__.py
+++ b/src/tilegym/kernel_inventory/__init__.py
@@ -41,6 +41,10 @@ class KernelInventoryError(ValueError):
     """Raised when kernel inventory metadata is invalid."""
 
 
+# Backend subdirectories a suite may use below kernel_solutions/.
+_SUITE_BACKENDS = ("triton", "cutile", "cutile_rs")
+
+
 def load_json(path: str | Path) -> dict[str, Any]:
     """Load a JSON object from ``path``."""
     with Path(path).open(encoding="utf-8") as f:
@@ -65,7 +69,7 @@ def iter_kernel_definition_paths(root: str | Path) -> Iterator[Path]:
     paths.update(
         path
         for path in suite_paths
-        if any((path.parent.parent / "kernel_solutions" / backend).is_dir() for backend in ("triton", "cutile"))
+        if any((path.parent.parent / "kernel_solutions" / backend).is_dir() for backend in _SUITE_BACKENDS)
     )
     yield from sorted(paths)
 
@@ -73,10 +77,8 @@ def iter_kernel_definition_paths(root: str | Path) -> Iterator[Path]:
 def iter_kernel_solution_paths(root: str | Path) -> Iterator[Path]:
     """Yield checked-in backend-specific Solution JSON files under ``root``."""
     root_path = Path(root)
-    patterns = (
-        "src/tilegym/transformers/*/kernel_solutions/*.json",
-        "src/tilegym/suites/*/kernel_solutions/triton/*.json",
-        "src/tilegym/suites/*/kernel_solutions/cutile/*.json",
+    patterns = ("src/tilegym/transformers/*/kernel_solutions/*.json",) + tuple(
+        f"src/tilegym/suites/*/kernel_solutions/{backend}/*.json" for backend in _SUITE_BACKENDS
     )
     yield from _iter_paths(root_path, patterns)
 
@@ -104,7 +106,7 @@ def iter_solution_paths_for_definition(definition_path: str | Path) -> Iterator[
     if transformer_solution.is_file():
         yield transformer_solution
 
-    for backend in ("triton", "cutile"):
+    for backend in _SUITE_BACKENDS:
         suite_solution = definition.parent.parent / "kernel_solutions" / backend / definition.name
         if suite_solution.is_file():
             yield suite_solution

--- a/src/tilegym/ops/cutile/bmm.py
+++ b/src/tilegym/ops/cutile/bmm.py
@@ -267,7 +267,7 @@ def _persistent_bmm_autotune_base(stream, a, b, output, batch_size, M, N, K, tra
     # Call autotuner to find the best config and execute the kernel
     cache_key = (batch_size, M, N, K, transpose_a, transpose_b, a.dtype, str(a.device))
     if cache_key not in _bmm_tune_cache:
-        with ct.compiler_timeout(10):
+        with ct.compiler_timeout(15):
             result = exhaustive_search(
                 list(_bmm_autotune_configs()),
                 stream,

--- a/src/tilegym/ops/cutile/chunk_gated_delta_rule.py
+++ b/src/tilegym/ops/cutile/chunk_gated_delta_rule.py
@@ -24,9 +24,30 @@ def _ct_mm(a, b):
     return ct.astype(ct.matmul(a, b), ct.float32)
 
 
-def _ct_solve_tril_neumann(A, CS, n_steps):
-    """Return (I - A)^-1 for strictly lower-triangular (nilpotent) A via
-    Neumann-by-squaring.  Plain helper (no @ct.kernel).
+def _ct_solve_tril_serial(A, CS):
+    """Invert a unit lower-triangular system in reference operation order."""
+    offs = ct.arange(CS, dtype=ct.int32)
+    for i in range(1, CS):
+        is_row = offs == i
+        is_row_col = ct.expand_dims(is_row, axis=1)
+        row = ct.sum(ct.where(is_row_col, A, 0.0), axis=0)
+        correction = ct.sum(ct.expand_dims(row, axis=1) * A, axis=0)
+        A = A + ct.where(is_row_col, ct.expand_dims(correction, axis=0), 0.0)
+    eye = ct.where(
+        ct.expand_dims(offs, axis=1) == ct.expand_dims(offs, axis=0),
+        1.0,
+        0.0,
+    )
+    return A + eye
+
+
+def _ct_solve_tril_neumann_guarded(A, CS, n_steps):
+    """Use fast Neumann-by-squaring only when its powers cannot grow.
+
+    Full-fp32 Neumann products still create cancellation terms up to 1e15 on
+    correlated model keys, so changing MMA precision alone is insufficient.
+    The matrix infinity norm is submultiplicative, so ||A||_inf < 1 bounds every
+    squared power instead of discovering instability after the expensive solve.
     """
     offs = ct.arange(CS, dtype=ct.int32)
     eye = ct.where(
@@ -34,12 +55,17 @@ def _ct_solve_tril_neumann(A, CS, n_steps):
         1.0,
         0.0,
     )
-    P = eye + A  # (I + A)  -- first factor kept in fp32 (exact)
-    Apow = A
-    for _ in range(1, n_steps):
-        Apow = _ct_mm(Apow, Apow)  # A^(2^j)
-        P = _ct_mm(P, eye + Apow)  # accumulate (I + A^(2^j))
-    return P
+    norm_inf = ct.max(ct.sum(ct.abs(A), axis=1))
+    result = A
+    if norm_inf < 1.0:
+        result = eye + A
+        A_power = A
+        for _ in range(1, n_steps):
+            A_power = _ct_mm(A_power, A_power)
+            result = _ct_mm(result, eye + A_power)
+    else:
+        result = _ct_solve_tril_serial(A, CS)
+    return result
 
 
 @ct.kernel(occupancy=2)
@@ -62,7 +88,7 @@ def _intra_chunk_prepare_kernel(
     USE_QK_L2NORM: ConstBool,
     CHUNK_SIZE: ConstInt,
     BLOCK_K: ConstInt,
-    SOLVE_STEPS: ConstInt,  # ceil(log2(CHUNK_SIZE)); Neumann-by-squaring factor count
+    SOLVE_STEPS: ConstInt,
     INTER_BF16: ConstBool,  # bf16 intermediates (only when input is bf16/fp16)
 ):
     """Grid: (B*H, num_chunks, 1).  Each program handles one (b, h, chunk)."""
@@ -73,7 +99,7 @@ def _intra_chunk_prepare_kernel(
 
     _ZERO = ct.PaddingMode.ZERO
 
-    # General path (any chunk size): full CHUNK_SIZE x CHUNK_SIZE Neumann solve.
+    # General path (any chunk size): full reference-order triangular solve.
     k_tile = ct.astype(
         ct.load(
             K,
@@ -121,7 +147,12 @@ def _intra_chunk_prepare_kernel(
     kb_tile = k_tile * ct.expand_dims(beta_tile, axis=1)
     base_attn = _ct_mm(kb_tile, ct.transpose(k_tile))
     attn = ct.where(strict_lower, -(base_attn * decay_mask), 0.0)
-    attn = _ct_solve_tril_neumann(attn, CHUNK_SIZE, SOLVE_STEPS)
+    if USE_QK_L2NORM:
+        # Model-normalized keys can be nearly collinear; keep their exact
+        # reference-order solve so small prefill differences cannot alter decode.
+        attn = _ct_solve_tril_serial(attn, CHUNK_SIZE)
+    else:
+        attn = _ct_solve_tril_neumann_guarded(attn, CHUNK_SIZE, SOLVE_STEPS)
 
     num_v_tiles = ct.cdiv(V_dim, BLOCK_K)
     for vt in range(num_v_tiles):
@@ -345,10 +376,6 @@ class _ChunkGatedDeltaRuleCuTile(torch.autograd.Function):
 
         device = query.device
         BLOCK_K = 1 << (K - 1).bit_length()
-        # Neumann-by-squaring factor count for the CHUNK_SIZE x CHUNK_SIZE solve
-        # (s = ceil(log2(chunk_size))); over-provisioning is safe (extra factors
-        # past nilpotency are identity), so this also covers the 64-path's 32x32
-        # sub-blocks. Computed on the host where chunk_size is a real Python int.
         solve_steps = max(1, (chunk_size - 1).bit_length())
 
         # Allocate intermediates (5D). The four (chunk_size, K/V) buffers are the

--- a/src/tilegym/ops/cutile/chunk_gated_delta_rule.py
+++ b/src/tilegym/ops/cutile/chunk_gated_delta_rule.py
@@ -24,24 +24,25 @@ def _ct_mm(a, b):
     return ct.astype(ct.matmul(a, b), ct.float32)
 
 
-def _ct_solve_tril(A, CS):
-    """Invert (I + A) for strictly lower triangular A.  Plain helper (no @ct.kernel)."""
+def _ct_solve_tril_neumann(A, CS, n_steps):
+    """Return (I - A)^-1 for strictly lower-triangular (nilpotent) A via
+    Neumann-by-squaring.  Plain helper (no @ct.kernel).
+    """
     offs = ct.arange(CS, dtype=ct.int32)
-    for i in range(1, CS):
-        is_row = offs == i
-        is_row_col = ct.expand_dims(is_row, axis=1)  # (CS, 1)
-        row = ct.sum(ct.where(is_row_col, A, 0.0), axis=0)  # (CS,)
-        corr = ct.sum(ct.expand_dims(row, axis=1) * A, axis=0)  # (CS,)
-        A = A + ct.where(is_row_col, ct.expand_dims(corr, axis=0), 0.0)
     eye = ct.where(
         ct.expand_dims(offs, axis=1) == ct.expand_dims(offs, axis=0),
         1.0,
         0.0,
     )
-    return A + eye
+    P = eye + A  # (I + A)  -- first factor kept in fp32 (exact)
+    Apow = A
+    for _ in range(1, n_steps):
+        Apow = _ct_mm(Apow, Apow)  # A^(2^j)
+        P = _ct_mm(P, eye + Apow)  # accumulate (I + A^(2^j))
+    return P
 
 
-@ct.kernel
+@ct.kernel(occupancy=2)
 def _intra_chunk_prepare_kernel(
     Q,
     K,
@@ -61,6 +62,8 @@ def _intra_chunk_prepare_kernel(
     USE_QK_L2NORM: ConstBool,
     CHUNK_SIZE: ConstInt,
     BLOCK_K: ConstInt,
+    SOLVE_STEPS: ConstInt,  # ceil(log2(CHUNK_SIZE)); Neumann-by-squaring factor count
+    INTER_BF16: ConstBool,  # bf16 intermediates (only when input is bf16/fp16)
 ):
     """Grid: (B*H, num_chunks, 1).  Each program handles one (b, h, chunk)."""
     pid_bh = ct.bid(0)
@@ -70,216 +73,114 @@ def _intra_chunk_prepare_kernel(
 
     _ZERO = ct.PaddingMode.ZERO
 
-    if CHUNK_SIZE == 64:
-        # Hierarchical 32×32 block solve for CHUNK_SIZE=64
-        # 2 diagonal blocks + 1 off-diagonal (simpler than old 16×16).
-        BS = 32
-        offs_bs = ct.arange(BS, dtype=ct.int32)
-        strict_lower_bs = ct.expand_dims(offs_bs, axis=1) > ct.expand_dims(offs_bs, axis=0)
+    # General path (any chunk size): full CHUNK_SIZE x CHUNK_SIZE Neumann solve.
+    k_tile = ct.astype(
+        ct.load(
+            K,
+            index=(b, pid_chunk, h, 0),
+            shape=(1, CHUNK_SIZE, 1, BLOCK_K),
+            padding_mode=_ZERO,
+        ).reshape((CHUNK_SIZE, BLOCK_K)),
+        ct.float32,
+    )
 
-        t_base = pid_chunk * 2  # block index into T dim (32-row blocks)
+    if USE_QK_L2NORM:
+        k_tile = k_tile * ct.rsqrt(ct.sum(k_tile * k_tile, axis=1, keepdims=True) + 1e-6)
 
-        k0 = ct.astype(
-            ct.load(K, index=(b, t_base, h, 0), shape=(1, BS, 1, BLOCK_K), padding_mode=_ZERO).reshape((BS, BLOCK_K)),
-            ct.float32,
-        )
-        k1 = ct.astype(
-            ct.load(K, index=(b, t_base + 1, h, 0), shape=(1, BS, 1, BLOCK_K), padding_mode=_ZERO).reshape(
-                (BS, BLOCK_K)
-            ),
-            ct.float32,
-        )
+    beta_tile = ct.astype(
+        ct.load(
+            Beta,
+            index=(b, pid_chunk, h),
+            shape=(1, CHUNK_SIZE, 1),
+            padding_mode=_ZERO,
+        ).reshape((CHUNK_SIZE,)),
+        ct.float32,
+    )
 
-        if USE_QK_L2NORM:
-            k0 = k0 * ct.rsqrt(ct.sum(k0 * k0, axis=1, keepdims=True) + 1e-6)
-            k1 = k1 * ct.rsqrt(ct.sum(k1 * k1, axis=1, keepdims=True) + 1e-6)
+    g_raw = ct.astype(
+        ct.load(
+            G,
+            index=(b, pid_chunk, h),
+            shape=(1, CHUNK_SIZE, 1),
+            padding_mode=_ZERO,
+        ).reshape((CHUNK_SIZE,)),
+        ct.float32,
+    )
+    g_cum = ct.cumsum(g_raw, axis=0)
 
-        b0 = ct.astype(
-            ct.load(Beta, index=(b, t_base, h), shape=(1, BS, 1), padding_mode=_ZERO).reshape((BS,)), ct.float32
-        )
-        b1 = ct.astype(
-            ct.load(Beta, index=(b, t_base + 1, h), shape=(1, BS, 1), padding_mode=_ZERO).reshape((BS,)), ct.float32
-        )
+    offs_c = ct.arange(CHUNK_SIZE, dtype=ct.int32)
+    offs_c_row = ct.expand_dims(offs_c, axis=1)
+    offs_c_col = ct.expand_dims(offs_c, axis=0)
+    lower_tri = offs_c_row >= offs_c_col
+    strict_lower = offs_c_row > offs_c_col
 
-        g0_raw = ct.astype(
-            ct.load(G, index=(b, t_base, h), shape=(1, BS, 1), padding_mode=_ZERO).reshape((BS,)), ct.float32
-        )
-        g1_raw = ct.astype(
-            ct.load(G, index=(b, t_base + 1, h), shape=(1, BS, 1), padding_mode=_ZERO).reshape((BS,)), ct.float32
-        )
+    gc_row = ct.expand_dims(g_cum, axis=1)
+    gc_col = ct.expand_dims(g_cum, axis=0)
+    decay_mask = ct.where(lower_tri, ct.exp(gc_row - gc_col), 0.0)
 
-        gc0 = ct.cumsum(g0_raw, axis=0)
-        gc0_last = ct.sum(ct.where(offs_bs == BS - 1, gc0, 0.0))
-        gc1 = ct.cumsum(g1_raw, axis=0) + gc0_last
+    kb_tile = k_tile * ct.expand_dims(beta_tile, axis=1)
+    base_attn = _ct_mm(kb_tile, ct.transpose(k_tile))
+    attn = ct.where(strict_lower, -(base_attn * decay_mask), 0.0)
+    attn = _ct_solve_tril_neumann(attn, CHUNK_SIZE, SOLVE_STEPS)
 
-        kb0 = k0 * ct.expand_dims(b0, axis=1)
-        kb1 = k1 * ct.expand_dims(b1, axis=1)
-
-        gc0r = ct.expand_dims(gc0, axis=1)
-        gc0c = ct.expand_dims(gc0, axis=0)
-        gc1r = ct.expand_dims(gc1, axis=1)
-        gc1c = ct.expand_dims(gc1, axis=0)
-
-        D0 = ct.where(
-            strict_lower_bs, -(_ct_mm(kb0, ct.transpose(k0)) * ct.where(strict_lower_bs, ct.exp(gc0r - gc0c), 0.0)), 0.0
-        )
-        D1 = ct.where(
-            strict_lower_bs, -(_ct_mm(kb1, ct.transpose(k1)) * ct.where(strict_lower_bs, ct.exp(gc1r - gc1c), 0.0)), 0.0
-        )
-
-        L10 = -(_ct_mm(kb1, ct.transpose(k0)) * ct.exp(gc1r - gc0c))
-
-        D0 = _ct_solve_tril(D0, BS)
-        D1 = _ct_solve_tril(D1, BS)
-
-        M10 = -(_ct_mm(D1, _ct_mm(L10, D0)))
-
-        num_v_tiles = ct.cdiv(V_dim, BLOCK_K)
-        for vt in range(num_v_tiles):
-            vb0 = ct.astype(
-                ct.load(V, index=(b, t_base, h, vt), shape=(1, BS, 1, BLOCK_K), padding_mode=_ZERO).reshape(
-                    (BS, BLOCK_K)
-                ),
-                ct.float32,
-            ) * ct.expand_dims(b0, axis=1)
-            vb1 = ct.astype(
-                ct.load(V, index=(b, t_base + 1, h, vt), shape=(1, BS, 1, BLOCK_K), padding_mode=_ZERO).reshape(
-                    (BS, BLOCK_K)
-                ),
-                ct.float32,
-            ) * ct.expand_dims(b1, axis=1)
-
-            vc0 = _ct_mm(D0, vb0)
-            vc1 = _ct_mm(M10, vb0) + _ct_mm(D1, vb1)
-
-            ct.store(V_corr, index=(b, h, pid_chunk, 0, vt), tile=ct.reshape(vc0, (1, 1, 1, BS, BLOCK_K)))
-            ct.store(V_corr, index=(b, h, pid_chunk, 1, vt), tile=ct.reshape(vc1, (1, 1, 1, BS, BLOCK_K)))
-
-        kbe0 = kb0 * ct.expand_dims(ct.exp(gc0), axis=1)
-        kbe1 = kb1 * ct.expand_dims(ct.exp(gc1), axis=1)
-
-        kc0 = _ct_mm(D0, kbe0)
-        kc1 = _ct_mm(M10, kbe0) + _ct_mm(D1, kbe1)
-
-        ct.store(K_cumdecay, index=(b, h, pid_chunk, 0, 0), tile=ct.reshape(kc0, (1, 1, 1, BS, BLOCK_K)))
-        ct.store(K_cumdecay, index=(b, h, pid_chunk, 1, 0), tile=ct.reshape(kc1, (1, 1, 1, BS, BLOCK_K)))
-
-        ct.store(G_cum_out, index=(b, h, pid_chunk, 0), tile=ct.reshape(gc0, (1, 1, 1, BS)))
-        ct.store(G_cum_out, index=(b, h, pid_chunk, 1), tile=ct.reshape(gc1, (1, 1, 1, BS)))
-
-        q0 = ct.astype(
-            ct.load(Q, index=(b, t_base, h, 0), shape=(1, BS, 1, BLOCK_K), padding_mode=_ZERO).reshape((BS, BLOCK_K)),
-            ct.float32,
-        )
-        q1 = ct.astype(
-            ct.load(Q, index=(b, t_base + 1, h, 0), shape=(1, BS, 1, BLOCK_K), padding_mode=_ZERO).reshape(
-                (BS, BLOCK_K)
-            ),
-            ct.float32,
-        )
-
-        if USE_QK_L2NORM:
-            q0 = q0 * ct.rsqrt(ct.sum(q0 * q0, axis=1, keepdims=True) + 1e-6)
-            q1 = q1 * ct.rsqrt(ct.sum(q1 * q1, axis=1, keepdims=True) + 1e-6)
-
-        q0 = q0 * scale
-        q1 = q1 * scale
-
-        ct.store(Q_out, index=(b, h, pid_chunk, 0, 0), tile=ct.reshape(q0, (1, 1, 1, BS, BLOCK_K)))
-        ct.store(Q_out, index=(b, h, pid_chunk, 1, 0), tile=ct.reshape(q1, (1, 1, 1, BS, BLOCK_K)))
-
-        ct.store(K_out, index=(b, h, pid_chunk, 0, 0), tile=ct.reshape(k0, (1, 1, 1, BS, BLOCK_K)))
-        ct.store(K_out, index=(b, h, pid_chunk, 1, 0), tile=ct.reshape(k1, (1, 1, 1, BS, BLOCK_K)))
-
-    else:
-        # Fallback: row-by-row Neumann series for other chunk sizes
-        k_tile = ct.astype(
+    num_v_tiles = ct.cdiv(V_dim, BLOCK_K)
+    for vt in range(num_v_tiles):
+        v_tile = ct.astype(
             ct.load(
-                K,
-                index=(b, pid_chunk, h, 0),
+                V,
+                index=(b, pid_chunk, h, vt),
                 shape=(1, CHUNK_SIZE, 1, BLOCK_K),
                 padding_mode=_ZERO,
             ).reshape((CHUNK_SIZE, BLOCK_K)),
             ct.float32,
         )
-
-        if USE_QK_L2NORM:
-            k_tile = k_tile * ct.rsqrt(ct.sum(k_tile * k_tile, axis=1, keepdims=True) + 1e-6)
-
-        beta_tile = ct.astype(
-            ct.load(
-                Beta,
-                index=(b, pid_chunk, h),
-                shape=(1, CHUNK_SIZE, 1),
-                padding_mode=_ZERO,
-            ).reshape((CHUNK_SIZE,)),
-            ct.float32,
-        )
-
-        g_raw = ct.astype(
-            ct.load(
-                G,
-                index=(b, pid_chunk, h),
-                shape=(1, CHUNK_SIZE, 1),
-                padding_mode=_ZERO,
-            ).reshape((CHUNK_SIZE,)),
-            ct.float32,
-        )
-        g_cum = ct.cumsum(g_raw, axis=0)
-
-        offs_c = ct.arange(CHUNK_SIZE, dtype=ct.int32)
-        offs_c_row = ct.expand_dims(offs_c, axis=1)
-        offs_c_col = ct.expand_dims(offs_c, axis=0)
-        lower_tri = offs_c_row >= offs_c_col
-        strict_lower = offs_c_row > offs_c_col
-
-        gc_row = ct.expand_dims(g_cum, axis=1)
-        gc_col = ct.expand_dims(g_cum, axis=0)
-        decay_mask = ct.where(lower_tri, ct.exp(gc_row - gc_col), 0.0)
-
-        kb_tile = k_tile * ct.expand_dims(beta_tile, axis=1)
-        base_attn = _ct_mm(kb_tile, ct.transpose(k_tile))
-        attn = ct.where(strict_lower, -(base_attn * decay_mask), 0.0)
-        attn = _ct_solve_tril(attn, CHUNK_SIZE)
-
-        num_v_tiles = ct.cdiv(V_dim, BLOCK_K)
-        for vt in range(num_v_tiles):
-            v_tile = ct.astype(
-                ct.load(
-                    V,
-                    index=(b, pid_chunk, h, vt),
-                    shape=(1, CHUNK_SIZE, 1, BLOCK_K),
-                    padding_mode=_ZERO,
-                ).reshape((CHUNK_SIZE, BLOCK_K)),
-                ct.float32,
-            )
-            vb_tile = v_tile * ct.expand_dims(beta_tile, axis=1)
+        vb_tile = v_tile * ct.expand_dims(beta_tile, axis=1)
+        vc_out = _ct_mm(attn, vb_tile)
+        if INTER_BF16:
             ct.store(
                 V_corr,
                 index=(b, h, pid_chunk, 0, vt),
-                tile=ct.reshape(_ct_mm(attn, vb_tile), (1, 1, 1, CHUNK_SIZE, BLOCK_K)),
+                tile=ct.reshape(ct.astype(vc_out, ct.bfloat16), (1, 1, 1, CHUNK_SIZE, BLOCK_K)),
             )
+        else:
+            ct.store(V_corr, index=(b, h, pid_chunk, 0, vt), tile=ct.reshape(vc_out, (1, 1, 1, CHUNK_SIZE, BLOCK_K)))
 
-        kbe_tile = kb_tile * ct.expand_dims(ct.exp(g_cum), axis=1)
+    kbe_tile = kb_tile * ct.expand_dims(ct.exp(g_cum), axis=1)
+    kc_out = _ct_mm(attn, kbe_tile)
+    if INTER_BF16:
         ct.store(
             K_cumdecay,
             index=(b, h, pid_chunk, 0, 0),
-            tile=ct.reshape(_ct_mm(attn, kbe_tile), (1, 1, 1, CHUNK_SIZE, BLOCK_K)),
+            tile=ct.reshape(ct.astype(kc_out, ct.bfloat16), (1, 1, 1, CHUNK_SIZE, BLOCK_K)),
         )
-        ct.store(G_cum_out, index=(b, h, pid_chunk, 0), tile=ct.reshape(g_cum, (1, 1, 1, CHUNK_SIZE)))
+    else:
+        ct.store(K_cumdecay, index=(b, h, pid_chunk, 0, 0), tile=ct.reshape(kc_out, (1, 1, 1, CHUNK_SIZE, BLOCK_K)))
+    ct.store(G_cum_out, index=(b, h, pid_chunk, 0), tile=ct.reshape(g_cum, (1, 1, 1, CHUNK_SIZE)))
 
-        q_tile = ct.astype(
-            ct.load(
-                Q,
-                index=(b, pid_chunk, h, 0),
-                shape=(1, CHUNK_SIZE, 1, BLOCK_K),
-                padding_mode=_ZERO,
-            ).reshape((CHUNK_SIZE, BLOCK_K)),
-            ct.float32,
+    q_tile = ct.astype(
+        ct.load(
+            Q,
+            index=(b, pid_chunk, h, 0),
+            shape=(1, CHUNK_SIZE, 1, BLOCK_K),
+            padding_mode=_ZERO,
+        ).reshape((CHUNK_SIZE, BLOCK_K)),
+        ct.float32,
+    )
+    if USE_QK_L2NORM:
+        q_tile = q_tile * ct.rsqrt(ct.sum(q_tile * q_tile, axis=1, keepdims=True) + 1e-6)
+    q_tile = q_tile * scale
+    if INTER_BF16:
+        ct.store(
+            Q_out,
+            index=(b, h, pid_chunk, 0, 0),
+            tile=ct.reshape(ct.astype(q_tile, ct.bfloat16), (1, 1, 1, CHUNK_SIZE, BLOCK_K)),
         )
-        if USE_QK_L2NORM:
-            q_tile = q_tile * ct.rsqrt(ct.sum(q_tile * q_tile, axis=1, keepdims=True) + 1e-6)
-        q_tile = q_tile * scale
+        ct.store(
+            K_out,
+            index=(b, h, pid_chunk, 0, 0),
+            tile=ct.reshape(ct.astype(k_tile, ct.bfloat16), (1, 1, 1, CHUNK_SIZE, BLOCK_K)),
+        )
+    else:
         ct.store(Q_out, index=(b, h, pid_chunk, 0, 0), tile=ct.reshape(q_tile, (1, 1, 1, CHUNK_SIZE, BLOCK_K)))
         ct.store(K_out, index=(b, h, pid_chunk, 0, 0), tile=ct.reshape(k_tile, (1, 1, 1, CHUNK_SIZE, BLOCK_K)))
 
@@ -328,28 +229,37 @@ def _chunk_inter_recurrence_kernel(
 
     for ci in range(num_chunks):
         # Load intermediates from 5D tensors
-        kc_chunk = ct.load(
-            K_cumdecay,
-            index=(b, h, ci, 0, 0),
-            shape=(1, 1, 1, CHUNK_SIZE, BLOCK_K),
-            padding_mode=_ZERO,
-        ).reshape((CHUNK_SIZE, BLOCK_K))
+        kc_chunk = ct.astype(
+            ct.load(
+                K_cumdecay,
+                index=(b, h, ci, 0, 0),
+                shape=(1, 1, 1, CHUNK_SIZE, BLOCK_K),
+                padding_mode=_ZERO,
+            ).reshape((CHUNK_SIZE, BLOCK_K)),
+            ct.float32,
+        )
         v_prime = _ct_mm(kc_chunk, state)  # (CS, BV)
 
-        v_corr = ct.load(
-            V_corr,
-            index=(b, h, ci, 0, pid_v),
-            shape=(1, 1, 1, CHUNK_SIZE, BLOCK_V),
-            padding_mode=_ZERO,
-        ).reshape((CHUNK_SIZE, BLOCK_V))
+        v_corr = ct.astype(
+            ct.load(
+                V_corr,
+                index=(b, h, ci, 0, pid_v),
+                shape=(1, 1, 1, CHUNK_SIZE, BLOCK_V),
+                padding_mode=_ZERO,
+            ).reshape((CHUNK_SIZE, BLOCK_V)),
+            ct.float32,
+        )
         v_new = v_corr - v_prime
 
-        q_chunk = ct.load(
-            Q_ch,
-            index=(b, h, ci, 0, 0),
-            shape=(1, 1, 1, CHUNK_SIZE, BLOCK_K),
-            padding_mode=_ZERO,
-        ).reshape((CHUNK_SIZE, BLOCK_K))
+        q_chunk = ct.astype(
+            ct.load(
+                Q_ch,
+                index=(b, h, ci, 0, 0),
+                shape=(1, 1, 1, CHUNK_SIZE, BLOCK_K),
+                padding_mode=_ZERO,
+            ).reshape((CHUNK_SIZE, BLOCK_K)),
+            ct.float32,
+        )
 
         g_cum = ct.load(
             G_cum_in,
@@ -363,12 +273,15 @@ def _chunk_inter_recurrence_kernel(
         attn_inter = _ct_mm(q_weighted, state)  # (CS, BV)
 
         # Intra-chunk: QK^T with causal decay mask
-        k_chunk = ct.load(
-            K_ch,
-            index=(b, h, ci, 0, 0),
-            shape=(1, 1, 1, CHUNK_SIZE, BLOCK_K),
-            padding_mode=_ZERO,
-        ).reshape((CHUNK_SIZE, BLOCK_K))
+        k_chunk = ct.astype(
+            ct.load(
+                K_ch,
+                index=(b, h, ci, 0, 0),
+                shape=(1, 1, 1, CHUNK_SIZE, BLOCK_K),
+                padding_mode=_ZERO,
+            ).reshape((CHUNK_SIZE, BLOCK_K)),
+            ct.float32,
+        )
 
         qk = _ct_mm(q_chunk, ct.transpose(k_chunk))  # (CS, CS)
         gc_row = ct.expand_dims(g_cum, axis=1)
@@ -432,12 +345,24 @@ class _ChunkGatedDeltaRuleCuTile(torch.autograd.Function):
 
         device = query.device
         BLOCK_K = 1 << (K - 1).bit_length()
+        # Neumann-by-squaring factor count for the CHUNK_SIZE x CHUNK_SIZE solve
+        # (s = ceil(log2(chunk_size))); over-provisioning is safe (extra factors
+        # past nilpotency are identity), so this also covers the 64-path's 32x32
+        # sub-blocks. Computed on the host where chunk_size is a real Python int.
+        solve_steps = max(1, (chunk_size - 1).bit_length())
 
-        # Allocate intermediates (5D)
-        q_chunked = torch.empty(B, H, num_chunks, chunk_size, K, device=device, dtype=torch.float32)
-        k_chunked = torch.empty(B, H, num_chunks, chunk_size, K, device=device, dtype=torch.float32)
-        v_corrected = torch.empty(B, H, num_chunks, chunk_size, V, device=device, dtype=torch.float32)
-        k_cumdecay = torch.empty(B, H, num_chunks, chunk_size, K, device=device, dtype=torch.float32)
+        # Allocate intermediates (5D). The four (chunk_size, K/V) buffers are the
+        # dominant write/read traffic between the intra and inter kernels; store
+        # them as bf16 to halve that traffic (the intra kernel is ~memory-bound at
+        # low occupancy). g_cum stays fp32 (used as exp(g_last - g_cum) decay).
+        # Only reduce precision when the op runs reduced-precision; fp32 inputs
+        # keep fp32 intermediates so no accuracy is lost.
+        inter_bf16 = initial_dtype in (torch.bfloat16, torch.float16)
+        inter_dtype = torch.bfloat16 if inter_bf16 else torch.float32
+        q_chunked = torch.empty(B, H, num_chunks, chunk_size, K, device=device, dtype=inter_dtype)
+        k_chunked = torch.empty(B, H, num_chunks, chunk_size, K, device=device, dtype=inter_dtype)
+        v_corrected = torch.empty(B, H, num_chunks, chunk_size, V, device=device, dtype=inter_dtype)
+        k_cumdecay = torch.empty(B, H, num_chunks, chunk_size, K, device=device, dtype=inter_dtype)
         g_cum = torch.empty(B, H, num_chunks, chunk_size, device=device, dtype=torch.float32)
         output_buf = torch.empty(B, H, num_chunks, chunk_size, V, device=device, dtype=torch.float32)
 
@@ -465,6 +390,8 @@ class _ChunkGatedDeltaRuleCuTile(torch.autograd.Function):
                 use_qk_l2norm_in_kernel,
                 chunk_size,
                 BLOCK_K,
+                solve_steps,
+                inter_bf16,
             ),
         )
 

--- a/src/tilegym/ops/cutile/matmul.py
+++ b/src/tilegym/ops/cutile/matmul.py
@@ -134,6 +134,11 @@ def _static_persistent_matmul_autotune_configs():
         yield SimpleNamespace(
             TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=128, GROUP_SIZE_M=8, num_ctas=2, occupancy=1, LOAD_LATENCY=-1
         )
+        # Small-tile candidate for small/rectangular GEMMs, where the entries above cap
+        # the persistent grid at 16-32 tile-jobs and strand most SMs.
+        yield SimpleNamespace(
+            TILE_SIZE_M=128, TILE_SIZE_N=128, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=1, LOAD_LATENCY=-1
+        )
 
 
 @ct.kernel

--- a/src/tilegym/ops/cutile/mla.py
+++ b/src/tilegym/ops/cutile/mla.py
@@ -27,6 +27,7 @@ def _mla_sm80_autotune_configs():
     for tm in [64, 128]:
         for tn in [64, 128]:
             yield SimpleNamespace(TILE_M=tm, TILE_N=tn, num_ctas=1, occupancy=2)
+    yield SimpleNamespace(TILE_M=64, TILE_N=64, num_ctas=1, occupancy=3)
 
 
 def _mla_sm90_autotune_configs():

--- a/src/tilegym/ops/cutile_rs/ffi_util.rs
+++ b/src/tilegym/ops/cutile_rs/ffi_util.rs
@@ -29,7 +29,8 @@ pub struct TensorDesc {
     pub ndim: i32,
     pub shape: [i64; MAX_DIMS],
     pub strides: [i64; MAX_DIMS],
-    /// dtype code: 0 = f32, 1 = f16, 2 = bf16, 3 = i32, 4 = i64, 5 = f8e5m2.
+    /// dtype code: 0 = f32, 1 = f16, 2 = bf16, 3 = i32, 4 = i64, 5 = f8e5m2,
+    /// 6 = f4e2m1fnx2 (packed NVFP4 pair, torch.uint8), 7 = f8e4m3fn.
     pub dtype: i32,
 }
 
@@ -65,7 +66,9 @@ impl TensorDesc {
 
 /// dtype code -> cutile type-name string used in `.generics(...)`. `None` if unknown.
 /// Codes 3 (i32) / 4 (i64) are integer tensors (index / descriptor-table
-/// entries), never element-type generics; included for completeness.
+/// entries), never element-type generics; included for completeness. Codes 6
+/// (f4e2m1fnx2, packed NVFP4 pair crossing as torch.uint8) / 7 (f8e4m3fn block
+/// scales) are fixed-role NVFP4 storage types.
 pub fn dtype_str(code: i32) -> Option<&'static str> {
     match code {
         0 => Some("f32"),
@@ -74,6 +77,8 @@ pub fn dtype_str(code: i32) -> Option<&'static str> {
         3 => Some("i32"),
         4 => Some("i64"),
         5 => Some("f8e5m2"),
+        6 => Some("f4e2m1fnx2"),
+        7 => Some("f8e4m3fn"),
         _ => None,
     }
 }
@@ -84,7 +89,7 @@ pub fn dtype_elem_size(code: i32) -> usize {
         0 | 3 => 4,
         1 | 2 => 2,
         4 => 8,
-        5 => 1,
+        5..=7 => 1,
         _ => 0,
     }
 }

--- a/src/tilegym/ops/tilecpp/flash_decode.cuh
+++ b/src/tilegym/ops/tilecpp/flash_decode.cuh
@@ -71,7 +71,11 @@ __tile_global__ void attention_decode_kernel_optimized(
     // Load Q and transpose to [HEAD_DIM, QUERY_GROUP_BLOCK_SIZE]
     using Q_4D_Tile = ct::tile<T, ct::shape<1, 1, QUERY_GROUP_BLOCK_SIZE, HEAD_DIM>>;
     using T_DxQG = ct::tile<T, ct::shape<HEAD_DIM, QUERY_GROUP_BLOCK_SIZE>>;
-    Q_4D_Tile q_4d = Q_view.load(batch_id, head_id, 0, 0);
+    // Q_PER_KV may be smaller than QUERY_GROUP_BLOCK_SIZE, so the query-group
+    // tile overhangs the Q tensor. Use a masked load so out-of-bounds group
+    // rows are padded instead of reading past the tensor (do not rely on the
+    // implicit in-bounds assumption of the plain load).
+    Q_4D_Tile q_4d = Q_view.load_masked(batch_id, head_id, 0, 0);
     auto q_2d = ct::reshape(q_4d, ct::shape<QUERY_GROUP_BLOCK_SIZE, HEAD_DIM>{});
     // Keep Q in native type for tensor core K@Q MMA
     auto q_native = ct::transpose(q_2d);  // [HEAD_DIM, QUERY_GROUP_BLOCK_SIZE]
@@ -161,11 +165,14 @@ __tile_global__ void attention_decode_kernel_optimized(
     auto Out_span = ct::tensor_span{Out_ptr, ct::extents{B, H_KV, Q_PER_KV, NUM_KV_SPLITS, HEAD_DIM}};
     auto Out_view = ct::partition_view(Out_span, ct::shape<1, 1, QUERY_GROUP_BLOCK_SIZE, 1, HEAD_DIM>{});
     auto acc_out_5d = ct::reshape(acc_out_T, ct::shape<1, 1, QUERY_GROUP_BLOCK_SIZE, 1, HEAD_DIM>{});
-    Out_view.store(acc_out_5d, batch_id, head_id, 0, split_id, 0);
+    // The query-group tile overhangs the Q_PER_KV dimension; a masked store
+    // writes only the valid group rows and masks the out-of-bounds ones so
+    // they do not clobber neighboring (split/head) entries.
+    Out_view.store_masked(acc_out_5d, batch_id, head_id, 0, split_id, 0);
 
     // Store LSE
     auto LSE_span = ct::tensor_span{LSE_ptr, ct::extents{B, H_KV, Q_PER_KV, NUM_KV_SPLITS}};
     auto LSE_view = ct::partition_view(LSE_span, ct::shape<1, 1, QUERY_GROUP_BLOCK_SIZE, 1>{});
     auto lse_4d = ct::reshape(lse, ct::shape<1, 1, QUERY_GROUP_BLOCK_SIZE, 1>{});
-    LSE_view.store(lse_4d, batch_id, head_id, 0, split_id);
+    LSE_view.store_masked(lse_4d, batch_id, head_id, 0, split_id);
 }

--- a/src/tilegym/ops/tilecpp/matmul.cuh
+++ b/src/tilegym/ops/tilecpp/matmul.cuh
@@ -17,6 +17,8 @@
 #include <cuda_fp16.h>
 #include <cuda_bf16.h>
 #include <cuda_fp8.h>
+#include <cuda_tf32.h>
+#include <type_traits>
 
 /**
  * Matrix Multiplication Kernel with transpose support
@@ -68,6 +70,7 @@ __tile_global__ void matmul_kernel(
     using BTile = ct::tile<T, ct::shape<TILE_SIZE_K, TILE_SIZE_N>>;
     using AccTile = ct::tile<float, ct::shape<TILE_SIZE_M, TILE_SIZE_N>>;
     using CTile = ct::tile<T, ct::shape<TILE_SIZE_M, TILE_SIZE_N>>;
+    using MmaType = std::conditional_t<std::is_same_v<T, float>, __nv_tf32, T>;
 
     // Initialize accumulator
     AccTile acc = ct::zeros<AccTile>();
@@ -81,8 +84,8 @@ __tile_global__ void matmul_kernel(
         auto pB = ct::partition_view{ct::tensor_span{B, ct::extents<uint32_t, K, N>{}}, ct::shape<TILE_SIZE_K, TILE_SIZE_N>{}};
 
         for (auto k : ct::irange(0, num_tiles_k)) {
-            auto a = pA.template load_masked<zero_pad>(bidx, k);
-            auto b = pB.template load_masked<zero_pad>(k, bidy);
+            auto a = ct::element_cast<MmaType>(pA.template load_masked<zero_pad>(bidx, k));
+            auto b = ct::element_cast<MmaType>(pB.template load_masked<zero_pad>(k, bidy));
             acc = ct::mma(a, b, acc);
         }
     } else if constexpr (TRANSPOSE_A && !TRANSPOSE_B) {
@@ -92,8 +95,8 @@ __tile_global__ void matmul_kernel(
 
         for (auto k : ct::irange(0, num_tiles_k)) {
             auto a_raw = pA.template load_masked<zero_pad>(k, bidx);
-            auto b = pB.template load_masked<zero_pad>(k, bidy);
-            auto a = ct::transpose(a_raw);  // [TILE_K, TILE_M] -> [TILE_M, TILE_K]
+            auto a = ct::element_cast<MmaType>(ct::transpose(a_raw));  // [TILE_K, TILE_M] -> [TILE_M, TILE_K]
+            auto b = ct::element_cast<MmaType>(pB.template load_masked<zero_pad>(k, bidy));
             acc = ct::mma(a, b, acc);
         }
     } else if constexpr (!TRANSPOSE_A && TRANSPOSE_B) {
@@ -102,9 +105,9 @@ __tile_global__ void matmul_kernel(
         auto pB = ct::partition_view{ct::tensor_span{B, ct::extents<uint32_t, N, K>{}}, ct::shape<TILE_SIZE_N, TILE_SIZE_K>{}};
 
         for (auto k : ct::irange(0, num_tiles_k)) {
-            auto a = pA.template load_masked<zero_pad>(bidx, k);
+            auto a = ct::element_cast<MmaType>(pA.template load_masked<zero_pad>(bidx, k));
             auto b_raw = pB.template load_masked<zero_pad>(bidy, k);
-            auto b = ct::transpose(b_raw);  // [TILE_N, TILE_K] -> [TILE_K, TILE_N]
+            auto b = ct::element_cast<MmaType>(ct::transpose(b_raw));  // [TILE_N, TILE_K] -> [TILE_K, TILE_N]
             acc = ct::mma(a, b, acc);
         }
     } else {
@@ -115,8 +118,8 @@ __tile_global__ void matmul_kernel(
         for (auto k : ct::irange(0, num_tiles_k)) {
             auto a_raw = pA.template load_masked<zero_pad>(k, bidx);
             auto b_raw = pB.template load_masked<zero_pad>(bidy, k);
-            auto a = ct::transpose(a_raw);  // [TILE_K, TILE_M] -> [TILE_M, TILE_K]
-            auto b = ct::transpose(b_raw);  // [TILE_N, TILE_K] -> [TILE_K, TILE_N]
+            auto a = ct::element_cast<MmaType>(ct::transpose(a_raw));  // [TILE_K, TILE_M] -> [TILE_M, TILE_K]
+            auto b = ct::element_cast<MmaType>(ct::transpose(b_raw));  // [TILE_N, TILE_K] -> [TILE_K, TILE_N]
             acc = ct::mma(a, b, acc);
         }
     }

--- a/src/tilegym/ops/tilecpp/matmul.cuh
+++ b/src/tilegym/ops/tilecpp/matmul.cuh
@@ -55,6 +55,7 @@ __tile_global__ void matmul_kernel(
     constexpr int num_bid_m = (M + TILE_SIZE_M - 1) / TILE_SIZE_M;
     constexpr int num_bid_n = (N + TILE_SIZE_N - 1) / TILE_SIZE_N;
     constexpr int num_bid_in_group = GROUP_SIZE_M * num_bid_n;
+    constexpr bool output_tiles_are_full = (M % TILE_SIZE_M == 0) && (N % TILE_SIZE_N == 0);
 
     // 2D swizzle for L2 cache reuse
     int bidval = ct::bid().x;
@@ -128,5 +129,10 @@ __tile_global__ void matmul_kernel(
     auto pC = ct::partition_view{ct::tensor_span{C, ct::extents<uint32_t, M, N>{}}, ct::shape<TILE_SIZE_M, TILE_SIZE_N>{}};
 
     // Cast and store result
-    pC.store(ct::element_cast<T>(acc), bidx, bidy);
+    auto result = ct::element_cast<T>(acc);
+    if constexpr (output_tiles_are_full) {
+        pC.store(result, bidx, bidy);
+    } else {
+        pC.store_masked(result, bidx, bidy);
+    }
 }

--- a/src/tilegym/ops/tilecpp/persistent_matmul.cuh
+++ b/src/tilegym/ops/tilecpp/persistent_matmul.cuh
@@ -43,6 +43,7 @@ __tile_global__ void static_persistent_matmul_kernel(
     constexpr int k_tiles          = (K + TILE_SIZE_K - 1) / TILE_SIZE_K;
     constexpr int num_tiles        = num_bid_m * num_bid_n;
     constexpr int num_bid_in_group = GROUP_SIZE_M * num_bid_n;
+    constexpr bool output_tiles_are_full = (M % TILE_SIZE_M == 0) && (N % TILE_SIZE_N == 0);
 
     constexpr auto zero_pad = ct::view_padding::zero;
 
@@ -66,7 +67,12 @@ __tile_global__ void static_persistent_matmul_kernel(
                 auto b = pB.template load_masked<zero_pad>(k, bid_n);
                 acc = ct::mma(a, b, acc);
             }
-            pC.store(ct::element_cast<T>(acc), bid_m, bid_n);
+            auto result = ct::element_cast<T>(acc);
+            if constexpr (output_tiles_are_full) {
+                pC.store(result, bid_m, bid_n);
+            } else {
+                pC.store_masked(result, bid_m, bid_n);
+            }
         }
     } else if constexpr (TRANSPOSE_A && !TRANSPOSE_B) {
         auto pA = ct::partition_view{ct::tensor_span{A, ct::extents<uint32_t, K, M>{}}, ct::shape<TILE_SIZE_K, TILE_SIZE_M>{}};
@@ -87,7 +93,12 @@ __tile_global__ void static_persistent_matmul_kernel(
                 auto a     = ct::transpose(a_raw);
                 acc = ct::mma(a, b, acc);
             }
-            pC.store(ct::element_cast<T>(acc), bid_m, bid_n);
+            auto result = ct::element_cast<T>(acc);
+            if constexpr (output_tiles_are_full) {
+                pC.store(result, bid_m, bid_n);
+            } else {
+                pC.store_masked(result, bid_m, bid_n);
+            }
         }
     } else if constexpr (!TRANSPOSE_A && TRANSPOSE_B) {
         auto pA = ct::partition_view{ct::tensor_span{A, ct::extents<uint32_t, M, K>{}}, ct::shape<TILE_SIZE_M, TILE_SIZE_K>{}};
@@ -108,7 +119,12 @@ __tile_global__ void static_persistent_matmul_kernel(
                 auto b     = ct::transpose(b_raw);
                 acc = ct::mma(a, b, acc);
             }
-            pC.store(ct::element_cast<T>(acc), bid_m, bid_n);
+            auto result = ct::element_cast<T>(acc);
+            if constexpr (output_tiles_are_full) {
+                pC.store(result, bid_m, bid_n);
+            } else {
+                pC.store_masked(result, bid_m, bid_n);
+            }
         }
     } else {
         auto pA = ct::partition_view{ct::tensor_span{A, ct::extents<uint32_t, K, M>{}}, ct::shape<TILE_SIZE_K, TILE_SIZE_M>{}};
@@ -130,7 +146,12 @@ __tile_global__ void static_persistent_matmul_kernel(
                 auto b     = ct::transpose(b_raw);
                 acc = ct::mma(a, b, acc);
             }
-            pC.store(ct::element_cast<T>(acc), bid_m, bid_n);
+            auto result = ct::element_cast<T>(acc);
+            if constexpr (output_tiles_are_full) {
+                pC.store(result, bid_m, bid_n);
+            } else {
+                pC.store_masked(result, bid_m, bid_n);
+            }
         }
     }
 }

--- a/src/tilegym/suites/flashinfer/cutile/fmha_decode_bsr.py
+++ b/src/tilegym/suites/flashinfer/cutile/fmha_decode_bsr.py
@@ -22,6 +22,41 @@ _decode_mla_paged_tune_cache: dict = {}
 
 INV_LOG_2 = 1.0 / math.log(2)
 
+# sm120/sm121 (GB20x consumer/workstation Blackwell) do NOT have the wide
+# tcgen05 / large-WGMMA tensor cores of sm100 (GB200 datacenter Blackwell).
+# The TRANS_QK optimisation swaps the Q/K MMA operands so the GEMM M-dim
+# becomes BLOCK_N (forced to 128) instead of BLOCK_H (16/32) -- this only pays
+# off when the wide MMA tile exists (sm100). On sm120/121 it just forces
+# BLOCK_N=128 (blocking small-BLOCK_N autotune configs) and adds transpose
+# overhead, regressing MLADecodePaged / DecodePaged 6~80%. Gate
+# TRANS_QK to datacenter Blackwell only, mirroring the sm120/121 exclusion
+# idiom already used in ops/cutile/{matmul,bmm,attention}.py.
+_SM120_LIKE = [(12, 0), (12, 1)]
+
+
+def _supports_trans_qk() -> bool:
+    """True only on Blackwell parts with the wide MMA that TRANS_QK targets.
+
+    Excludes A100 (sm80, no benefit) and sm120/sm121 (no wide MMA -> regression).
+    """
+    cap = torch.cuda.get_device_capability("cuda")
+    return cap[0] >= 10 and cap not in _SM120_LIKE
+
+
+def _supports_gather_page_load() -> bool:
+    """True only on datacenter Blackwell (sm100/sm103), where the gather-TMA that
+    backs ct.load_advanced_indexing is a large win for multi-page KV loads.
+
+    On sm100 the gathered multi-page load is 10-74% FASTER than per-page TMA loads
+    (measured, DecodePaged). On sm120/sm121 (consumer Blackwell, no efficient
+    gather-TMA) it REGRESSES 29-83% and the penalty scales with NUM_PAGES, so those
+    parts (and A100) fall back to per-page TMA loads. Same datacenter-Blackwell
+    predicate as _supports_trans_qk.
+    """
+    cap = torch.cuda.get_device_capability("cuda")
+    return cap[0] >= 10 and cap not in _SM120_LIKE
+
+
 ConstInt = ct.Constant[int]
 ConstBool = ct.Constant[bool]
 ConstFloat = ct.Constant[float]
@@ -135,14 +170,22 @@ def _load_page(
     LOAD_BLOCK_N,
     BLOCK_D,
     _PAGE_SIZE,
+    USE_GATHER_PAGE_LOAD,
 ):
     """
-    Load data from paged cache via TMA.
+    Load data from paged cache.
 
     For single page, issues one TMA load.
-    For multiple pages, uses ct.load_advanced_indexing (gather TMA) with the 4D
-    cache [total_pages, PAGE_SIZE, N_KV_HEADS, BLOCK_D] directly, issuing
-    NUM_PAGES gather transactions instead of NUM_PAGES*LOAD_BLOCK_N individual ones.
+    For multiple pages, the strategy is arch-gated (USE_GATHER_PAGE_LOAD, set on the
+    host from _supports_gather_page_load()):
+      * datacenter Blackwell (sm100/sm103): ct.load_advanced_indexing (gather TMA)
+        against the 4D cache directly, issuing NUM_PAGES gather transactions instead
+        of NUM_PAGES*LOAD_BLOCK_N individual ones -- 10-74% faster there.
+      * everywhere else (sm120/sm121, A100, ...): one per-page TMA load + ct.cat.
+        Their gather-TMA path is slow, so the gather regresses this memory-bound
+        kernel 29-83% (worse with more pages); per-page TMA restores baseline
+        throughput. NUM_PAGES in {1,2,4} covers every decode autotune config
+        (BLOCK_N<=128, page_size>=32); larger counts use the gather fallback.
 
     Args:
         cache: cache array [total_num_pages, PAGE_SIZE, N_KV_HEADS, BLOCK_D]
@@ -155,6 +198,7 @@ def _load_page(
         LOAD_BLOCK_N: tokens per page load (== PAGE_SIZE)
         BLOCK_D: feature dimension
         _PAGE_SIZE: tokens per page
+        USE_GATHER_PAGE_LOAD: constexpr; True on datacenter Blackwell (use gather)
 
     Returns:
         Loaded tensor of shape [NUM_PAGES * LOAD_BLOCK_N, BLOCK_D]
@@ -173,6 +217,94 @@ def _load_page(
             ),
             (LOAD_BLOCK_N, BLOCK_D),
         )
+    elif USE_GATHER_PAGE_LOAD:
+        p_idx = ct.arange(NUM_PAGES, dtype=ct.int32)
+        page_ids = ct.gather(block_tables, (page_table_offset + page + p_idx,), padding_value=0)
+        data = ct.reshape(
+            ct.load_advanced_indexing(
+                cache,
+                (page_ids, ct.Slice(token, LOAD_BLOCK_N), ct.Slice(off_kv_h, 1), ct.Slice(0, BLOCK_D)),
+                padding_mode=PAD_ZERO,
+            ),
+            (NUM_PAGES * LOAD_BLOCK_N, BLOCK_D),
+        )
+    elif NUM_PAGES == 2:
+        pg0 = ct.gather(block_tables, (page_table_offset + page,), padding_value=0).item()
+        d0 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg0, token // LOAD_BLOCK_N, off_kv_h, 0),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=2,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg1 = ct.gather(block_tables, (page_table_offset + page + 1,), padding_value=0).item()
+        d1 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg1, 0, off_kv_h, 0),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=2,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        data = ct.cat((d0, d1), 0)
+    elif NUM_PAGES == 4:
+        pg0 = ct.gather(block_tables, (page_table_offset + page,), padding_value=0).item()
+        d0 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg0, token // LOAD_BLOCK_N, off_kv_h, 0),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=2,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg1 = ct.gather(block_tables, (page_table_offset + page + 1,), padding_value=0).item()
+        d1 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg1, 0, off_kv_h, 0),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=2,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg2 = ct.gather(block_tables, (page_table_offset + page + 2,), padding_value=0).item()
+        d2 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg2, 0, off_kv_h, 0),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=2,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        pg3 = ct.gather(block_tables, (page_table_offset + page + 3,), padding_value=0).item()
+        d3 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg3, 0, off_kv_h, 0),
+                shape=(1, LOAD_BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2, 3),
+                allow_tma=True,
+                latency=2,
+            ),
+            (LOAD_BLOCK_N, BLOCK_D),
+        )
+        # ct.cat takes exactly a pair; chain for 4 pages
+        data = ct.cat((ct.cat((d0, d1), 0), ct.cat((d2, d3), 0)), 0)
     else:
         p_idx = ct.arange(NUM_PAGES, dtype=ct.int32)
         page_ids = ct.gather(block_tables, (page_table_offset + page + p_idx,), padding_value=0)
@@ -197,6 +329,7 @@ def _load_page_wrapper(
     BLOCK_N,
     BLOCK_D,
     LOAD_BLOCK_N,
+    USE_GATHER_PAGE_LOAD,
 ):
     """
     Load cache data (K or V) for current position.
@@ -218,6 +351,7 @@ def _load_page_wrapper(
         LOAD_BLOCK_N,
         BLOCK_D,
         PAGE_SIZE,
+        USE_GATHER_PAGE_LOAD,
     )
     return data
 
@@ -247,6 +381,7 @@ def _decode_attention_kv_paged_kernel(
     TRANS_QK: ConstBool,
     LOAD_BLOCK_N: ConstInt,
     NUM_PAGES_PER_BLOCK: ConstInt,
+    USE_GATHER_PAGE_LOAD: ConstBool,
 ):
     batch_id = ct.bid(0)
     head_block_id = ct.bid(1)
@@ -325,6 +460,7 @@ def _decode_attention_kv_paged_kernel(
                     BLOCK_N,
                     BLOCK_D,
                     LOAD_BLOCK_N,
+                    USE_GATHER_PAGE_LOAD,
                 )
 
             qk = ct.mma(k, ct.transpose(q_tile), acc=qk_zeros)
@@ -367,6 +503,7 @@ def _decode_attention_kv_paged_kernel(
                     BLOCK_N,
                     BLOCK_D,
                     LOAD_BLOCK_N,
+                    USE_GATHER_PAGE_LOAD,
                 )
 
             acc = ct.mma(ct.transpose(v), ct.astype(p, q.dtype), acc=acc)
@@ -415,6 +552,7 @@ def _decode_attention_kv_paged_kernel(
                     BLOCK_N,
                     BLOCK_D,
                     LOAD_BLOCK_N,
+                    USE_GATHER_PAGE_LOAD,
                 )
 
             qk = ct.mma(q_tile, ct.transpose(k), acc=qk_zeros)
@@ -455,6 +593,7 @@ def _decode_attention_kv_paged_kernel(
                     BLOCK_N,
                     BLOCK_D,
                     LOAD_BLOCK_N,
+                    USE_GATHER_PAGE_LOAD,
                 )
 
             acc = acc * ct.reshape(alpha, (BLOCK_H, 1))
@@ -482,13 +621,29 @@ def _decode_attention_kv_paged_kernel(
         ct.scatter(lse_out, lse_indices, lse)
 
 
-def _load_page_mla(cache, block_tables, page_table_offset, page, token, NUM_PAGES, LOAD_BLOCK_N, BLOCK_DIM, _PAGE_SIZE):
+def _load_page_mla(
+    cache,
+    block_tables,
+    page_table_offset,
+    page,
+    token,
+    NUM_PAGES,
+    LOAD_BLOCK_N,
+    BLOCK_DIM,
+    _PAGE_SIZE,
+    USE_GATHER_PAGE_LOAD,
+):
     """
-    Load data from paged MLA cache (3D: [total_num_pages, PAGE_SIZE, dim]) via TMA.
+    Load data from paged MLA cache (3D: [total_num_pages, PAGE_SIZE, dim]).
 
-    For single page, issues one TMA load.
-    For multiple pages, uses ct.load_advanced_indexing (gather TMA) on the 3D
-    cache directly, issuing NUM_PAGES transactions instead of NUM_PAGES*LOAD_BLOCK_N.
+    For single page, issues one TMA load. For multiple pages the strategy is
+    arch-gated (USE_GATHER_PAGE_LOAD, set on the host from
+    _supports_gather_page_load()), identical rationale to the GQA _load_page:
+      * datacenter Blackwell (sm100/sm103): ct.load_advanced_indexing (gather TMA).
+      * everywhere else (sm120/sm121, A100, ...): one per-page TMA load + ct.cat,
+        because the gather regresses this memory-bound kernel there.
+        NUM_PAGES in {1,2,4} covers every decode autotune config; larger counts
+        use the gather fallback.
 
     Args:
         cache: cache array [total_num_pages, PAGE_SIZE, dim]
@@ -500,6 +655,7 @@ def _load_page_mla(cache, block_tables, page_table_offset, page, token, NUM_PAGE
         LOAD_BLOCK_N: tokens per page load (== PAGE_SIZE)
         BLOCK_DIM: feature dimension (BLOCK_D or BLOCK_R)
         _PAGE_SIZE: tokens per page
+        USE_GATHER_PAGE_LOAD: constexpr; True on datacenter Blackwell (use gather)
 
     Returns:
         Loaded tensor of shape [NUM_PAGES * LOAD_BLOCK_N, BLOCK_DIM]
@@ -518,6 +674,74 @@ def _load_page_mla(cache, block_tables, page_table_offset, page, token, NUM_PAGE
             ),
             (LOAD_BLOCK_N, BLOCK_DIM),
         )
+    elif USE_GATHER_PAGE_LOAD:
+        p_idx = ct.arange(NUM_PAGES, dtype=ct.int32)
+        page_ids = ct.gather(block_tables, (page_table_offset + page + p_idx,), padding_value=0)
+        data = ct.reshape(
+            ct.load_advanced_indexing(
+                cache,
+                (page_ids, ct.Slice(token, LOAD_BLOCK_N), ct.Slice(0, BLOCK_DIM)),
+                padding_mode=PAD_ZERO,
+            ),
+            (NUM_PAGES * LOAD_BLOCK_N, BLOCK_DIM),
+        )
+    elif NUM_PAGES == 2:
+        pg0 = ct.gather(block_tables, (page_table_offset + page,), padding_value=0).item()
+        d0 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg0, token // LOAD_BLOCK_N, 0),
+                shape=(1, LOAD_BLOCK_N, BLOCK_DIM),
+                order=(0, 1, 2),
+                allow_tma=True,
+                latency=2,
+            ),
+            (LOAD_BLOCK_N, BLOCK_DIM),
+        )
+        pg1 = ct.gather(block_tables, (page_table_offset + page + 1,), padding_value=0).item()
+        d1 = ct.reshape(
+            ct.load(
+                cache, index=(pg1, 0, 0), shape=(1, LOAD_BLOCK_N, BLOCK_DIM), order=(0, 1, 2), allow_tma=True, latency=2
+            ),
+            (LOAD_BLOCK_N, BLOCK_DIM),
+        )
+        data = ct.cat((d0, d1), 0)
+    elif NUM_PAGES == 4:
+        pg0 = ct.gather(block_tables, (page_table_offset + page,), padding_value=0).item()
+        d0 = ct.reshape(
+            ct.load(
+                cache,
+                index=(pg0, token // LOAD_BLOCK_N, 0),
+                shape=(1, LOAD_BLOCK_N, BLOCK_DIM),
+                order=(0, 1, 2),
+                allow_tma=True,
+                latency=2,
+            ),
+            (LOAD_BLOCK_N, BLOCK_DIM),
+        )
+        pg1 = ct.gather(block_tables, (page_table_offset + page + 1,), padding_value=0).item()
+        d1 = ct.reshape(
+            ct.load(
+                cache, index=(pg1, 0, 0), shape=(1, LOAD_BLOCK_N, BLOCK_DIM), order=(0, 1, 2), allow_tma=True, latency=2
+            ),
+            (LOAD_BLOCK_N, BLOCK_DIM),
+        )
+        pg2 = ct.gather(block_tables, (page_table_offset + page + 2,), padding_value=0).item()
+        d2 = ct.reshape(
+            ct.load(
+                cache, index=(pg2, 0, 0), shape=(1, LOAD_BLOCK_N, BLOCK_DIM), order=(0, 1, 2), allow_tma=True, latency=2
+            ),
+            (LOAD_BLOCK_N, BLOCK_DIM),
+        )
+        pg3 = ct.gather(block_tables, (page_table_offset + page + 3,), padding_value=0).item()
+        d3 = ct.reshape(
+            ct.load(
+                cache, index=(pg3, 0, 0), shape=(1, LOAD_BLOCK_N, BLOCK_DIM), order=(0, 1, 2), allow_tma=True, latency=2
+            ),
+            (LOAD_BLOCK_N, BLOCK_DIM),
+        )
+        # ct.cat takes exactly a pair; chain for 4 pages
+        data = ct.cat((ct.cat((d0, d1), 0), ct.cat((d2, d3), 0)), 0)
     else:
         p_idx = ct.arange(NUM_PAGES, dtype=ct.int32)
         page_ids = ct.gather(block_tables, (page_table_offset + page + p_idx,), padding_value=0)
@@ -532,7 +756,17 @@ def _load_page_mla(cache, block_tables, page_table_offset, page, token, NUM_PAGE
     return data
 
 
-def _load_page_mla_wrapper(curr_n, cache, block_tables, page_table_offset, PAGE_SIZE, BLOCK_N, BLOCK_DIM, LOAD_BLOCK_N):
+def _load_page_mla_wrapper(
+    curr_n,
+    cache,
+    block_tables,
+    page_table_offset,
+    PAGE_SIZE,
+    BLOCK_N,
+    BLOCK_DIM,
+    LOAD_BLOCK_N,
+    USE_GATHER_PAGE_LOAD,
+):
     """
     Load MLA cache data (K, V, or K_rope) for current position.
 
@@ -543,7 +777,16 @@ def _load_page_mla_wrapper(curr_n, cache, block_tables, page_table_offset, PAGE_
     token = curr_n % PAGE_SIZE
 
     data = _load_page_mla(
-        cache, block_tables, page_table_offset, page, token, NUM_PAGES, LOAD_BLOCK_N, BLOCK_DIM, PAGE_SIZE
+        cache,
+        block_tables,
+        page_table_offset,
+        page,
+        token,
+        NUM_PAGES,
+        LOAD_BLOCK_N,
+        BLOCK_DIM,
+        PAGE_SIZE,
+        USE_GATHER_PAGE_LOAD,
     )
     return data
 
@@ -574,6 +817,7 @@ def _decode_mla_kv_paged_kernel(
     LOAD_BLOCK_N: ConstInt,
     NUM_PAGES_PER_BLOCK: ConstInt,
     TRANS_QK: ConstBool,
+    USE_GATHER_PAGE_LOAD: ConstBool,
 ):
     batch_id = ct.bid(0)
     head_block_id = ct.bid(1)
@@ -665,20 +909,24 @@ def _decode_mla_kv_paged_kernel(
                 (BLOCK_N, BLOCK_R),
             )
 
-            # Prefetch V before QK computation so TMA can overlap V load with QK+softmax
-            v_tile = ct.reshape(
-                ct.load(
-                    v_cache,
-                    index=(page_id, token_block_idx, 0),
-                    shape=(1, BLOCK_N, BLOCK_D),
-                    order=(0, 1, 2),
-                    allow_tma=True,
-                    latency=4,
-                ),
-                (BLOCK_N, BLOCK_D),
-            )
-        else:
-            # Multi-page path: compute page_ids once, share across K / K_rope / V loads
+            if USE_GATHER_PAGE_LOAD:
+                # Prefetch V before QK on datacenter Blackwell (overlap TMA with QK+softmax).
+                # On A100/sm120 the extra live V tile (BLOCK_N x BLOCK_D=512) spills / cuts
+                # occupancy, so V is deferred to after the QK GEMM below (baseline scheduling).
+                v_tile = ct.reshape(
+                    ct.load(
+                        v_cache,
+                        index=(page_id, token_block_idx, 0),
+                        shape=(1, BLOCK_N, BLOCK_D),
+                        order=(0, 1, 2),
+                        allow_tma=True,
+                        latency=4,
+                    ),
+                    (BLOCK_N, BLOCK_D),
+                )
+        elif USE_GATHER_PAGE_LOAD:
+            # Multi-page on datacenter Blackwell: gather TMA, page_ids computed once
+            # and shared across K / K_rope / V loads (fast here).
             PAD_ZERO = ct.PaddingMode.ZERO
             page = curr_n // PAGE_SIZE
             token = curr_n % PAGE_SIZE
@@ -710,6 +958,38 @@ def _decode_mla_kv_paged_kernel(
                 ),
                 (BLOCK_N, BLOCK_D),
             )
+        else:
+            # Multi-page on sm120/sm121/A100: per-page TMA loads (gather regresses the
+            # memory-bound decode kernel there). _load_page_mla handles NUM_PAGES in
+            # {2,4} via ct.load(allow_tma)+ct.cat (USE_GATHER_PAGE_LOAD is False here).
+            page = curr_n // PAGE_SIZE
+            token = curr_n % PAGE_SIZE
+            k_tile = _load_page_mla(
+                k_cache,
+                block_tables,
+                page_table_offset,
+                page,
+                token,
+                NUM_PAGES_PER_BLOCK,
+                LOAD_BLOCK_N,
+                BLOCK_D,
+                PAGE_SIZE,
+                USE_GATHER_PAGE_LOAD,
+            )
+            k_rope_tile = _load_page_mla(
+                k_rope,
+                block_tables,
+                page_table_offset,
+                page,
+                token,
+                NUM_PAGES_PER_BLOCK,
+                LOAD_BLOCK_N,
+                BLOCK_R,
+                PAGE_SIZE,
+                USE_GATHER_PAGE_LOAD,
+            )
+            # V deferred to after the QK GEMM (per-page path regresses A100/sm120 under
+            # prefetch pressure); loaded below.
 
         # QK computation — TRANS_QK swaps operands: M=BLOCK_N (large) instead of M=BLOCK_H (small)
         if TRANS_QK:
@@ -731,6 +1011,36 @@ def _decode_mla_kv_paged_kernel(
             else:
                 mask = ct.reshape((offs_n < end_n), (1, BLOCK_N))
                 qk = ct.where(mask, qk, ct.full((BLOCK_H, BLOCK_N), -1.0e6, dtype=ct.float32))
+
+        # Deferred V load on the per-page path (single- and multi-page on A100/sm120): loaded
+        # here, after the QK GEMM, so V is not held live across QK — restores baseline occupancy
+        # on smaller SMs. Datacenter Blackwell already prefetched V above.
+        if not USE_GATHER_PAGE_LOAD:
+            if NUM_PAGES_PER_BLOCK == 1:
+                v_tile = ct.reshape(
+                    ct.load(
+                        v_cache,
+                        index=(page_id, token_block_idx, 0),
+                        shape=(1, BLOCK_N, BLOCK_D),
+                        order=(0, 1, 2),
+                        allow_tma=True,
+                        latency=2,
+                    ),
+                    (BLOCK_N, BLOCK_D),
+                )
+            else:
+                v_tile = _load_page_mla(
+                    v_cache,
+                    block_tables,
+                    page_table_offset,
+                    page,
+                    token,
+                    NUM_PAGES_PER_BLOCK,
+                    LOAD_BLOCK_N,
+                    BLOCK_D,
+                    PAGE_SIZE,
+                    USE_GATHER_PAGE_LOAD,
+                )
 
         if TRANS_QK:
             # reduce over axis 0 (N-dim) → [BLOCK_H]
@@ -832,6 +1142,7 @@ def _gqa_decode_autotune_base(
     HAS_LSE_OUT,
     stride_block_table,
     TRANS_QK,
+    USE_GATHER_PAGE_LOAD,
 ):
     configs = _get_gqa_decode_autotune_configs(QUERY_GROUP_SIZE, page_size)
 
@@ -846,6 +1157,7 @@ def _gqa_decode_autotune_base(
         kv_len_per_split,
         HAS_LSE_OUT,
         TRANS_QK,
+        USE_GATHER_PAGE_LOAD,
         q.dtype,
         str(q.device),
     )
@@ -879,6 +1191,7 @@ def _gqa_decode_autotune_base(
                 TRANS_QK,
                 min(cfg.BLOCK_N, page_size),
                 max(cfg.BLOCK_N // page_size, 1),
+                USE_GATHER_PAGE_LOAD,
             ),
             lambda cfg: {"occupancy": cfg.occupancy},
         )
@@ -916,6 +1229,7 @@ def _gqa_decode_autotune_base(
             TRANS_QK,
             min(best_cfg.BLOCK_N, page_size),
             max(best_cfg.BLOCK_N // page_size, 1),
+            USE_GATHER_PAGE_LOAD,
         ),
     )
     return Att_Out
@@ -945,7 +1259,12 @@ def decode_attention_kv_paged(
     head_dim_vo = v_cache.shape[-1]
 
     QUERY_GROUP_SIZE = num_qo_heads // num_kv_heads
+    # GQA DecodePaged: baseline enabled TRANS_QK on every arch (M=BLOCK_N=128 wide MMA)
+    # and it is the fast path on sm120/B20X too. The _supports_trans_qk() gate is only
+    # correct for the MLA host (whose baseline had TRANS_QK=False); gating it here flips
+    # TRANS_QK True->False on B20X and regresses DecodePaged ~3x.
     TRANS_QK = QUERY_GROUP_SIZE < 64
+    USE_GATHER_PAGE_LOAD = _supports_gather_page_load()
 
     if not (is_power_of_2(head_dim_qk) and is_power_of_2(head_dim_vo)):
         raise NotImplementedError(
@@ -1022,6 +1341,7 @@ def decode_attention_kv_paged(
         HAS_LSE_OUT,
         stride_block_table,
         TRANS_QK,
+        USE_GATHER_PAGE_LOAD,
     )
 
     if should_use_split_kv:
@@ -1063,6 +1383,7 @@ def _mla_decode_autotune_base(
     HAS_LSE_OUT,
     stride_block_table,
     TRANS_QK,
+    USE_GATHER_PAGE_LOAD,
 ):
     mla_cache_key = (
         num_batch,
@@ -1075,6 +1396,7 @@ def _mla_decode_autotune_base(
         kv_len_per_split,
         HAS_LSE_OUT,
         TRANS_QK,
+        USE_GATHER_PAGE_LOAD,
         q.dtype,
         str(q.device),
     )
@@ -1109,6 +1431,7 @@ def _mla_decode_autotune_base(
                 min(cfg.BLOCK_N, page_size),
                 max(cfg.BLOCK_N // page_size, 1),
                 TRANS_QK,
+                USE_GATHER_PAGE_LOAD,
             ),
             lambda cfg: {"occupancy": cfg.occupancy},
         )
@@ -1147,6 +1470,7 @@ def _mla_decode_autotune_base(
             min(best_cfg.BLOCK_N, page_size),
             max(best_cfg.BLOCK_N // page_size, 1),
             TRANS_QK,
+            USE_GATHER_PAGE_LOAD,
         ),
     )
     return Att_Out
@@ -1175,7 +1499,8 @@ def decode_mla_kv_paged(
     page_size = kv_cache.shape[1]
 
     QUERY_GROUP_SIZE = num_qo_heads
-    TRANS_QK = QUERY_GROUP_SIZE < 64
+    TRANS_QK = QUERY_GROUP_SIZE < 64 and _supports_trans_qk()
+    USE_GATHER_PAGE_LOAD = _supports_gather_page_load()
 
     use_autotune = is_autotune_enabled()
     if use_autotune:
@@ -1245,6 +1570,7 @@ def decode_mla_kv_paged(
             HAS_LSE_OUT,
             stride_block_table,
             TRANS_QK,
+            USE_GATHER_PAGE_LOAD,
         )
 
         if should_use_split_kv:
@@ -1374,6 +1700,7 @@ def decode_mla_kv_paged(
             LOAD_BLOCK_N,
             NUM_PAGES_PER_BLOCK,
             TRANS_QK,
+            USE_GATHER_PAGE_LOAD,
         ),
     )
 

--- a/src/tilegym/suites/flashinfer/cutile/fmha_prefill_bsr.py
+++ b/src/tilegym/suites/flashinfer/cutile/fmha_prefill_bsr.py
@@ -560,16 +560,25 @@ def _prefill_attention_ragged_body(
     offs_n_base = ct.arange(BLOCK_N, dtype=ct.int32)
     offs_m = start_m + ct.arange(BLOCK_M, dtype=ct.int32)
 
-    # Unified KV loop: single loop over all KV positions up to the causal boundary.
-    # IS_CAUSAL is ConstBool — the outer branch compiles away.
-    # curr_n >= start_m is a uniform scalar branch (no warp divergence).
+    # Two-stage causal split: keep the masking machinery (offs_n / causal_mask /
+    # ct.where) out of the bulk off-band iterations. Only the single diagonal
+    # block needs masking, so the off-band loop body stays small — better
+    # software pipelining and lower register pressure than a merged loop that
+    # drags the mask through every iteration.
     if IS_CAUSAL:
-        loop_hi = ct.minimum(seq_len_kv, start_m + BLOCK_M)
+        # Off-band: everything before the diagonal block (fully unmasked)
+        off_band_hi = ct.minimum(seq_len_kv, start_m)
+        # On-band: the diagonal block itself
+        on_band_lo = start_m
+        on_band_hi = ct.minimum(seq_len_kv, start_m + BLOCK_M)
     else:
-        loop_hi = seq_len_kv
+        # Non-causal: process everything in off-band loop
+        off_band_hi = seq_len_kv
+        on_band_lo = 0
+        on_band_hi = 0
 
-    total_iters = (loop_hi + BLOCK_N - 1) // BLOCK_N
-    for iter_idx in range(total_iters):
+    off_band_iters = (off_band_hi + BLOCK_N - 1) // BLOCK_N
+    for iter_idx in range(off_band_iters):
         curr_n = iter_idx * BLOCK_N
 
         k_tile = ct.load(
@@ -598,13 +607,6 @@ def _prefill_attention_ragged_body(
             k_pe = ct.reshape(k_pe_tile, (BLOCK_N, BLOCK_R))
             qk = ct.mma(q_pe, ct.transpose(k_pe), acc=qk)
 
-        # Apply causal mask only in the diagonal region (curr_n >= start_m).
-        if IS_CAUSAL:
-            if curr_n >= start_m:
-                offs_n = curr_n + offs_n_base
-                causal_mask = ct.reshape(offs_m, (BLOCK_M, 1)) >= ct.reshape(offs_n, (1, BLOCK_N))
-                qk = ct.where(causal_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32))
-
         qk_max = ct.max(qk, axis=1, keepdims=False)
         m_ij = ct.maximum(m_i, (qk_max * qk_scale))
         p = ct.exp2(qk * qk_scale - ct.reshape(m_ij, (BLOCK_M, 1)), flush_to_zero=True)
@@ -626,6 +628,65 @@ def _prefill_attention_ragged_body(
 
         acc = ct.mma(ct.astype(p, q.dtype), v, acc=acc)
         m_i = m_ij
+
+    if IS_CAUSAL:
+        on_band_iters = (on_band_hi - on_band_lo + BLOCK_N - 1) // BLOCK_N
+        on_band_block_start = on_band_lo // BLOCK_N
+        for iter_idx in range(on_band_iters):
+            curr_n = on_band_lo + iter_idx * BLOCK_N
+            block_idx = on_band_block_start + iter_idx
+
+            k_tile = ct.load(
+                k_seq,
+                index=(block_idx, off_kv_h, 0),
+                shape=(BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2),
+                allow_tma=True,
+                latency=2,
+                padding_mode=PAD_ZERO,
+            )
+            k = ct.reshape(k_tile, (BLOCK_N, BLOCK_D))
+
+            qk = ct.mma(q, ct.transpose(k), acc=qk_zeros)
+
+            if BLOCK_R > 0:
+                k_pe_tile = ct.load(
+                    k_seq,
+                    index=(block_idx, off_kv_h, BLOCK_D // BLOCK_R),
+                    shape=(BLOCK_N, 1, BLOCK_R),
+                    order=(0, 1, 2),
+                    allow_tma=True,
+                    latency=2,
+                    padding_mode=PAD_ZERO,
+                )
+                k_pe = ct.reshape(k_pe_tile, (BLOCK_N, BLOCK_R))
+                qk = ct.mma(q_pe, ct.transpose(k_pe), acc=qk)
+
+            offs_n = curr_n + offs_n_base
+            causal_mask = ct.reshape(offs_m, (BLOCK_M, 1)) >= ct.reshape(offs_n, (1, BLOCK_N))
+            qk = ct.where(causal_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32))
+
+            qk_max = ct.max(qk, axis=1, keepdims=False)
+            m_ij = ct.maximum(m_i, (qk_max * qk_scale))
+            p = ct.exp2(qk * qk_scale - ct.reshape(m_ij, (BLOCK_M, 1)), flush_to_zero=True)
+
+            alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
+            l_i = l_i * alpha + ct.sum(p, axis=1, keepdims=False)
+            acc = acc * ct.reshape(alpha, (BLOCK_M, 1))
+
+            v_tile = ct.load(
+                v_seq,
+                index=(block_idx, off_kv_h, 0),
+                shape=(BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2),
+                allow_tma=True,
+                latency=2,
+                padding_mode=PAD_ZERO,
+            )
+            v = ct.reshape(v_tile, (BLOCK_N, BLOCK_D))
+
+            acc = ct.mma(ct.astype(p, q.dtype), v, acc=acc)
+            m_i = m_ij
 
     l_i_rcp = ct.truediv(v_scale, l_i, flush_to_zero=True, rounding_mode=RMd.APPROX)
     acc = acc * ct.reshape(l_i_rcp, (BLOCK_M, 1))

--- a/src/tilegym/suites/flashinfer/cutile/gemm/gemm_alpha_beta.py
+++ b/src/tilegym/suites/flashinfer/cutile/gemm/gemm_alpha_beta.py
@@ -180,7 +180,15 @@ def _gemm_alpha_beta_kernel(
             )
 
 
-def _gemm_alpha_beta_autotune_configs():
+def _effective_occupancy(num_sms, occupancy):
+    """Keep an explicit, realizable SM limit from expanding the launch grid."""
+    actual_sms = torch.cuda.get_device_properties("cuda").multi_processor_count
+    if num_sms is not None and 0 < num_sms < actual_sms:
+        return 1
+    return occupancy
+
+
+def _gemm_alpha_beta_autotune_configs(num_sms=None):
     """
     Iterator of autotune configurations for gemm_alpha_beta kernel.
     Returns configurations optimized for different GPU architectures.
@@ -202,6 +210,8 @@ def _gemm_alpha_beta_autotune_configs():
         ]:
             for BK in [64]:
                 for occupancy in [1, 2, 4, 8]:
+                    if occupancy != _effective_occupancy(num_sms, occupancy):
+                        continue
                     for subtile in subtile_options:
                         yield SimpleNamespace(
                             BLOCK_M=BM,
@@ -222,6 +232,8 @@ def _gemm_alpha_beta_autotune_configs():
         ]:
             for BK in [64]:
                 for occupancy in [1, 2, 4]:
+                    if occupancy != _effective_occupancy(num_sms, occupancy):
+                        continue
                     yield SimpleNamespace(
                         BLOCK_M=BM,
                         BLOCK_N=BN,
@@ -241,6 +253,8 @@ def _gemm_alpha_beta_autotune_configs():
         ]:
             for BK in [64]:
                 for occupancy in [1, 2]:
+                    if occupancy != _effective_occupancy(num_sms, occupancy):
+                        continue
                     yield SimpleNamespace(
                         BLOCK_M=BM,
                         BLOCK_N=BN,
@@ -307,6 +321,7 @@ def _compute_grid_and_programs(M, N, BLOCK_M, BLOCK_N, num_sms, num_ctas, occupa
     NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
     if num_sms is not None:
         NUM_SMS = min(NUM_SMS, num_sms)
+    occupancy = _effective_occupancy(num_sms, occupancy)
 
     num_pid_m = ct.cdiv(M, BLOCK_M)
     num_pid_n = ct.cdiv(N, BLOCK_N)
@@ -424,7 +439,7 @@ def gemm_alpha_beta(
         cache_key = (M, N, K, transpose_a_int, transpose_b_int, a.dtype, num_sms, str(a.device))
         if cache_key not in _gemm_alpha_beta_tune_cache:
             result = exhaustive_search(
-                list(_gemm_alpha_beta_autotune_configs()),
+                list(_gemm_alpha_beta_autotune_configs(num_sms)),
                 stream,
                 grid_fn,
                 _gemm_alpha_beta_kernel,
@@ -451,7 +466,7 @@ def gemm_alpha_beta(
         BLOCK_K = kernel_configs.get("BLOCK_K")
         GROUP_SIZE_M = kernel_configs.get("GROUP_SIZE_M", 8)
         num_ctas = kernel_configs.get("num_ctas", 1)
-        occupancy = kernel_configs.get("occupancy", 1)
+        occupancy = _effective_occupancy(num_sms, kernel_configs.get("occupancy", 1))
         epilogue_subtile = kernel_configs.get("EPILOGUE_SUBTILE", 0)
 
         num_programs = _compute_grid_and_programs(M, N, BLOCK_M, BLOCK_N, num_sms, num_ctas, occupancy)[3]

--- a/src/tilegym/suites/flashinfer/cutile/gemm/ragged_block_scaled_bmm.py
+++ b/src/tilegym/suites/flashinfer/cutile/gemm/ragged_block_scaled_bmm.py
@@ -408,7 +408,6 @@ def _get_default_kernel_configs(total_m, Q, VEC_SIZE):
     """
     gpu_capability = torch.cuda.get_device_capability()
     is_large_m = _is_large_m(total_m, Q)
-    average_m = total_m / Q if Q > 0 else 0
 
     if gpu_capability in [(12, 0), (12, 1)]:
         return {
@@ -421,27 +420,20 @@ def _get_default_kernel_configs(total_m, Q, VEC_SIZE):
             "occupancy": 2,
         }
     elif gpu_capability[0] == 10:
-        # SM100 ragged workloads are sensitive to tail waste at BLOCK_M=256.
-        # Use 256 only for clearly large average segment sizes.
-        if is_large_m and average_m >= 640:
-            return {
-                "BLOCK_M": 256,
-                "BLOCK_N": 128,
-                "BLOCK_K": VEC_SIZE,
-                "GROUP_SIZE_M": 8,
-                "swap_ab": False,
-                "num_ctas": 2,
-                "occupancy": 2,
-            }
-        elif is_large_m:
+        if is_large_m:
+            # The num_ctas=2 / occupancy=2 tuning (and BLOCK_M=256 for large avg-M)
+            # added in 1fb8021e regressed the block-scaled MoE BMM 19-47% on these
+            # ragged fp8 shapes vs the pre-tuning default on datacenter Blackwell
+            # (bit-exact B300/sm103 A/B). Restore the baseline num_ctas=1 /
+            # occupancy=1 / BLOCK_M=128 config, which recovers it.
             return {
                 "BLOCK_M": 128,
                 "BLOCK_N": 128,
                 "BLOCK_K": VEC_SIZE,
                 "GROUP_SIZE_M": 8,
                 "swap_ab": False,
-                "num_ctas": 2,
-                "occupancy": 2,
+                "num_ctas": 1,
+                "occupancy": 1,
             }
         else:
             return {

--- a/src/tilegym/suites/liger/__init__.py
+++ b/src/tilegym/suites/liger/__init__.py
@@ -19,19 +19,28 @@ if is_backend_available("cutile"):
 
 # Import unified interface
 from .ops import cross_entropy
+from .ops import dyt
+from .ops import fused_add_rms_norm
+from .ops import fused_linear_cross_entropy
 from .ops import fused_linear_jsd
 from .ops import fused_neighborhood_attention
 from .ops import geglu
 from .ops import group_norm
+from .ops import grpo_loss
 from .ops import jsd
 from .ops import kl_div
 from .ops import layer_norm
 from .ops import llama4_rope
 from .ops import multi_token_attention
+from .ops import poly_norm
 from .ops import qwen2vl_mrope
+from .ops import rms_norm
 from .ops import rope
+from .ops import softmax
 from .ops import sparsemax
+from .ops import swiglu
 from .ops import tiled_mlp
+from .ops import tvd
 
 __all__ = [
     "cross_entropy",
@@ -48,4 +57,13 @@ __all__ = [
     "rope",
     "sparsemax",
     "tiled_mlp",
+    "dyt",
+    "fused_add_rms_norm",
+    "fused_linear_cross_entropy",
+    "grpo_loss",
+    "poly_norm",
+    "rms_norm",
+    "softmax",
+    "swiglu",
+    "tvd",
 ]

--- a/src/tilegym/suites/liger/cutile/__init__.py
+++ b/src/tilegym/suites/liger/cutile/__init__.py
@@ -5,31 +5,48 @@
 """CuTile implementations for liger suite."""
 
 from . import cross_entropy  # noqa: F401
+from . import dyt  # noqa: F401
+from . import fused_add_rms_norm  # noqa: F401
+from . import fused_linear_cross_entropy  # noqa: F401
 from . import fused_linear_jsd  # noqa: F401
 from . import fused_neighborhood_attention  # noqa: F401
 from . import geglu  # noqa: F401
 from . import group_norm  # noqa: F401
+from . import grpo_loss  # noqa: F401
 from . import jsd  # noqa: F401
 from . import kl_div  # noqa: F401
 from . import layer_norm  # noqa: F401
 from . import llama4_rope  # noqa: F401
 from . import multi_token_attention  # noqa: F401
+from . import poly_norm  # noqa: F401
 from . import qwen2vl_mrope  # noqa: F401
+from . import rms_norm  # noqa: F401
 from . import rope  # noqa: F401
+from . import softmax  # noqa: F401
 from . import sparsemax  # noqa: F401
+from . import swiglu  # noqa: F401
 from . import tiled_mlp  # noqa: F401
+from . import tvd  # noqa: F401
 from .cross_entropy import CrossEntropyCuTileFunction  # noqa: F401
+from .fused_add_rms_norm import FusedAddRMSNormCuTileFunction  # noqa: F401
+from .fused_linear_cross_entropy import FusedLinearCrossEntropyCuTileFunction  # noqa: F401
 from .fused_linear_jsd import FusedLinearJSDCuTileFunction  # noqa: F401
 from .geglu import GEGLUCuTileFunction  # noqa: F401
 from .group_norm import GroupNormCuTileFunction  # noqa: F401
+from .grpo_loss import GrpoLossCuTileFunction  # noqa: F401
 from .jsd import JSDCuTileFunction  # noqa: F401
 from .kl_div import KLDivCuTileFunction  # noqa: F401
 from .layer_norm import LayerNormCuTileFunction  # noqa: F401
 from .llama4_rope import Llama4RopeCuTileFunction  # noqa: F401
 from .multi_token_attention import MultiTokenAttentionCuTileFunction  # noqa: F401
+from .poly_norm import PolyNormCuTileFunction  # noqa: F401
 from .qwen2vl_mrope import Qwen2VLMRopeCuTileFunction  # noqa: F401
+from .rms_norm import RMSNormCuTileFunction  # noqa: F401
 from .rope import RopeCuTileFunction  # noqa: F401
+from .softmax import SoftmaxCuTileFunction  # noqa: F401
 from .sparsemax import SparsemaxCuTileFunction  # noqa: F401
+from .swiglu import SwiGLUCuTileFunction  # noqa: F401
+from .tvd import TVDLossCuTileFunction  # noqa: F401
 
 __all__ = [
     "CrossEntropyCuTileFunction",
@@ -58,4 +75,21 @@ __all__ = [
     "rope",
     "sparsemax",
     "tiled_mlp",
+    "FusedAddRMSNormCuTileFunction",
+    "FusedLinearCrossEntropyCuTileFunction",
+    "GrpoLossCuTileFunction",
+    "PolyNormCuTileFunction",
+    "RMSNormCuTileFunction",
+    "SwiGLUCuTileFunction",
+    "SoftmaxCuTileFunction",
+    "TVDLossCuTileFunction",
+    "dyt",
+    "fused_add_rms_norm",
+    "fused_linear_cross_entropy",
+    "grpo_loss",
+    "poly_norm",
+    "rms_norm",
+    "softmax",
+    "swiglu",
+    "tvd",
 ]

--- a/src/tilegym/suites/liger/cutile/cross_entropy.py
+++ b/src/tilegym/suites/liger/cutile/cross_entropy.py
@@ -5,10 +5,12 @@
 """CuTile fused cross-entropy with optional in-place gradient writes."""
 
 import math
+from types import SimpleNamespace
 from typing import Optional
 
 import cuda.tile as ct
 import torch
+from cuda.tile.tune import exhaustive_search
 
 from tilegym.backend import register_impl
 
@@ -22,6 +24,76 @@ MAX_FUSED_SIZE = 65536 // 2
 # ct.exp2(x * LOG2E) avoids a slower exp path in the streaming reductions.
 LOG2E = 1.4426950408889634
 
+# Autotune space for the streaming row-reduction over the vocab. num_worker_warps=8
+# (256 threads) is the max cuTile allows and is the sweet spot for the per-row
+# reduction (nww=4 halves parallelism); occupancy trades off with BLOCK_SIZE — a
+# large whole-vocab tile favours occ=2, a small chunked tile favours occ=4. The
+# best pair is shape-dependent, so exhaustive_search picks it per (n_cols, BLOCK).
+_CE_TUNE_CONFIGS = [SimpleNamespace(occ=o, nww=n) for o in [2, 4] for n in [4, 8]]
+_CE_TUNE_CACHE: dict = {}
+
+
+def _get_tuned_ce_kernel(n_cols, block_size, dtype, device):
+    """Autotune occupancy+nww per (n_cols, BLOCK_SIZE, dtype); cache the tuned kernel.
+
+    Tuned on a fresh stream over throwaway tensors (the kernel writes gradients in
+    place, and the autograd backward stream is not safe for exhaustive_search). The
+    reduction cost is driven by n_cols/BLOCK_SIZE, so the tuned hints apply across
+    all output-flag combos launched with the same (n_cols, BLOCK_SIZE, dtype).
+    """
+    key = (int(n_cols), int(block_size), dtype)
+    if key in _CE_TUNE_CACHE:
+        return _CE_TUNE_CACHE[key]
+
+    tune_rows = 2048  # enough CTAs to fill the GPU while keeping the tune tensor small
+    tune_stream = torch.cuda.Stream(device=device)
+    inp = torch.zeros(tune_rows, int(n_cols), dtype=dtype, device=device)
+    tgt = torch.zeros(tune_rows, dtype=torch.int64, device=device)
+    loss = torch.zeros(tune_rows, dtype=dtype, device=device)
+    d_f32 = torch.zeros(1, dtype=torch.float32, device=device)
+    d_i64 = torch.zeros(1, dtype=torch.int64, device=device)
+    d_w = torch.zeros(1, dtype=torch.float32, device=device)
+
+    def args_fn(_cfg):
+        return (
+            inp,
+            tgt,
+            d_w,
+            loss,
+            d_f32,
+            d_f32,
+            d_i64,
+            int(n_cols),
+            1.0,
+            float(tune_rows),
+            0.0,
+            -100,
+            0.0,
+            0.0,
+            0.0,
+            int(block_size),
+            1,  # HAS_GRADIENTS=1 (the expensive path)
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,  # RETURN_PREDICTED_TOKENS=0
+        )
+
+    result = exhaustive_search(
+        _CE_TUNE_CONFIGS,
+        tune_stream,
+        lambda cfg: (tune_rows, 1, 1),
+        _liger_cross_entropy_kernel,
+        args_fn,
+        lambda cfg: {"occupancy": cfg.occ, "num_worker_warps": cfg.nww},
+        quiet=True,
+    )
+    best = result.best.config
+    _CE_TUNE_CACHE[key] = _liger_cross_entropy_kernel.replace_hints(occupancy=best.occ, num_worker_warps=best.nww)
+    return _CE_TUNE_CACHE[key]
+
 
 def _select_block_size(vocab_size: int, device=None) -> int:
     cap = torch.cuda.get_device_capability(device)
@@ -29,7 +101,7 @@ def _select_block_size(vocab_size: int, device=None) -> int:
     return min(max_block, min(MAX_FUSED_SIZE, next_power_of_2(vocab_size)))
 
 
-@ct.kernel(occupancy=4)
+@ct.kernel
 def _liger_cross_entropy_kernel(
     input,
     target,
@@ -374,10 +446,11 @@ class CrossEntropyCuTileFunction(torch.autograd.Function):
         dummy_weight = torch.zeros(1, dtype=torch.float32, device=_input.device)
 
         grid = (num_rows, 1, 1)
+        _ce_kernel = _get_tuned_ce_kernel(vocab_size, BLOCK_SIZE, _input.dtype, _input.device)
         ct.launch(
             torch.cuda.current_stream(),
             grid,
-            _liger_cross_entropy_kernel,
+            _ce_kernel,
             (
                 _input,
                 target,

--- a/src/tilegym/suites/liger/cutile/dyt.py
+++ b/src/tilegym/suites/liger/cutile/dyt.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Dynamic Tanh (DyT) activation kernel (cuTile backend).
+
+Formula: y = tanh(alpha * x) * gamma + beta
+
+Reference:
+https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/dyt.py
+"""
+
+import cuda.tile as ct
+import torch
+from cuda.tile import RoundingMode as RMd
+
+from tilegym.backend import register_impl
+
+from .utils import next_power_of_2
+
+MAX_FUSED_SIZE = 65536
+
+
+@ct.kernel
+def _dyt_fwd_kernel(
+    x_input,  # (M, N) input
+    y_output,  # (M, N) output
+    alpha_tensor,  # (1,) scalar alpha
+    gamma_tensor,  # (N,) per-channel scale
+    beta_tensor,  # (N,) per-channel bias (or dummy 1-element tensor when HAVE_BETA=0)
+    HAVE_BETA: ct.Constant[int],
+    CHECK_BOUNDS: ct.Constant[bool],
+    BLOCK_N: ct.Constant[int],
+):
+    """
+    DyT forward kernel.
+
+    Grid: (num_col_blocks, M, 1).
+    CHECK_BOUNDS=False fast path (BLOCK_N==N, power-of-2, num_col_blocks==1) avoids
+    predicate-mask instructions on every gather/scatter — ~9-11% faster.
+    """
+    row_id = ct.bid(1)
+    # Aligned path (CHECK_BOUNDS=False): single col-block, no col offset, no padding_value.
+    # CuTile DCE collapses the unused branch since CHECK_BOUNDS is a compile-time Constant.
+    if CHECK_BOUNDS:
+        col_indices = ct.arange(BLOCK_N, dtype=ct.int32) + ct.bid(0) * BLOCK_N
+        gamma = ct.astype(ct.gather(gamma_tensor, col_indices, check_bounds=True, padding_value=0.0), ct.float32)
+        x = ct.astype(ct.gather(x_input, (row_id, col_indices), check_bounds=True, padding_value=0.0), ct.float32)
+    else:
+        col_indices = ct.arange(BLOCK_N, dtype=ct.int32)
+        gamma = ct.astype(ct.gather(gamma_tensor, col_indices, check_bounds=False), ct.float32)
+        x = ct.astype(ct.gather(x_input, (row_id, col_indices), check_bounds=False), ct.float32)
+
+    alpha = ct.astype(ct.load(alpha_tensor, 0, shape=()), ct.float32)
+    tanh_x = ct.tanh(alpha * x)
+    y = tanh_x * gamma
+    if HAVE_BETA:
+        if CHECK_BOUNDS:
+            beta = ct.astype(ct.gather(beta_tensor, col_indices, check_bounds=True, padding_value=0.0), ct.float32)
+        else:
+            beta = ct.astype(ct.gather(beta_tensor, col_indices, check_bounds=False), ct.float32)
+        y = y + beta
+
+    ct.scatter(y_output, (row_id, col_indices), ct.astype(y, y_output.dtype), check_bounds=CHECK_BOUNDS)
+
+
+@ct.kernel
+def _dyt_bwd_kernel(
+    dy_input,  # (M, N) upstream gradient
+    dx_output,  # (M, N) gradient w.r.t. x
+    da_partial,  # (NUM_SMS, num_col_blocks) partial d_alpha per block, host reduces
+    dg_partial,  # (NUM_SMS, N) partial d_gamma per block row, host reduces
+    db_partial,  # (NUM_SMS, N) partial d_beta when HAVE_BETA, host reduces
+    x_input,  # (M, N) saved input
+    alpha_tensor,  # (1,) scalar alpha
+    gamma_tensor,  # (N,) per-channel scale
+    HAVE_BETA: ct.Constant[int],
+    M: ct.Constant[int],
+    BLOCK_N: ct.Constant[int],
+    NUM_SMS: ct.Constant[int],
+):
+    """
+    DyT backward kernel (persistent 2D grid).
+
+    Grid: (num_col_blocks, NUM_SMS)
+    Block (col_block, start_row_id) strides over rows: start_row_id, start_row_id+NUM_SMS, ...
+    Writes DG/DB/DA to unique (start_row_id, col) so no atomics; host sums.
+    """
+    col_block = ct.bid(0)
+    start_row_id = ct.bid(1)
+    col_start = col_block * BLOCK_N
+    col_indices = ct.arange(BLOCK_N, dtype=ct.int32) + col_start
+
+    alpha = ct.astype(ct.load(alpha_tensor, 0, shape=()), ct.float32)
+    gamma = ct.astype(ct.gather(gamma_tensor, col_indices, check_bounds=True, padding_value=0.0), ct.float32)
+
+    da_acc = ct.full((BLOCK_N,), 0.0, dtype=ct.float32)  # tile accumulator, reduce once at end
+    dg_acc = ct.full((BLOCK_N,), 0.0, dtype=ct.float32)
+    if HAVE_BETA:
+        db_acc = ct.full((BLOCK_N,), 0.0, dtype=ct.float32)
+
+    # Stride over rows assigned to this block: start_row_id, start_row_id+NUM_SMS, ...
+    num_iters = (M + NUM_SMS - 1) // NUM_SMS
+    for i in range(num_iters):
+        row_id = start_row_id + i * NUM_SMS
+        if row_id < M:
+            x = ct.astype(ct.gather(x_input, (row_id, col_indices), check_bounds=True, padding_value=0.0), ct.float32)
+            dy = ct.astype(ct.gather(dy_input, (row_id, col_indices), check_bounds=True, padding_value=0.0), ct.float32)
+
+            # APPROX tanh: ~1.6x faster, 2-4 ULP off; well within bwd tolerance 1e-2.
+            tanh_x = ct.tanh(alpha * x, rounding_mode=RMd.APPROX)
+            sech2_x = ct.full((BLOCK_N,), 1.0, dtype=ct.float32) - tanh_x * tanh_x
+
+            if HAVE_BETA:
+                db_acc = db_acc + dy
+
+            dg_acc = dg_acc + dy * tanh_x
+
+            tmp = sech2_x * dy * gamma
+            da_acc = da_acc + x * tmp
+            dx = alpha * tmp
+            ct.scatter(dx_output, (row_id, col_indices), ct.astype(dx, dx_output.dtype), check_bounds=True)
+
+    # Write to unique (start_row_id, col) so host can sum over dim 0
+    row_idx_tile = ct.full((BLOCK_N,), start_row_id, dtype=ct.int32)
+    ct.scatter(dg_partial, (row_idx_tile, col_indices), dg_acc, check_bounds=True)
+    if HAVE_BETA:
+        ct.scatter(db_partial, (row_idx_tile, col_indices), db_acc, check_bounds=True)
+    # DA: one scalar per block at (start_row_id, col_block) — single reduction at end
+    da_scalar = ct.full((1,), ct.sum(da_acc, 0, keepdims=False), dtype=ct.float32)
+    ct.scatter(
+        da_partial,
+        (ct.full((1,), start_row_id, dtype=ct.int32), ct.full((1,), col_block, dtype=ct.int32)),
+        da_scalar,
+    )
+
+
+# nww=8 (256 threads) on this bwd kernel.
+_dyt_bwd_kernel_nww8 = _dyt_bwd_kernel.replace_hints(num_worker_warps=8)
+
+
+def _dyt_forward_ct(x, alpha, gamma, beta):
+    HAVE_BETA = beta is not None
+    input_shape = x.shape
+    x_2d = x.view(-1, input_shape[-1])
+    M, N = x_2d.shape
+
+    BLOCK_N = min(MAX_FUSED_SIZE, next_power_of_2(N))
+    num_col_blocks = (N + BLOCK_N - 1) // BLOCK_N
+    # Aligned fast path: single col-block + N is power-of-2 → all gathers/scatters
+    # are in-bounds, kernel compiles with check_bounds=False (no predicate masks).
+    check_bounds = not ((BLOCK_N == N) and (num_col_blocks == 1))
+
+    y = torch.empty_like(x_2d)
+    beta_tensor = beta if HAVE_BETA else torch.empty(1, device=x.device, dtype=x.dtype)
+
+    ct.launch(
+        torch.cuda.current_stream(),
+        (num_col_blocks, M, 1),
+        _dyt_fwd_kernel,
+        (x_2d, y, alpha, gamma, beta_tensor, int(HAVE_BETA), bool(check_bounds), int(BLOCK_N)),
+    )
+    return y.view(input_shape)
+
+
+def _dyt_backward_ct(dy, x, alpha, gamma, beta):
+    HAVE_BETA = beta is not None
+    input_shape = x.shape
+    x_2d = x.view(-1, input_shape[-1])
+    dy_2d = dy.view(-1, input_shape[-1])
+    M, N = x_2d.shape
+
+    NUM_SMS = torch.cuda.get_device_properties(x.device).multi_processor_count
+    BLOCK_N = min(next_power_of_2(N), 1024)
+    num_col_blocks = (N + BLOCK_N - 1) // BLOCK_N
+
+    dx = torch.empty_like(dy_2d)
+    # Per-block partials: host reduces over dim 0
+    da_partial = torch.zeros(NUM_SMS, num_col_blocks, dtype=torch.float32, device=x.device)
+    dg_partial = torch.empty(NUM_SMS, N, dtype=torch.float32, device=x.device)
+    db_partial = torch.empty(NUM_SMS, N, dtype=torch.float32, device=x.device) if HAVE_BETA else None
+
+    db_tensor = db_partial if HAVE_BETA else torch.empty(1, device=x.device, dtype=torch.float32)
+
+    ct.launch(
+        torch.cuda.current_stream(),
+        (num_col_blocks, NUM_SMS, 1),
+        _dyt_bwd_kernel_nww8,
+        (
+            dy_2d,
+            dx,
+            da_partial,
+            dg_partial,
+            db_tensor,
+            x_2d,
+            alpha,
+            gamma,
+            int(HAVE_BETA),
+            int(M),
+            int(BLOCK_N),
+            int(NUM_SMS),
+        ),
+    )
+
+    da = da_partial.sum().to(x.dtype).unsqueeze(0)
+    dg = dg_partial.sum(0).to(gamma.dtype)
+    db = db_partial.sum(0).to(x.dtype) if HAVE_BETA else None
+    return dx.view(input_shape), da, dg, db
+
+
+class _DytFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, alpha, gamma, beta):
+        x = x.contiguous()
+        alpha = alpha.contiguous()
+        gamma = gamma.contiguous()
+        if beta is not None:
+            beta = beta.contiguous()
+        y = _dyt_forward_ct(x, alpha, gamma, beta)
+        ctx.save_for_backward(x, alpha, gamma, beta)
+        return y
+
+    @staticmethod
+    def backward(ctx, dy):
+        x, alpha, gamma, beta = ctx.saved_tensors
+        dy = dy.contiguous()
+        dx, dalpha, dgamma, dbeta = _dyt_backward_ct(dy, x, alpha, gamma, beta)
+        return dx, dalpha, dgamma, dbeta
+
+
+@register_impl("liger.dyt", backend="cutile")
+def dyt(x, alpha, gamma, beta=None):
+    """
+    Dynamic Tanh (DyT): y = tanh(alpha * x) * gamma + beta
+
+    Args:
+        x: Input tensor of shape (*, N)
+        alpha: Scalar learnable parameter, shape (1,)
+        gamma: Per-channel scale, shape (N,)
+        beta: Optional per-channel bias, shape (N,)
+
+    Returns:
+        Output tensor of same shape as x
+    """
+    return _DytFunction.apply(x, alpha, gamma, beta)

--- a/src/tilegym/suites/liger/cutile/fused_add_rms_norm.py
+++ b/src/tilegym/suites/liger/cutile/fused_add_rms_norm.py
@@ -1,0 +1,623 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Fused residual-add + RMS normalization kernel (CuTile backend).
+
+Computes:
+  1. S = X + R          (residual addition, stored)
+  2. Y = rmsnorm(S)     (normalized output with weight W and optional offset)
+
+Forward kernel: row-parallel (one block per row), two passes.
+  Pass 1: compute S = X + R, accumulate sum(S^2)
+  Pass 2: compute Y = S * rstd * (W + offset)
+
+Backward kernel: persistent (one block per SM), strided row loop, single pass per row.
+  Grid = (sm_count,) — each block handles ceil(n_rows / sm_count) rows in a loop.
+  This reduces from ceil(n_rows / sm_count) waves (one-block-per-row) to exactly 1 wave.
+
+  BLOCK_SIZE = next_power_of_2(n_cols), NO register-pressure cap.
+  The persistent grid guarantees exactly 1 block/SM, so each block owns the full
+  256KB register file (512 float32/thread at 128 threads). Peak usage is ~7 live
+  tiles (n_cols=4096 → 7×32=224 f32/thread; n_cols=8192 → 7×64=448 f32/thread)
+  — well within budget.
+
+  Per row (single pass, tiles reused for dW and dX):
+    Load dY, S, W → compute m=dY*(W+offset), sum_mS=sum(m*S)
+    dW_acc += dY * (S * rstd)         (register accumulation)
+    Load dS_out → dX = rstd*m - (rstd^3/n)*sum_mS*S + dS_out  (scatter)
+  After the row loop, write dW_partial[sm_id, :] ONCE.
+
+dW_partial shape: (sm_count, n_cols) — much smaller than (n_rows, n_cols).
+Host reduces: dW = dW_partial.sum(dim=0).
+
+All intermediate computations are in float32 for numerical stability.
+Output is cast back to the original dtype.
+"""
+
+import functools
+import math
+from types import SimpleNamespace
+
+import cuda.tile as ct
+import torch
+from cuda.tile.tune import exhaustive_search
+
+from tilegym.backend import register_impl
+
+from .utils import next_power_of_2
+
+_CASTING_MODE_NONE = -1
+_CASTING_MODE_LLAMA = 0
+_CASTING_MODE_GEMMA = 1
+
+_STR_TO_CASTING_MODE = {
+    "llama": _CASTING_MODE_LLAMA,
+    "gemma": _CASTING_MODE_GEMMA,
+    "none": _CASTING_MODE_NONE,
+}
+
+# _BWD_MAX_CHUNK_SIZE: threshold for switching to the 2-chunk persistent kernel.
+# When BLOCK_SIZE (= next_power_of_2(n_cols)) exceeds this value, the backward
+# dispatch uses _fused_add_rms_norm_bwd_persistent_2c_ct with CHUNK_SIZE = BLOCK_SIZE//2.
+# This caps per-thread register usage at CHUNK_SIZE/128 elements per tile (32 f32/thread
+# at CHUNK_SIZE=4096), reducing peak pressure from 87% → 56% of the B200 budget.
+_BWD_MAX_CHUNK_SIZE = 4096
+
+
+def ensure_contiguous(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        args = [a.contiguous() if isinstance(a, torch.Tensor) else a for a in args]
+        kwargs = {k: v.contiguous() if isinstance(v, torch.Tensor) else v for k, v in kwargs.items()}
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def calculate_settings(n_cols):
+    BLOCK_SIZE = next_power_of_2(n_cols)
+    if BLOCK_SIZE > 65536:
+        raise RuntimeError(f"Hidden dimension {n_cols} exceeds maximum supported size of 65536.")
+    return BLOCK_SIZE
+
+
+@ct.kernel
+def _fused_add_rms_norm_fwd_ct(
+    Y,  # (n_rows, n_cols) normalized output
+    S,  # (n_rows, n_cols) updated residual (X + R)
+    X,  # (n_rows, n_cols) hidden states input
+    R,  # (n_rows, n_cols) residual input
+    W,  # (n_cols,) RMSNorm weight
+    RSTD,  # (n_rows,) cached rstd (scalar per row)
+    n_cols: ct.Constant[int],
+    eps: ct.Constant[float],
+    offset: ct.Constant[float],
+    BLOCK_SIZE: ct.Constant[int],
+    casting_mode: ct.Constant[int],
+):
+    """
+    Forward: S = X + R, Y = S * rstd * (W + offset).
+
+    Row-parallel: one block per row. Two passes over columns.
+
+    Casting modes:
+      _CASTING_MODE_LLAMA  (0): fp32 RMS; S*rstd cast back to X.dtype before W multiply
+      _CASTING_MODE_GEMMA  (1): full fp32, Y cast back to X.dtype at end (original behavior)
+      _CASTING_MODE_NONE  (-1): no casting, compute in X.dtype throughout
+    """
+    row_idx = ct.bid(0)
+    num_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    if num_chunks == 1:
+        # Single-pass: S stays in registers across the
+        # rstd compute, so pass 2 doesn't re-load it from DRAM. Reassigning S_tile
+        # through dtype transitions drops the previous register footprint.
+        col_idx = ct.arange(BLOCK_SIZE, dtype=ct.int32)
+        S_tile = ct.add(
+            ct.gather(X, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=2),
+            ct.gather(R, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=2),
+        )
+        ct.scatter(S, (row_idx, col_idx), S_tile, check_bounds=True)
+        W_tile = ct.gather(W, col_idx, check_bounds=True, padding_value=0.0)
+
+        if casting_mode == _CASTING_MODE_LLAMA:
+            S_tile = ct.astype(S_tile, ct.float32)
+            rstd = ct.rsqrt(ct.sum(ct.mul(S_tile, S_tile), 0, keepdims=False) / n_cols + eps)
+            ct.scatter(RSTD, row_idx, rstd)
+            S_tile = ct.astype(ct.mul(S_tile, rstd), X.dtype)
+            ct.scatter(Y, (row_idx, col_idx), ct.mul(S_tile, ct.add(W_tile, offset)), check_bounds=True)
+        elif casting_mode == _CASTING_MODE_GEMMA:
+            S_tile = ct.astype(S_tile, ct.float32)
+            rstd = ct.rsqrt(ct.sum(ct.mul(S_tile, S_tile), 0, keepdims=False) / n_cols + eps)
+            ct.scatter(RSTD, row_idx, rstd)
+            W_shifted = ct.add(ct.astype(W_tile, ct.float32), offset)
+            Y_f32 = ct.mul(ct.mul(S_tile, rstd), W_shifted)
+            ct.scatter(Y, (row_idx, col_idx), ct.astype(Y_f32, Y.dtype), check_bounds=True)
+        else:
+            # NONE: compute mean_sq in X.dtype (then promote to fp32 at division),
+            # store rstd as X.dtype.
+            mean_sq = ct.sum(ct.mul(S_tile, S_tile), 0, keepdims=False) / n_cols
+            rstd = ct.rsqrt(mean_sq + eps)
+            ct.scatter(RSTD, row_idx, rstd)
+            ct.scatter(Y, (row_idx, col_idx), ct.mul(ct.mul(S_tile, rstd), ct.add(W_tile, offset)), check_bounds=True)
+        return
+
+    # ---- Multi-chunk path (BLOCK_SIZE chunked from n_cols, num_chunks >= 2) ----
+    # Two-pass loop: pass 1 computes S, scatters S, accumulates sum(S^2).
+    # Pass 2 re-loads S to compute Y (unavoidable: tiles don't fit in registers across chunks).
+    if casting_mode == _CASTING_MODE_NONE:
+        sum_sq_tile = ct.full((BLOCK_SIZE,), 0.0, dtype=X.dtype)
+    else:
+        sum_sq_tile = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+
+    for ci in range(num_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+        X_tile = ct.gather(X, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=2)
+        R_tile = ct.gather(R, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=2)
+        S_tile = ct.add(X_tile, R_tile)
+        ct.scatter(S, (row_idx, col_idx), S_tile, check_bounds=True)
+        if casting_mode == _CASTING_MODE_NONE:
+            sum_sq_tile = ct.add(sum_sq_tile, ct.mul(S_tile, S_tile))
+        else:
+            S_tile_f32 = ct.astype(S_tile, ct.float32)
+            sum_sq_tile = ct.add(sum_sq_tile, ct.mul(S_tile_f32, S_tile_f32))
+
+    mean_sq = ct.sum(sum_sq_tile, 0, keepdims=False) / n_cols
+    rstd = ct.rsqrt(mean_sq + eps)
+    ct.scatter(RSTD, row_idx, rstd)
+
+    for ci in range(num_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+        S_tile = ct.gather(S, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=2)
+        W_tile = ct.gather(W, col_idx, check_bounds=True, padding_value=0.0)
+
+        if casting_mode == _CASTING_MODE_LLAMA:
+            S_tile = ct.astype(S_tile, ct.float32)
+            S_normed = ct.astype(ct.mul(S_tile, rstd), X.dtype)
+            ct.scatter(Y, (row_idx, col_idx), ct.mul(S_normed, ct.add(W_tile, offset)), check_bounds=True)
+        elif casting_mode == _CASTING_MODE_GEMMA:
+            S_tile = ct.astype(S_tile, ct.float32)
+            W_shifted = ct.add(ct.astype(W_tile, ct.float32), offset)
+            Y_f32 = ct.mul(ct.mul(S_tile, rstd), W_shifted)
+            ct.scatter(Y, (row_idx, col_idx), ct.astype(Y_f32, Y.dtype), check_bounds=True)
+        else:
+            ct.scatter(Y, (row_idx, col_idx), ct.mul(ct.mul(S_tile, rstd), ct.add(W_tile, offset)), check_bounds=True)
+
+
+_fused_add_rms_norm_fwd_large_ct = _fused_add_rms_norm_fwd_ct.replace_hints(num_worker_warps=8)
+# Small BLOCK_SIZE: use num_warps=4 for BLOCK_SIZE<2048.
+# This avoids over-warping when each thread only has 4 fp32/tile of work.
+_fused_add_rms_norm_fwd_small_ct = _fused_add_rms_norm_fwd_ct.replace_hints(num_worker_warps=4)
+
+
+# Per-shape autotune for fwd occupancy. Higher occupancy forces the compiler to budget
+# fewer regs/thread (target: 1/occ of the SM register file). Sweet spot is shape-
+# dependent — tiny tiles at small N benefit from occ>=8, large tiles spill above occ=1.
+def _fwd_autotune_configs():
+    for occ in (None, 2, 3, 4, 5, 6, 8):
+        yield SimpleNamespace(occupancy=occ)
+
+
+_fwd_tune_cache: dict = {}
+
+
+def _autotune_fwd_kernel(base_kernel, args, n_rows, cache_key, stream):
+    if cache_key in _fwd_tune_cache:
+        return _fwd_tune_cache[cache_key]
+    result = exhaustive_search(
+        list(_fwd_autotune_configs()),
+        stream,
+        lambda cfg: (n_rows, 1, 1),
+        base_kernel,
+        lambda cfg: args,
+        lambda cfg: {"occupancy": cfg.occupancy} if cfg.occupancy is not None else {},
+        quiet=True,
+    )
+    best = result.best.config
+    tuned = base_kernel.replace_hints(occupancy=best.occupancy) if best.occupancy is not None else base_kernel
+    _fwd_tune_cache[cache_key] = tuned
+    return tuned
+
+
+@ct.kernel(occupancy=1)
+def _fused_add_rms_norm_bwd_persistent_ct(
+    dY,  # (n_rows, n_cols) gradient of Y
+    dS_out,  # (n_rows, n_cols) gradient of S flowing from downstream
+    dX,  # (n_rows, n_cols) output gradient (also used for dR)
+    S,  # (n_rows, n_cols) saved residual S = X + R from forward
+    W,  # (n_cols,) RMSNorm weight
+    RSTD,  # (n_rows,) cached rstd from forward
+    dW_partial,  # (sm_count, n_cols) per-SM dW, host reduces with sum(dim=0)
+    n_cols: ct.Constant[int],
+    offset: ct.Constant[float],
+    num_iters: ct.Constant[int],
+    sm_count: ct.Constant[int],
+    n_rows: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],  # = next_power_of_2(n_cols) — no cap
+    casting_mode: ct.Constant[int],
+):
+    """
+    Persistent backward: grid = (sm_count,).
+    Each block handles ceil(n_rows / sm_count) rows in a blocked loop:
+      row_idx = sm_id * num_iters + i   for i in range(num_iters)
+
+    Casting modes:
+      _CASTING_MODE_LLAMA  (0): m = (dY * W).to(f32); dW uses cast-back intermediate
+      _CASTING_MODE_GEMMA  (1): dY cast to f32 first, then full fp32 (original behavior)
+      _CASTING_MODE_NONE  (-1): compute in S.dtype throughout
+    """
+    sm_id = ct.bid(0)
+    col_idx = ct.arange(BLOCK_SIZE, dtype=ct.int32)
+
+    # Hoist W load outside the row loop: W is row-invariant, load it once per SM.
+    W_tile = ct.gather(W, col_idx, check_bounds=True, padding_value=0.0)
+    if casting_mode == _CASTING_MODE_NONE:
+        W_shifted = ct.add(W_tile, offset)
+    else:
+        W_shifted = ct.add(ct.astype(W_tile, ct.float32), offset)
+
+    # Single register-resident dW accumulator (always float32 for numerical stability).
+    dW_acc = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+    inv_n_cols = 1.0 / n_cols
+
+    row_start = sm_id * num_iters
+    for i in range(num_iters):
+        row_idx = row_start + i
+
+        if row_idx < n_rows:
+            rstd = ct.load(RSTD, row_idx, shape=())  # scalar
+
+            dY_tile = ct.gather(dY, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=3)
+            S_tile = ct.gather(S, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=3)
+
+            if casting_mode == _CASTING_MODE_LLAMA:
+                # m = (dY * W_orig_dtype).to(f32)
+                m_tile = ct.astype(ct.mul(dY_tile, ct.astype(W_shifted, dY.dtype)), ct.float32)
+                S_tile_f32 = ct.astype(S_tile, ct.float32)
+                sum_mS = ct.sum(ct.mul(m_tile, S_tile_f32), 0, keepdims=False)
+                # dW: dY * (S * rstd).to(S.dtype)
+                dW_acc = ct.add(
+                    dW_acc, ct.astype(ct.mul(dY_tile, ct.astype(ct.mul(S_tile_f32, rstd), S.dtype)), ct.float32)
+                )
+                dS_out_tile = ct.astype(
+                    ct.gather(dS_out, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=3), ct.float32
+                )
+                rstd3_coeff = rstd * rstd * rstd * inv_n_cols * sum_mS
+                dX_tile = ct.add(ct.sub(ct.mul(rstd, m_tile), ct.mul(rstd3_coeff, S_tile_f32)), dS_out_tile)
+                ct.scatter(dX, (row_idx, col_idx), ct.astype(dX_tile, dX.dtype), check_bounds=True)
+            elif casting_mode == _CASTING_MODE_GEMMA:
+                dY_tile_f32 = ct.astype(dY_tile, ct.float32)
+                S_tile_f32 = ct.astype(S_tile, ct.float32)
+                m_tile = ct.mul(dY_tile_f32, W_shifted)
+                sum_mS = ct.sum(ct.mul(m_tile, S_tile_f32), 0, keepdims=False)
+                dW_acc = ct.add(dW_acc, ct.mul(dY_tile_f32, ct.mul(S_tile_f32, rstd)))
+                dS_out_tile = ct.astype(
+                    ct.gather(dS_out, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=3), ct.float32
+                )
+                rstd3_coeff = rstd * rstd * rstd * inv_n_cols * sum_mS
+                dX_tile = ct.add(ct.sub(ct.mul(rstd, m_tile), ct.mul(rstd3_coeff, S_tile_f32)), dS_out_tile)
+                ct.scatter(dX, (row_idx, col_idx), ct.astype(dX_tile, dX.dtype), check_bounds=True)
+            else:
+                # _CASTING_MODE_NONE: compute in S.dtype
+                m_tile = ct.mul(dY_tile, W_shifted)
+                sum_mS = ct.sum(ct.astype(ct.mul(m_tile, S_tile), ct.float32), 0, keepdims=False)
+                dW_acc = ct.add(dW_acc, ct.astype(ct.mul(dY_tile, ct.mul(S_tile, rstd)), ct.float32))
+                dS_out_tile = ct.gather(dS_out, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=3)
+                rstd3_coeff = rstd * rstd * rstd * inv_n_cols * sum_mS
+                dX_tile = ct.add(
+                    ct.sub(
+                        ct.mul(rstd, m_tile), ct.astype(ct.mul(rstd3_coeff, ct.astype(S_tile, ct.float32)), S.dtype)
+                    ),
+                    dS_out_tile,
+                )
+                ct.scatter(dX, (row_idx, col_idx), dX_tile, check_bounds=True)
+
+    # Write register-accumulated dW to global memory — exactly ONCE per SM.
+    ct.scatter(dW_partial, (sm_id, col_idx), dW_acc, check_bounds=True)
+
+
+@ct.kernel(occupancy=1)
+def _fused_add_rms_norm_bwd_persistent_2c_ct(
+    dY,  # (n_rows, n_cols) gradient of Y
+    dS_out,  # (n_rows, n_cols) gradient of S flowing from downstream
+    dX,  # (n_rows, n_cols) output gradient (also used for dR)
+    S,  # (n_rows, n_cols) saved residual S = X + R from forward
+    W,  # (n_cols,) RMSNorm weight
+    RSTD,  # (n_rows,) cached rstd from forward
+    dW_partial,  # (sm_count, n_cols) per-SM dW, host reduces with sum(dim=0)
+    n_cols: ct.Constant[int],
+    offset: ct.Constant[float],
+    num_iters: ct.Constant[int],
+    sm_count: ct.Constant[int],
+    n_rows: ct.Constant[int],
+    CHUNK_SIZE: ct.Constant[int],  # = BLOCK_SIZE // 2 = next_power_of_2(n_cols) // 2
+    casting_mode: ct.Constant[int],
+):
+    """
+    2-chunk persistent backward: used when BLOCK_SIZE > _BWD_MAX_CHUNK_SIZE.
+
+    Splits the n_cols dimension into two halves (lo=0..CHUNK_SIZE-1,
+    hi=CHUNK_SIZE..2*CHUNK_SIZE-1) processed together in a single pass per row.
+    Each half uses a separate set of register tiles, capping per-thread register
+    usage at CHUNK_SIZE/128 elements (32 f32/thread at CHUNK_SIZE=4096) vs.
+    BLOCK_SIZE/128 in the 1-chunk kernel (64 f32/thread for n_cols=8192).
+
+    Casting modes:
+      _CASTING_MODE_LLAMA  (0): m = (dY * W).to(f32); dW uses cast-back intermediate
+      _CASTING_MODE_GEMMA  (1): dY cast to f32 first, then full fp32 (original behavior)
+      _CASTING_MODE_NONE  (-1): compute in S.dtype throughout
+    """
+    sm_id = ct.bid(0)
+
+    # Column index tiles for each half
+    col_idx_lo = ct.arange(CHUNK_SIZE, dtype=ct.int32)
+    col_idx_hi = ct.add(ct.arange(CHUNK_SIZE, dtype=ct.int32), CHUNK_SIZE)
+
+    # Hoist W loads outside the row loop (W is row-invariant).
+    W_tile_lo_raw = ct.gather(W, col_idx_lo, check_bounds=True, padding_value=0.0)
+    W_tile_hi_raw = ct.gather(W, col_idx_hi, check_bounds=True, padding_value=0.0)
+    if casting_mode == _CASTING_MODE_NONE:
+        W_shifted_lo = ct.add(W_tile_lo_raw, offset)
+        W_shifted_hi = ct.add(W_tile_hi_raw, offset)
+    else:
+        W_shifted_lo = ct.add(ct.astype(W_tile_lo_raw, ct.float32), offset)
+        W_shifted_hi = ct.add(ct.astype(W_tile_hi_raw, ct.float32), offset)
+
+    # Separate dW accumulators for lo and hi halves.
+    dW_acc_lo = ct.full((CHUNK_SIZE,), 0.0, dtype=ct.float32)
+    dW_acc_hi = ct.full((CHUNK_SIZE,), 0.0, dtype=ct.float32)
+    inv_n_cols = 1.0 / n_cols
+
+    row_start = sm_id * num_iters
+    for i in range(num_iters):
+        row_idx = row_start + i
+
+        if row_idx < n_rows:
+            rstd = ct.load(RSTD, row_idx, shape=())  # scalar
+
+            dY_lo_raw = ct.gather(dY, (row_idx, col_idx_lo), check_bounds=True, padding_value=0.0, latency=3)
+            dY_hi_raw = ct.gather(dY, (row_idx, col_idx_hi), check_bounds=True, padding_value=0.0, latency=3)
+            S_lo_raw = ct.gather(S, (row_idx, col_idx_lo), check_bounds=True, padding_value=0.0, latency=3)
+            S_hi_raw = ct.gather(S, (row_idx, col_idx_hi), check_bounds=True, padding_value=0.0, latency=3)
+
+            if casting_mode == _CASTING_MODE_LLAMA:
+                m_lo = ct.astype(ct.mul(dY_lo_raw, ct.astype(W_shifted_lo, dY.dtype)), ct.float32)
+                m_hi = ct.astype(ct.mul(dY_hi_raw, ct.astype(W_shifted_hi, dY.dtype)), ct.float32)
+                S_lo = ct.astype(S_lo_raw, ct.float32)
+                S_hi = ct.astype(S_hi_raw, ct.float32)
+                sum_mS = ct.sum(ct.mul(m_lo, S_lo), 0, keepdims=False) + ct.sum(ct.mul(m_hi, S_hi), 0, keepdims=False)
+                dW_acc_lo = ct.add(
+                    dW_acc_lo, ct.astype(ct.mul(dY_lo_raw, ct.astype(ct.mul(S_lo, rstd), S.dtype)), ct.float32)
+                )
+                dW_acc_hi = ct.add(
+                    dW_acc_hi, ct.astype(ct.mul(dY_hi_raw, ct.astype(ct.mul(S_hi, rstd), S.dtype)), ct.float32)
+                )
+                rstd3_coeff = rstd * rstd * rstd * inv_n_cols * sum_mS
+                dS_out_lo = ct.astype(
+                    ct.gather(dS_out, (row_idx, col_idx_lo), check_bounds=True, padding_value=0.0, latency=3),
+                    ct.float32,
+                )
+                dX_lo = ct.add(ct.sub(ct.mul(rstd, m_lo), ct.mul(rstd3_coeff, S_lo)), dS_out_lo)
+                ct.scatter(dX, (row_idx, col_idx_lo), ct.astype(dX_lo, dX.dtype), check_bounds=True)
+                dS_out_hi = ct.astype(
+                    ct.gather(dS_out, (row_idx, col_idx_hi), check_bounds=True, padding_value=0.0, latency=3),
+                    ct.float32,
+                )
+                dX_hi = ct.add(ct.sub(ct.mul(rstd, m_hi), ct.mul(rstd3_coeff, S_hi)), dS_out_hi)
+                ct.scatter(dX, (row_idx, col_idx_hi), ct.astype(dX_hi, dX.dtype), check_bounds=True)
+            elif casting_mode == _CASTING_MODE_GEMMA:
+                dY_lo = ct.astype(dY_lo_raw, ct.float32)
+                dY_hi = ct.astype(dY_hi_raw, ct.float32)
+                S_lo = ct.astype(S_lo_raw, ct.float32)
+                S_hi = ct.astype(S_hi_raw, ct.float32)
+                m_lo = ct.mul(dY_lo, W_shifted_lo)
+                m_hi = ct.mul(dY_hi, W_shifted_hi)
+                sum_mS = ct.sum(ct.mul(m_lo, S_lo), 0, keepdims=False) + ct.sum(ct.mul(m_hi, S_hi), 0, keepdims=False)
+                dW_acc_lo = ct.add(dW_acc_lo, ct.mul(dY_lo, ct.mul(S_lo, rstd)))
+                dW_acc_hi = ct.add(dW_acc_hi, ct.mul(dY_hi, ct.mul(S_hi, rstd)))
+                rstd3_coeff = rstd * rstd * rstd * inv_n_cols * sum_mS
+                dS_out_lo = ct.astype(
+                    ct.gather(dS_out, (row_idx, col_idx_lo), check_bounds=True, padding_value=0.0, latency=3),
+                    ct.float32,
+                )
+                dX_lo = ct.add(ct.sub(ct.mul(rstd, m_lo), ct.mul(rstd3_coeff, S_lo)), dS_out_lo)
+                ct.scatter(dX, (row_idx, col_idx_lo), ct.astype(dX_lo, dX.dtype), check_bounds=True)
+                dS_out_hi = ct.astype(
+                    ct.gather(dS_out, (row_idx, col_idx_hi), check_bounds=True, padding_value=0.0, latency=3),
+                    ct.float32,
+                )
+                dX_hi = ct.add(ct.sub(ct.mul(rstd, m_hi), ct.mul(rstd3_coeff, S_hi)), dS_out_hi)
+                ct.scatter(dX, (row_idx, col_idx_hi), ct.astype(dX_hi, dX.dtype), check_bounds=True)
+            else:
+                # _CASTING_MODE_NONE: compute in S.dtype
+                m_lo = ct.mul(dY_lo_raw, W_shifted_lo)
+                m_hi = ct.mul(dY_hi_raw, W_shifted_hi)
+                sum_mS = ct.sum(ct.astype(ct.mul(m_lo, S_lo_raw), ct.float32), 0, keepdims=False) + ct.sum(
+                    ct.astype(ct.mul(m_hi, S_hi_raw), ct.float32), 0, keepdims=False
+                )
+                dW_acc_lo = ct.add(dW_acc_lo, ct.astype(ct.mul(dY_lo_raw, ct.mul(S_lo_raw, rstd)), ct.float32))
+                dW_acc_hi = ct.add(dW_acc_hi, ct.astype(ct.mul(dY_hi_raw, ct.mul(S_hi_raw, rstd)), ct.float32))
+                rstd3_coeff = rstd * rstd * rstd * inv_n_cols * sum_mS
+                dS_out_lo = ct.gather(dS_out, (row_idx, col_idx_lo), check_bounds=True, padding_value=0.0, latency=3)
+                dX_lo = ct.add(
+                    ct.sub(
+                        ct.mul(rstd, m_lo), ct.astype(ct.mul(rstd3_coeff, ct.astype(S_lo_raw, ct.float32)), S.dtype)
+                    ),
+                    dS_out_lo,
+                )
+                ct.scatter(dX, (row_idx, col_idx_lo), dX_lo, check_bounds=True)
+                dS_out_hi = ct.gather(dS_out, (row_idx, col_idx_hi), check_bounds=True, padding_value=0.0, latency=3)
+                dX_hi = ct.add(
+                    ct.sub(
+                        ct.mul(rstd, m_hi), ct.astype(ct.mul(rstd3_coeff, ct.astype(S_hi_raw, ct.float32)), S.dtype)
+                    ),
+                    dS_out_hi,
+                )
+                ct.scatter(dX, (row_idx, col_idx_hi), dX_hi, check_bounds=True)
+
+    # Write accumulated dW to global memory — ONCE per SM, both halves.
+    ct.scatter(dW_partial, (sm_id, col_idx_lo), dW_acc_lo, check_bounds=True)
+    ct.scatter(dW_partial, (sm_id, col_idx_hi), dW_acc_hi, check_bounds=True)
+
+
+_fused_add_rms_norm_bwd_persistent_ct_nww8 = _fused_add_rms_norm_bwd_persistent_ct.replace_hints(num_worker_warps=8)
+_fused_add_rms_norm_bwd_persistent_2c_ct_nww8 = _fused_add_rms_norm_bwd_persistent_2c_ct.replace_hints(
+    num_worker_warps=8
+)
+
+
+def _fused_add_rms_norm_forward_ct(X, R, W, eps, offset, casting_mode):
+    if isinstance(casting_mode, str):
+        casting_mode = _STR_TO_CASTING_MODE[casting_mode]
+
+    shape = X.shape
+    dim = shape[-1]
+    X2d = X.view(-1, dim)
+    R2d = R.view(-1, dim)
+    n_rows, n_cols = X2d.shape
+    BLOCK_SIZE = calculate_settings(n_cols)
+
+    Y = torch.empty_like(X2d)
+    S = torch.empty_like(X2d)
+    # RSTD dtype: float32 for llama/gemma (fp32 rstd computation), X.dtype for none
+    rstd_dtype = torch.float32 if casting_mode in (_CASTING_MODE_LLAMA, _CASTING_MODE_GEMMA) else X.dtype
+    RSTD = torch.empty(n_rows, dtype=rstd_dtype, device=X.device)
+
+    # Fwd register pressure: for n_cols > 4096, 1 huge chunk spills; 2 chunks is the
+    # sweet spot (3+ adds per-iteration overhead with no register benefit).
+    FWD_BLOCK_SIZE = BLOCK_SIZE // 2 if BLOCK_SIZE > 4096 else BLOCK_SIZE
+    base_kernel = _fused_add_rms_norm_fwd_small_ct if BLOCK_SIZE < 2048 else _fused_add_rms_norm_fwd_large_ct
+
+    stream = torch.cuda.current_stream()
+    args = (
+        Y,
+        S,
+        X2d.contiguous(),
+        R2d.contiguous(),
+        W.contiguous(),
+        RSTD,
+        int(n_cols),
+        float(eps),
+        float(offset),
+        int(FWD_BLOCK_SIZE),
+        int(casting_mode),
+    )
+    cache_key = (n_cols, FWD_BLOCK_SIZE, casting_mode, X.dtype, str(X.device))
+    tuned_kernel = _autotune_fwd_kernel(base_kernel, args, n_rows, cache_key, stream)
+
+    ct.launch(stream, (n_rows, 1, 1), tuned_kernel, args)
+
+    return Y.view(*shape), S.view(*shape), RSTD, BLOCK_SIZE, casting_mode
+
+
+def _fused_add_rms_norm_backward_ct(dY, dS_out, S, W, RSTD, offset, casting_mode, BLOCK_SIZE):
+    shape = dY.shape
+    dim = shape[-1]
+    dY2d = dY.view(-1, dim)
+    dS_out2d = dS_out.view(-1, dim)
+    S2d = S.view(-1, dim)
+    n_rows, n_cols = dY2d.shape
+
+    # Persistent kernel: one block per SM, each handles ceil(n_rows/sm_count) rows.
+    # Grid = (sm_count,) → exactly 1 block/SM → full 256KB register file available.
+    # When BLOCK_SIZE > _BWD_MAX_CHUNK_SIZE, use the 2-chunk kernel to reduce
+    # register pressure (CHUNK_SIZE/128 elements/thread vs BLOCK_SIZE/128).
+    sm_count = torch.cuda.get_device_properties(W.device).multi_processor_count
+    num_iters = math.ceil(n_rows / sm_count)
+
+    dX = torch.empty_like(dY2d)
+    # Per-SM partial dW: shape (sm_count, n_cols).
+    # Each SM accumulates dW in registers across its rows, writes once.
+    dW_partial = torch.empty(sm_count, n_cols, dtype=torch.float32, device=W.device)
+
+    grid = (sm_count, 1, 1)
+    # gather+latency=3 gives explicit cp.async-style pipelining that outperforms TMA
+    # at every test shape on this kernel. 2-chunk variant caps per-thread register
+    # usage when BLOCK_SIZE > _BWD_MAX_CHUNK_SIZE (splits cols into lo/hi halves).
+    if BLOCK_SIZE > _BWD_MAX_CHUNK_SIZE:
+        CHUNK_SIZE = BLOCK_SIZE // 2
+        ct.launch(
+            torch.cuda.current_stream(),
+            grid,
+            _fused_add_rms_norm_bwd_persistent_2c_ct_nww8,
+            (
+                dY2d.contiguous(),
+                dS_out2d.contiguous(),
+                dX,
+                S2d.contiguous(),
+                W.contiguous(),
+                RSTD,
+                dW_partial,
+                int(n_cols),
+                float(offset),
+                int(num_iters),
+                int(sm_count),
+                int(n_rows),
+                int(CHUNK_SIZE),
+                int(casting_mode),
+            ),
+        )
+    else:
+        ct.launch(
+            torch.cuda.current_stream(),
+            grid,
+            _fused_add_rms_norm_bwd_persistent_ct_nww8,
+            (
+                dY2d.contiguous(),
+                dS_out2d.contiguous(),
+                dX,
+                S2d.contiguous(),
+                W.contiguous(),
+                RSTD,
+                dW_partial,
+                int(n_cols),
+                float(offset),
+                int(num_iters),
+                int(sm_count),
+                int(n_rows),
+                int(BLOCK_SIZE),
+                int(casting_mode),
+            ),
+        )
+
+    dX = dX.view(*shape)
+    dW = dW_partial.sum(dim=0).to(W.dtype)
+    return dX, dX, dW  # dR == dX (gradient flows equally to X and R)
+
+
+class FusedAddRMSNormCuTileFunction(torch.autograd.Function):
+    """CuTile autograd wrapper for fused residual-add + RMSNorm."""
+
+    @staticmethod
+    @ensure_contiguous
+    def forward(ctx, X, R, W, eps, offset, casting_mode):
+        Y, S, RSTD, BLOCK_SIZE, casting_mode_int = _fused_add_rms_norm_forward_ct(X, R, W, eps, offset, casting_mode)
+        ctx.offset = offset
+        ctx.casting_mode = casting_mode_int
+        ctx.BLOCK_SIZE = BLOCK_SIZE
+        ctx.save_for_backward(S, W, RSTD)
+        return Y, S
+
+    @staticmethod
+    @ensure_contiguous
+    def backward(ctx, dY, dS_out):
+        S, W, RSTD = ctx.saved_tensors
+        dX, dR, dW = _fused_add_rms_norm_backward_ct(
+            dY, dS_out, S, W, RSTD, ctx.offset, ctx.casting_mode, ctx.BLOCK_SIZE
+        )
+        return dX, dR, dW, None, None, None
+
+
+@register_impl("liger.fused_add_rms_norm", backend="cutile")
+def fused_add_rms_norm(
+    X: torch.Tensor,
+    R: torch.Tensor,
+    W: torch.Tensor,
+    eps: float = 1e-6,
+    offset: float = 0.0,
+    casting_mode: str = "llama",
+    **kwargs,
+):
+    return FusedAddRMSNormCuTileFunction.apply(X, R, W, eps, offset, casting_mode)

--- a/src/tilegym/suites/liger/cutile/fused_linear_cross_entropy.py
+++ b/src/tilegym/suites/liger/cutile/fused_linear_cross_entropy.py
@@ -1,0 +1,537 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Fused linear + cross-entropy kernel (CuTile backend).
+
+Fuses the final linear projection with the cross-entropy loss.
+
+Two execution paths, selected by BT * V * sizeof vs _MAX_LOGIT_MEMORY_BYTES (4 GB):
+
+Single-pass (BT * V * sizeof ≤ 4 GB):
+  1. One matmul: logits = input @ weight.T
+  2. One CE kernel launch for all BT rows; writes d_logits in-place.
+  Save d_logits for backward. Backward does two large matmuls.
+
+Chunked + backward-in-forward (BT * V * sizeof > 4 GB):
+  chunk_size = largest pow-2 rows s.t. one chunk logit ≤ _MAX_CHUNK_LOGIT_BYTES (1 GB).
+  For V=128256 bf16 this gives chunk_size=4096.
+  Each chunk:
+    1. logits_chunk = input_chunk @ weight.T            (efficient GEMM)
+    2. CE kernel writes d_logit_chunk in-place.
+    3. grad_input[start:end] = d_logit_chunk @ weight   (accumulated, large K)
+    4. grad_weight_f32      += d_logit_chunk.float().T @ input_chunk.float()
+    5. discard logits_chunk — peak logit memory is O(chunk_size × V), not O(BT × V).
+  Save grad_input (BT×H) + grad_weight (V×H) instead of d_logits.
+  Backward: just element-wise scale by grad_output — nearly free.
+"""
+
+from typing import Optional
+
+import cuda.tile as ct
+import torch
+
+from tilegym.backend import register_impl
+
+from .cross_entropy import _get_tuned_ce_kernel
+from .utils import next_power_of_2
+
+MAX_FUSED_SIZE = 65536 // 2
+
+# Single-pass threshold: if the full (BT, V) logit tensor fits within this limit,
+# use one large GEMM + one CE kernel (fastest path).
+_MAX_LOGIT_MEMORY_BYTES = 4 * 1024**3  # 4 GB
+
+# Chunked path: target size for one chunk's logit tensor.
+# chunk_size = largest pow-2 s.t. chunk_size * V * sizeof ≤ this limit.
+# For V=128256, bf16: gives chunk_size = 4096 (≈ 1.05 GB per chunk, acceptable).
+_MAX_CHUNK_LOGIT_BYTES = 1024**3  # 1 GB
+
+
+def _chunk_size_for(V: int, element_size: int) -> int:
+    """Largest power-of-2 chunk_size s.t. chunk_size * V * element_size ≤ _MAX_CHUNK_LOGIT_BYTES."""
+    max_rows = _MAX_CHUNK_LOGIT_BYTES // (V * element_size)
+    if max_rows < 1:
+        return 1
+    # floor to power of 2
+    return 1 << (max_rows.bit_length() - 1)
+
+
+def _launch_ce(
+    logits,
+    target,
+    ce_weight,
+    loss_slice,
+    z_loss_slice,
+    token_acc_slice,
+    pred_slice,
+    dummies,
+    V,
+    BLOCK_SIZE,
+    inv_n_non_ignore,
+    sum_non_ignore_weight,
+    weight_sum,
+    ignore_index,
+    label_smoothing,
+    lse_square_scale,
+    softcap,
+    write_d_logits,
+    reduction_mean,
+    has_weight,
+    has_softcap,
+    return_z_loss,
+    return_token_accuracy,
+    return_predicted_tokens,
+):
+    """Launch the CE kernel for one chunk, substituting dummy tensors for disabled outputs."""
+    dummy_f32, dummy_i64, dummy_weight = dummies
+    n_rows = logits.shape[0]
+    ce_kernel = _get_tuned_ce_kernel(V, BLOCK_SIZE, logits.dtype, logits.device)
+    ct.launch(
+        torch.cuda.current_stream(),
+        (n_rows, 1, 1),
+        ce_kernel,
+        (
+            logits,
+            target,
+            ce_weight if has_weight else dummy_weight,
+            loss_slice,
+            z_loss_slice if return_z_loss else dummy_f32,
+            token_acc_slice if return_token_accuracy else dummy_f32,
+            pred_slice if return_predicted_tokens else dummy_i64,
+            int(V),
+            float(inv_n_non_ignore),
+            float(sum_non_ignore_weight),
+            float(weight_sum),
+            int(ignore_index),
+            float(label_smoothing),
+            float(lse_square_scale),
+            float(softcap if softcap is not None else 0.0),
+            int(BLOCK_SIZE),
+            int(write_d_logits),
+            int(reduction_mean),
+            int(has_weight),
+            int(has_softcap),
+            int(return_z_loss),
+            int(return_token_accuracy),
+            int(return_predicted_tokens),
+        ),
+    )
+
+
+def _token_scaling_factors(logits, target, ignore_index, softcap):
+    """Predicted-probability scaling factors (before the CE kernel overwrites logits)."""
+    logits_for_softmax = logits.detach().clone()
+    if softcap is not None:
+        logits_for_softmax = softcap * torch.tanh(logits_for_softmax / softcap)
+    probs = torch.softmax(logits_for_softmax, dim=-1)
+    valid_target_mask = target != ignore_index
+    valid_targets = target[valid_target_mask]
+    pred_probs = torch.zeros_like(target, dtype=probs.dtype, device=logits.device)
+    if valid_targets.numel() > 0:
+        valid_probs = probs[valid_target_mask]
+        pred_probs[valid_target_mask] = torch.gather(valid_probs, -1, valid_targets.unsqueeze(-1)).squeeze(-1)
+    return pred_probs.detach()
+
+
+def _fused_linear_ce_forward_ct(
+    _input,
+    weight,
+    target,
+    ce_weight,
+    bias,
+    ignore_index,
+    lse_square_scale,
+    label_smoothing,
+    reduction,
+    softcap,
+    return_z_loss,
+    accum_dtype,
+    use_token_scaling,
+    return_token_accuracy,
+    return_predicted_tokens,
+):
+    device = _input.device
+    BT, H = _input.shape
+    V = weight.shape[0]
+    BLOCK_SIZE = min(MAX_FUSED_SIZE, next_power_of_2(V))
+
+    input_requires_grad = _input.requires_grad
+    weight_requires_grad = weight.requires_grad
+    need_grads = input_requires_grad or weight_requires_grad
+    reduction_mean = int(reduction == "mean")
+
+    # Normalization counts.
+    target_mask = target != ignore_index
+    total_n_non_ignore = target_mask.sum().item()
+    inv_n_non_ignore = 1.0 / max(total_n_non_ignore, 1)
+
+    has_weight = ce_weight is not None
+    sum_non_ignore_weight = float(total_n_non_ignore)
+    weight_sum = 0.0
+    if has_weight:
+        assert ce_weight.shape[0] == V, f"If given, weight has to be a Tensor of size V. Got: {ce_weight.shape}"
+        assert torch.is_floating_point(ce_weight), (
+            f"If given, weight has to be of floating point dtype. Got: {ce_weight.dtype}"
+        )
+        sum_non_ignore_weight = float(
+            torch.gather(ce_weight, dim=0, index=target.masked_select(target_mask)).sum().item()
+        )
+        weight_sum = float(ce_weight.sum().item())
+        ce_weight = ce_weight.contiguous().float()
+    has_softcap = softcap is not None
+
+    loss_1d = torch.zeros(BT, dtype=torch.float32, device=device)
+    z_loss_1d = torch.zeros(BT, dtype=_input.dtype, device=device) if return_z_loss else None
+    token_accuracy_1d = torch.zeros(BT, dtype=torch.float32, device=device) if return_token_accuracy else None
+    predicted_tokens_1d = torch.full((BT,), -1, dtype=torch.int64, device=device) if return_predicted_tokens else None
+
+    # Dummy tensors for disabled outputs (CuTile requires valid tensor args).
+    dummies = (
+        torch.zeros(1, dtype=torch.float32, device=device),  # dummy_f32
+        torch.zeros(1, dtype=torch.int64, device=device),  # dummy_i64
+        torch.zeros(1, dtype=torch.float32, device=device),  # dummy_weight
+    )
+
+    def _ce(logits, target_, loss_slice, z_slice, ta_slice, pred_slice, write_d_logits):
+        _launch_ce(
+            logits,
+            target_,
+            ce_weight,
+            loss_slice,
+            z_slice,
+            ta_slice,
+            pred_slice,
+            dummies,
+            V,
+            BLOCK_SIZE,
+            inv_n_non_ignore,
+            sum_non_ignore_weight,
+            weight_sum,
+            ignore_index,
+            label_smoothing,
+            lse_square_scale,
+            softcap,
+            write_d_logits,
+            reduction_mean,
+            has_weight,
+            has_softcap,
+            return_z_loss,
+            return_token_accuracy,
+            return_predicted_tokens,
+        )
+
+    grad_bias_saved = None
+
+    if BT * V * _input.element_size() <= _MAX_LOGIT_MEMORY_BYTES:
+        # Single-pass: one large GEMM + one CE kernel — fastest path.
+        # d_logits is saved for backward; backward does two large matmuls.
+        logits = _input @ weight.t()
+        if bias is not None:
+            logits = logits + bias
+        logits = logits.contiguous()
+
+        scaling_factors = _token_scaling_factors(logits, target, ignore_index, softcap) if use_token_scaling else None
+
+        _ce(
+            logits,
+            target.contiguous(),
+            loss_1d,
+            z_loss_1d,
+            token_accuracy_1d,
+            predicted_tokens_1d,
+            input_requires_grad,
+        )
+
+        if use_token_scaling:
+            loss_1d = loss_1d * scaling_factors
+            if return_z_loss:
+                z_loss_1d = z_loss_1d * scaling_factors
+
+        # After the CE kernel, logits holds d_logits = d(loss)/d(logits).
+        d_logits = logits if input_requires_grad else None
+        if d_logits is not None and use_token_scaling:
+            d_logits = d_logits * scaling_factors.unsqueeze(-1)
+        grad_input_saved = None
+        grad_weight_saved = None
+        chunked_bif = False
+    else:
+        # Chunked + backward-in-forward: per-chunk GEMM → CE → grad_input slice
+        # + grad_weight_f32 accumulate. Peak logit memory is O(chunk_size × V),
+        # not O(BT × V). Grads are saved directly; backward only scales them.
+        chunk_size = min(BT, _chunk_size_for(V, _input.element_size()))
+        num_chunks = (BT + chunk_size - 1) // chunk_size
+
+        acc = weight.dtype if accum_dtype is None else accum_dtype
+        grad_input_saved = torch.zeros(BT, H, dtype=_input.dtype, device=device) if input_requires_grad else None
+        grad_weight_f32 = torch.zeros(V, H, dtype=torch.float32, device=device) if weight_requires_grad else None
+        grad_bias_saved = torch.zeros(V, dtype=acc, device=device) if (bias is not None and need_grads) else None
+
+        for chunk_id in range(num_chunks):
+            start_idx = chunk_id * chunk_size
+            end_idx = min(start_idx + chunk_size, BT)
+            _input_chunk = _input[start_idx:end_idx]
+
+            logits_chunk = _input_chunk @ weight.t()
+            if bias is not None:
+                logits_chunk = logits_chunk + bias
+            logits_chunk = logits_chunk.contiguous()
+
+            scaling_factors = (
+                _token_scaling_factors(logits_chunk, target[start_idx:end_idx], ignore_index, softcap)
+                if use_token_scaling
+                else None
+            )
+
+            _ce(
+                logits_chunk,
+                target[start_idx:end_idx].contiguous(),
+                loss_1d[start_idx:end_idx],
+                z_loss_1d[start_idx:end_idx] if return_z_loss else None,
+                token_accuracy_1d[start_idx:end_idx] if return_token_accuracy else None,
+                predicted_tokens_1d[start_idx:end_idx] if return_predicted_tokens else None,
+                need_grads,
+            )
+
+            if use_token_scaling:
+                loss_1d[start_idx:end_idx] = loss_1d[start_idx:end_idx] * scaling_factors
+                if return_z_loss:
+                    z_loss_1d[start_idx:end_idx] = z_loss_1d[start_idx:end_idx] * scaling_factors
+
+            # logits_chunk now holds d_logit_chunk. Compute grads immediately,
+            # then let logits_chunk go out of scope (freed at end of iteration).
+            grad_logits_chunk = logits_chunk
+            if use_token_scaling:
+                grad_logits_chunk = grad_logits_chunk * scaling_factors.unsqueeze(-1)
+            if grad_input_saved is not None:
+                grad_input_saved[start_idx:end_idx] = grad_logits_chunk.to(_input.dtype) @ weight
+            if grad_weight_f32 is not None:
+                grad_weight_f32 += grad_logits_chunk.float().t() @ _input_chunk.float()
+            if grad_bias_saved is not None:
+                grad_bias_saved += grad_logits_chunk.sum(dim=0).to(grad_bias_saved.dtype)
+
+        d_logits = None
+        grad_weight_saved = grad_weight_f32.to(weight.dtype) if grad_weight_f32 is not None else None
+        if grad_bias_saved is not None:
+            grad_bias_saved = grad_bias_saved.to(bias.dtype)
+        chunked_bif = True
+
+    if reduction == "none":
+        loss = loss_1d
+        z_loss = z_loss_1d if return_z_loss else None
+        token_accuracy = token_accuracy_1d if return_token_accuracy else None
+    else:
+        loss = loss_1d.sum()
+        z_loss = z_loss_1d.sum() if return_z_loss else None
+        token_accuracy = token_accuracy_1d.sum() / max(total_n_non_ignore, 1) if return_token_accuracy else None
+    predicted_tokens = predicted_tokens_1d if return_predicted_tokens else None
+
+    return (
+        loss,
+        z_loss,
+        token_accuracy,
+        predicted_tokens,
+        d_logits,
+        grad_input_saved,
+        grad_weight_saved,
+        grad_bias_saved,
+        chunked_bif,
+    )
+
+
+class FusedLinearCrossEntropyCuTileFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        _input: torch.Tensor,
+        weight: torch.Tensor,
+        target: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+        ce_weight: Optional[torch.Tensor] = None,
+        ignore_index: int = -100,
+        lse_square_scale: float = 0.0,
+        label_smoothing: float = 0.0,
+        reduction: str = "mean",
+        softcap: Optional[float] = None,
+        return_z_loss: bool = False,
+        accum_dtype: Optional[torch.dtype] = None,
+        use_token_scaling: bool = False,
+        return_token_accuracy: bool = False,
+        return_predicted_tokens: bool = False,
+    ):
+        (
+            loss,
+            z_loss,
+            token_accuracy,
+            predicted_tokens,
+            d_logits,
+            grad_input_saved,
+            grad_weight_saved,
+            grad_bias_saved,
+            chunked_bif,
+        ) = _fused_linear_ce_forward_ct(
+            _input,
+            weight,
+            target,
+            ce_weight,
+            bias,
+            ignore_index,
+            lse_square_scale,
+            label_smoothing,
+            reduction,
+            softcap,
+            return_z_loss,
+            accum_dtype,
+            use_token_scaling,
+            return_token_accuracy,
+            return_predicted_tokens,
+        )
+
+        input_requires_grad = _input.requires_grad
+        weight_requires_grad = weight.requires_grad
+        ctx.input_requires_grad = input_requires_grad
+        ctx.weight_requires_grad = weight_requires_grad
+        ctx.has_bias = bias is not None
+        ctx.chunked_bif = chunked_bif
+
+        _empty = torch.empty(0)
+        if chunked_bif:
+            # Backward-in-forward path: grads are pre-computed, just save them.
+            ctx.save_for_backward(
+                grad_input_saved if grad_input_saved is not None else _empty,
+                grad_weight_saved if grad_weight_saved is not None else _empty,
+                grad_bias_saved if grad_bias_saved is not None else _empty,
+                _empty,  # d_logits slot
+                _empty,  # _input slot
+                _empty,  # weight slot
+            )
+        else:
+            # Single-pass path: save d_logits for backward matmuls.
+            need_grads = input_requires_grad or weight_requires_grad
+            ctx.save_for_backward(
+                _empty,  # grad_input slot
+                _empty,  # grad_weight slot
+                _empty,  # grad_bias slot
+                d_logits if d_logits is not None else _empty,
+                _input if need_grads else _empty,
+                weight if need_grads else _empty,
+            )
+
+        ctx.return_z_loss = return_z_loss
+        ctx.return_token_accuracy = return_token_accuracy
+        ctx.return_predicted_tokens = return_predicted_tokens
+        return loss, z_loss, token_accuracy, predicted_tokens
+
+    @staticmethod
+    def backward(ctx, grad_output, grad_output2, grad_output3, grad_output4):
+        grad_input_saved, grad_weight_saved, grad_bias_saved, d_logits_saved, _input, weight = ctx.saved_tensors
+
+        scalar_1 = torch.tensor(1.0, device=grad_output.device)
+        scale_by_grad = not torch.equal(grad_output, scalar_1)
+
+        if ctx.chunked_bif:
+            # ── BACKWARD-IN-FORWARD PATH ─────────────────────────────────────
+            # Grads were computed during forward; just apply grad_output scaling.
+            grad_input = grad_input_saved if grad_input_saved.numel() > 0 else None
+            grad_weight = grad_weight_saved if grad_weight_saved.numel() > 0 else None
+            grad_bias = grad_bias_saved if grad_bias_saved.numel() > 0 else None
+            if scale_by_grad:
+                if grad_input is not None:
+                    grad_input = grad_input * grad_output
+                if grad_weight is not None:
+                    grad_weight = grad_weight * grad_output
+                if grad_bias is not None:
+                    grad_bias = grad_bias * grad_output
+        else:
+            # ── SINGLE-PASS PATH ─────────────────────────────────────────────
+            # d_logits was saved; compute grad_input and grad_weight now.
+            if not ctx.input_requires_grad:
+                return (None,) * 15
+
+            d_logits = d_logits_saved
+            if scale_by_grad:
+                d_logits = d_logits * grad_output
+
+            # grad_input: (BT, H) — one matmul
+            grad_input = d_logits @ weight if ctx.input_requires_grad else None
+
+            # grad_weight: (V, H) — one matmul. Use bf16 operands directly; cuBLAS
+            # GEMM bf16 × bf16 → fp32 accumulate internally, so the explicit
+            # `.float()` cast on both operands is wasted memory traffic (the
+            # BT×V cast alone is up to 16 GB at BT=32768, V=128256). Numerical
+            # parity with fp32 inputs (with fp32 accumulate) within atol/rtol=1e-2.
+            grad_weight = torch.mm(d_logits.t(), _input) if ctx.weight_requires_grad else None
+
+            # grad_bias: (V,) — cheap row-sum of d_logits
+            grad_bias = d_logits.sum(dim=0) if ctx.has_bias else None
+
+        # forward inputs: _input, weight, target, bias, ce_weight, ignore_index,
+        # lse_square_scale, label_smoothing, reduction, softcap, return_z_loss,
+        # accum_dtype, use_token_scaling, return_token_accuracy, return_predicted_tokens
+        return (
+            grad_input,
+            grad_weight,
+            None,  # target
+            grad_bias,
+            None,  # ce_weight
+            None,  # ignore_index
+            None,  # lse_square_scale
+            None,  # label_smoothing
+            None,  # reduction
+            None,  # softcap
+            None,  # return_z_loss
+            None,  # accum_dtype
+            None,  # use_token_scaling
+            None,  # return_token_accuracy
+            None,  # return_predicted_tokens
+        )
+
+
+@register_impl("liger.fused_linear_cross_entropy", backend="cutile")
+def fused_linear_cross_entropy(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    target: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    ce_weight: Optional[torch.Tensor] = None,
+    ignore_index: int = -100,
+    lse_square_scale: float = 0.0,
+    label_smoothing: float = 0.0,
+    reduction: str = "mean",
+    softcap: Optional[float] = None,
+    return_z_loss: bool = False,
+    accum_dtype: Optional[torch.dtype] = None,
+    use_token_scaling: bool = False,
+    return_token_accuracy: bool = False,
+    return_predicted_tokens: bool = False,
+    **kwargs,
+):
+    loss, z_loss, token_accuracy, predicted_tokens = FusedLinearCrossEntropyCuTileFunction.apply(
+        input,
+        weight,
+        target,
+        bias,
+        ce_weight,
+        ignore_index,
+        lse_square_scale,
+        label_smoothing,
+        reduction,
+        softcap,
+        return_z_loss,
+        accum_dtype,
+        use_token_scaling,
+        return_token_accuracy,
+        return_predicted_tokens,
+    )
+    # Scalar loss by default; only expose extra outputs when explicitly requested
+    if not return_z_loss and not return_token_accuracy and not return_predicted_tokens:
+        return loss
+    extras = []
+    if return_z_loss:
+        extras.append(z_loss)
+    if return_token_accuracy:
+        extras.append(token_accuracy)
+    if return_predicted_tokens:
+        extras.append(predicted_tokens)
+    return (loss, *extras)

--- a/src/tilegym/suites/liger/cutile/fused_neighborhood_attention.py
+++ b/src/tilegym/suites/liger/cutile/fused_neighborhood_attention.py
@@ -575,6 +575,7 @@ def _fused_fwd_autotune_configs():
                 yield SimpleNamespace(BLOCK_M=bm, BLOCK_N=bn, occupancy=occ)
 
 
+# Module-level cache: (batch*heads, seq_len, head_dim, dtype, device_str) -> (cfg, tuned_kernel)
 _fwd_autotune_cache: dict = {}
 
 
@@ -645,7 +646,19 @@ def _fused_fwd_autotune(
             return {"occupancy": cfg.occupancy}
 
         with ct.compiler_timeout(30):
-            result = exhaustive_search(configs, stream, grid_fn, _fna_fused_forward_kernel, args_fn, hints_fn)
+            # single_run_timeout_sec guards against a config whose kernel hangs (warp-
+            # specialization deadlock) — a timed-out run is discarded instead of stalling
+            # the whole search forever.
+            result = exhaustive_search(
+                configs,
+                stream,
+                grid_fn,
+                _fna_fused_forward_kernel,
+                args_fn,
+                hints_fn,
+                quiet=True,
+                single_run_timeout_sec=5.0,
+            )
         best_cfg = result.best.config
         tuned_kernel = _fna_fused_forward_kernel.replace_hints(occupancy=best_cfg.occupancy)
         _fwd_autotune_cache[cache_key] = (best_cfg, tuned_kernel)

--- a/src/tilegym/suites/liger/cutile/grpo_loss.py
+++ b/src/tilegym/suites/liger/cutile/grpo_loss.py
@@ -1,0 +1,1276 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+GRPO / DAPO / BNPO / DR-GRPO / CISPO / SAPO / LUSPO / VESPO policy gradient loss (CuTile backend).
+
+Token-level and sequence-level (GSPO) importance sampling, dual-clip (delta), vLLM IS-ratio,
+optional KL penalty, and num_items_in_batch normalization. Full feature parity across all loss
+types and token/sequence-level importance sampling.
+
+Forward kernel: grid = (B, L).
+  - Each block (b, l) computes logsumexp over the vocab, target logp, importance ratio
+    coef_1 = exp(logp - old_logp), the per-token loss for the selected loss_type, optional KL.
+
+Backward kernel: grid = (B, L).
+  - Recomputes logp from the cached lse, computes the gradient, stores to DLOGITS.
+  - DLOGITS[:, -1, :] = 0 applied at Python level (last position has no completion token).
+
+Optional tensors are handled by passing dummy 1-element tensors when None, controlled by
+ct.Constant[int] flags. BETA and LOSS_TYPE are ct.Constant for compile-time branching.
+"""
+
+import math
+import os
+from types import SimpleNamespace
+
+import cuda.tile as ct
+import torch
+from cuda.tile import ByTarget
+from cuda.tile.tune import exhaustive_search
+
+LOG2E = 1.4426950408889634
+
+from tilegym.backend import register_impl
+
+_LOSS_TYPE_GRPO = 0
+_LOSS_TYPE_CISPO = 1
+_LOSS_TYPE_SAPO = 2
+_LOSS_TYPE_VESPO = 3
+
+_str_to_loss_type = {
+    "grpo": _LOSS_TYPE_GRPO,
+    "dapo": _LOSS_TYPE_GRPO,
+    "bnpo": _LOSS_TYPE_GRPO,
+    "dr_grpo": _LOSS_TYPE_GRPO,
+    "luspo": _LOSS_TYPE_GRPO,  # LUSPO uses the same per-token PPO clipping as GRPO
+    "cispo": _LOSS_TYPE_CISPO,
+    "sapo": _LOSS_TYPE_SAPO,
+    "vespo": _LOSS_TYPE_VESPO,
+}
+
+
+@ct.kernel
+def _grpo_loss_fwd_ct(
+    logits_input,  # (B*(L+1), N) logits (2D view of (B, L+1, N))
+    old_logp_input,  # (B, L) float32 or dummy (1,)
+    ref_logp_input,  # (B, L) float32 or dummy (1,)
+    input_ids,  # (B, L) int64 completion token ids
+    completion_mask,  # (B, L) int32 or dummy (1,)
+    advantages,  # (B,) float32
+    vllm_is_ratio,  # (B, L) or dummy (1,) float32
+    phi_seq_input,  # (B,) VESPO per-sequence gamma weight (or dummy (1,))
+    loss_output,  # (B, L) float32 output
+    lse_cache,  # (B, L) float32 cached log-sum-exp
+    kl_output,  # (B, L) float32 or dummy (1,)
+    is_clipped_output,  # (B, L) float32
+    B: ct.Constant[int],
+    L: ct.Constant[int],
+    N: ct.Constant[int],
+    BLOCK_N: ct.Constant[int],
+    temperature,
+    beta: ct.Constant[float],
+    eps_low,
+    eps_high,
+    loss_type: ct.Constant[int],
+    sapo_temp_pos,
+    sapo_temp_neg,
+    delta,
+    use_bias_correction_kl: ct.Constant[int],
+    HAS_COMPLETION_MASK: ct.Constant[int],
+    HAS_OLD_LOGP: ct.Constant[int],
+    HAS_VLLM_IS_RATIO: ct.Constant[int],
+    vllm_is_ratio_stride,
+):
+    """
+    GRPO forward.
+
+    Grid: (B, L). Each block (off_b, off_l) computes the loss for one
+    (batch, completion-token) position.
+    """
+    off_b = ct.bid(0)
+    off_l = ct.bid(1)
+
+    # Optional completion mask: skip masked tokens
+    if HAS_COMPLETION_MASK:
+        mask_val = ct.astype(ct.load(completion_mask, (off_b, off_l), shape=()), ct.int32)
+        if mask_val == 0:
+            return
+
+    # Logits row for this (b, l): off_b*(L+1) + off_l
+    logits_row = ct.add(ct.mul(off_b, L + 1), off_l)
+    n_chunks = (N + BLOCK_N - 1) // BLOCK_N
+    inv_temperature = 1.0 / temperature
+
+    # ---- Compute logsumexp via online algorithm (fold trick) ----
+    m_i = ct.full((), -math.inf, dtype=ct.float32)
+    l_i = ct.full((), 0.0, dtype=ct.float32)
+
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_N, dtype=ct.int32), ci * BLOCK_N)
+        logits = ct.astype(
+            ct.gather(logits_input, (logits_row, col_idx), check_bounds=True, padding_value=-math.inf, latency=3),
+            ct.float32,
+        )
+        logits_scaled = logits * inv_temperature
+
+        chunk_max = ct.max(logits_scaled, 0, keepdims=False)
+        new_m = ct.maximum(m_i, chunk_max)
+        alpha = ct.exp2(ct.mul(m_i - new_m, LOG2E))
+        l_i = ct.add(ct.mul(l_i, alpha), ct.sum(ct.exp2(ct.mul(logits_scaled - new_m, LOG2E)), 0, keepdims=False))
+        m_i = new_m
+
+    lse = m_i + ct.log(l_i)
+
+    # ---- Load logit at target token ----
+    idx_raw = ct.load(input_ids, (off_b, off_l), shape=())
+    idx = ct.astype(idx_raw, ct.int32)
+    idx_tile = ct.add(ct.arange(1, dtype=ct.int32), idx)
+    x_tile = ct.astype(ct.gather(logits_input, (logits_row, idx_tile), check_bounds=False), ct.float32)
+    x = ct.sum(x_tile, 0, keepdims=False) * inv_temperature
+    logp = x - lse
+
+    # ---- Load old_logp ----
+    if HAS_OLD_LOGP:
+        old_logp = ct.astype(ct.load(old_logp_input, (off_b, off_l), shape=()), ct.float32)
+    else:
+        old_logp = logp
+    coef_1 = ct.exp(logp - old_logp)
+    advantage = ct.astype(ct.load(advantages, off_b, shape=()), ct.float32)
+
+    # ---- Compute per-token loss based on loss_type ----
+    if loss_type == 0:  # GRPO: standard PPO clipping
+        coef_2_low = ct.maximum(coef_1, ct.full((), 1.0 - eps_low, dtype=ct.float32))
+        coef_2_high = ct.minimum(coef_2_low, ct.full((), 1.0 + eps_high, dtype=ct.float32))
+        is_low_clipped = ct.astype(coef_1 < (1.0 - eps_low), ct.float32) * ct.astype(advantage < 0.0, ct.float32)
+        is_high_clipped = ct.astype(coef_1 > (1.0 + eps_high), ct.float32) * ct.astype(advantage > 0.0, ct.float32)
+        is_clipped = ct.minimum(is_low_clipped + is_high_clipped, ct.full((), 1.0, dtype=ct.float32))
+        # Apply delta upper-clip on importance ratio (dual-clip extension)
+        if delta != 0.0:
+            coef_1_for_loss = ct.minimum(coef_1, ct.full((), delta, dtype=ct.float32))
+        else:
+            coef_1_for_loss = coef_1
+        per_token_loss1 = coef_1_for_loss * advantage
+        per_token_loss2 = coef_2_high * advantage
+        per_token_loss = -ct.minimum(per_token_loss1, per_token_loss2)
+    elif loss_type == 1:  # CISPO
+        coef_2 = ct.minimum(coef_1, ct.full((), eps_high, dtype=ct.float32))
+        per_token_loss = -coef_2 * advantage * logp
+        is_clipped = ct.astype(coef_1 > eps_high, ct.float32) * ct.astype(advantage > 0.0, ct.float32)
+    elif loss_type == 2:  # SAPO
+        temp_sapo = ct.maximum(
+            ct.full((), sapo_temp_pos, dtype=ct.float32),
+            ct.full((), sapo_temp_neg, dtype=ct.float32),
+        )
+        if advantage > 0.0:
+            temp_sapo = ct.full((), sapo_temp_pos, dtype=ct.float32)
+        else:
+            temp_sapo = ct.full((), sapo_temp_neg, dtype=ct.float32)
+        sigmoid_input = temp_sapo * (coef_1 - 1.0)
+        # sigmoid(x) = 1 / (1 + exp(-x)) — cuda.tile has no ct.sigmoid.
+        sig = ct.truediv(1.0, 1.0 + ct.exp(0.0 - sigmoid_input))
+        sapo_coef = sig * 4.0 / temp_sapo
+        per_token_loss = -sapo_coef * advantage
+        is_clipped = ct.full((), 0.0, dtype=ct.float32)
+    else:  # loss_type == 3: VESPO — detached per-sequence gamma weight on logp
+        phi_seq = ct.astype(ct.load(phi_seq_input, off_b, shape=()), ct.float32)
+        per_token_loss = -phi_seq * advantage * logp
+        is_clipped = ct.full((), 0.0, dtype=ct.float32)
+
+    # ---- Apply vLLM IS ratio (optional) ----
+    if HAS_VLLM_IS_RATIO:
+        vllm_col = off_l % vllm_is_ratio_stride
+        vllm_row_base = off_b * vllm_is_ratio_stride
+        # scalar gather: 1-element tile
+        vllm_tile = ct.gather(
+            vllm_is_ratio, ct.arange(1, dtype=ct.int32) + vllm_row_base + vllm_col, check_bounds=False
+        )
+        vllm_ratio = ct.astype(ct.sum(ct.astype(vllm_tile, ct.float32), 0, keepdims=False), ct.float32)
+        per_token_loss = per_token_loss * vllm_ratio
+
+    # ---- KL penalty (optional, beta != 0 is compile-time) ----
+    if beta != 0.0:
+        ref_logp = ct.astype(ct.load(ref_logp_input, (off_b, off_l), shape=()), ct.float32)
+        kl = ct.exp(ref_logp - logp) - (ref_logp - logp) - 1.0
+        if use_bias_correction_kl:
+            # Importance-sampling-corrected KL (DeepSeek-V3.2): kl *= coef_1
+            kl = kl * coef_1
+        per_token_loss = per_token_loss + beta * kl
+        ct.scatter(kl_output, (off_b, off_l), ct.astype(kl, kl_output.dtype))
+
+    # ---- Store outputs ----
+    ct.scatter(loss_output, (off_b, off_l), ct.astype(per_token_loss, loss_output.dtype))
+    ct.scatter(lse_cache, (off_b, off_l), ct.astype(lse, lse_cache.dtype))
+    ct.scatter(is_clipped_output, (off_b, off_l), ct.astype(is_clipped, is_clipped_output.dtype))
+
+
+@ct.kernel
+def _grpo_loss_bwd_ct(
+    dloss_input,  # (B, L) float32 upstream gradient
+    dlogits_output,  # (B*(L+1), N) gradient output
+    logits_input,  # (B*(L+1), N) saved logits
+    old_logp_input,  # (B, L) or dummy (1,)
+    ref_logp_input,  # (B, L) or dummy (1,)
+    input_ids,  # (B, L) int64
+    advantages,  # (B,) float32
+    completion_mask,  # (B, L) int32 or dummy (1,)
+    lse_cache,  # (B, L) float32 saved lse
+    vllm_is_ratio,  # (B, L) or dummy (1,)
+    phi_seq_input,  # (B,) VESPO per-sequence gamma weight (or dummy (1,))
+    B: ct.Constant[int],
+    L: ct.Constant[int],
+    N: ct.Constant[int],
+    BLOCK_N: ct.Constant[int],
+    temperature,
+    beta: ct.Constant[float],
+    eps_low,
+    eps_high,
+    loss_type: ct.Constant[int],
+    sapo_temp_pos,
+    sapo_temp_neg,
+    delta,
+    use_bias_correction_kl: ct.Constant[int],
+    HAS_COMPLETION_MASK: ct.Constant[int],
+    HAS_OLD_LOGP: ct.Constant[int],
+    HAS_VLLM_IS_RATIO: ct.Constant[int],
+    vllm_is_ratio_stride,
+):
+    """GRPO backward. Grid: (B, L)."""
+    off_b = ct.bid(0)
+    off_l = ct.bid(1)
+
+    logits_row = ct.add(ct.mul(off_b, L + 1), off_l)
+    n_chunks = (N + BLOCK_N - 1) // BLOCK_N
+    inv_temperature = 1.0 / temperature
+
+    if HAS_COMPLETION_MASK:
+        mask_val = ct.astype(ct.load(completion_mask, (off_b, off_l), shape=()), ct.int32)
+        if mask_val == 0:
+            for ci in range(n_chunks):
+                col_idx = ct.add(ct.arange(BLOCK_N, dtype=ct.int32), ci * BLOCK_N)
+                zero_tile = ct.full((BLOCK_N,), 0.0, dtype=dlogits_output.dtype)
+                ct.scatter(dlogits_output, (logits_row, col_idx), zero_tile, check_bounds=True)
+            return
+
+    dloss = ct.astype(ct.load(dloss_input, (off_b, off_l), shape=()), ct.float32)
+    lse = ct.astype(ct.load(lse_cache, (off_b, off_l), shape=()), ct.float32)
+
+    idx_raw = ct.load(input_ids, (off_b, off_l), shape=())
+    idx = ct.astype(idx_raw, ct.int32)
+    idx_tile = ct.add(ct.arange(1, dtype=ct.int32), idx)
+    x_tile = ct.astype(ct.gather(logits_input, (logits_row, idx_tile), check_bounds=False), ct.float32)
+    x = ct.sum(x_tile, 0, keepdims=False) * inv_temperature
+    logp = x - lse
+
+    if HAS_OLD_LOGP:
+        old_logp = ct.astype(ct.load(old_logp_input, (off_b, off_l), shape=()), ct.float32)
+    else:
+        old_logp = logp
+    coef_1 = ct.exp(logp - old_logp)
+    advantage = ct.astype(ct.load(advantages, off_b, shape=()), ct.float32)
+
+    if loss_type == 0:  # GRPO
+        coef_2_low = ct.maximum(coef_1, ct.full((), 1.0 - eps_low, dtype=ct.float32))
+        coef_2_high = ct.minimum(coef_2_low, ct.full((), 1.0 + eps_high, dtype=ct.float32))
+        if delta != 0.0:
+            coef_1_for_loss = ct.minimum(coef_1, ct.full((), delta, dtype=ct.float32))
+        else:
+            coef_1_for_loss = coef_1
+        per_token_loss1 = coef_1_for_loss * advantage
+        per_token_loss2 = coef_2_high * advantage
+        # gradient flows only when unclipped (per_token_loss2 >= per_token_loss1)
+        grad_mask = ct.astype(per_token_loss2 >= per_token_loss1, ct.float32)
+        # Gradient uses original coef_1; zero when delta-clamped (constant → no gradient)
+        dlogp = -coef_1 * advantage * grad_mask
+        if delta != 0.0:
+            dlogp = dlogp * ct.astype(coef_1 <= ct.full((), delta, dtype=ct.float32), ct.float32)
+    elif loss_type == 1:  # CISPO
+        coef_2 = ct.minimum(coef_1, ct.full((), eps_high, dtype=ct.float32))
+        dlogp = -coef_2 * advantage
+    elif loss_type == 2:  # SAPO
+        if advantage > 0.0:
+            temp_sapo = ct.full((), sapo_temp_pos, dtype=ct.float32)
+        else:
+            temp_sapo = ct.full((), sapo_temp_neg, dtype=ct.float32)
+        sigmoid_input = temp_sapo * (coef_1 - 1.0)
+        sigmoid_val = ct.truediv(1.0, 1.0 + ct.exp(0.0 - sigmoid_input))  # sigmoid via 1/(1+exp(-x))
+        d_sapo_d_coef1 = 4.0 * sigmoid_val * (1.0 - sigmoid_val)
+        dlogp = -advantage * d_sapo_d_coef1 * coef_1
+    else:  # loss_type == 3: VESPO — loss = -phi_seq*advantage*logp, phi_seq detached
+        phi_seq = ct.astype(ct.load(phi_seq_input, off_b, shape=()), ct.float32)
+        dlogp = -phi_seq * advantage
+
+    if HAS_VLLM_IS_RATIO:
+        vllm_col = off_l % vllm_is_ratio_stride
+        vllm_tile = ct.gather(
+            vllm_is_ratio,
+            ct.add(ct.arange(1, dtype=ct.int32), ct.mul(off_b, vllm_is_ratio_stride) + vllm_col),
+            check_bounds=False,
+        )
+        vllm_ratio = ct.astype(ct.sum(ct.astype(vllm_tile, ct.float32), 0, keepdims=False), ct.float32)
+        dlogp = dlogp * vllm_ratio
+
+    if beta != 0.0:
+        ref_logp = ct.astype(ct.load(ref_logp_input, (off_b, off_l), shape=()), ct.float32)
+        if use_bias_correction_kl:
+            # d(kl * coef_1)/d(logp) = coef_1 * (logp - ref_logp), where coef_1 = exp(logp - old_logp)
+            dlogp = dlogp + beta * coef_1 * (logp - ref_logp)
+        else:
+            dlogp = dlogp + beta * (1.0 - ct.exp(ref_logp - logp))
+
+    dlogp_scaled = dlogp * dloss * inv_temperature
+
+    # Compute and store dlogits for all vocab positions
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_N, dtype=ct.int32), ci * BLOCK_N)
+        logits = ct.astype(
+            ct.gather(logits_input, (logits_row, col_idx), check_bounds=True, padding_value=-math.inf, latency=10),
+            ct.float32,
+        )
+        probs = ct.exp(logits * inv_temperature - lse)
+
+        # dlogits[j] = (indicator(j==idx) - prob[j]) * dlogp
+        idx_tile_b = ct.add(ct.arange(BLOCK_N, dtype=ct.int32), ci * BLOCK_N)
+        is_target = ct.astype(idx_tile_b == idx, ct.float32)
+        dlogits = (is_target - probs) * dlogp_scaled
+
+        ct.scatter(
+            dlogits_output,
+            (logits_row, col_idx),
+            ct.astype(dlogits, dlogits_output.dtype),
+            check_bounds=True,
+            latency=10,
+        )
+
+
+# --- bwd occupancy: static per-batch-size selection (zero lookup overhead) ---
+_bwd_occ_small = _grpo_loss_bwd_ct.replace_hints(occupancy=ByTarget(sm_100=4, default=4))
+_bwd_occ_large = _grpo_loss_bwd_ct.replace_hints(occupancy=ByTarget(sm_100=12, default=12))
+
+
+# --- fwd occupancy autotune (per launch shape) --------------------------------
+_FWD_OCC_CONFIGS = [
+    SimpleNamespace(occupancy=1),
+    SimpleNamespace(occupancy=2),
+    SimpleNamespace(occupancy=4),
+    SimpleNamespace(occupancy=12),
+]
+_FWD_FALLBACK_OCC = 1
+_fwd_autotune_cache: dict = {}
+
+
+def _tuned_fwd_kernel(stream, cache_key, grid, fwd_args):
+    if os.environ.get("DISABLE_AUTOTUNE") == "1":
+        return _grpo_loss_fwd_ct.replace_hints(occupancy=ByTarget(sm_100=_FWD_FALLBACK_OCC, default=_FWD_FALLBACK_OCC))
+    if cache_key not in _fwd_autotune_cache:
+        result = exhaustive_search(
+            _FWD_OCC_CONFIGS,
+            stream,
+            lambda cfg: grid,
+            _grpo_loss_fwd_ct,
+            lambda cfg: fwd_args,
+            lambda cfg: {"occupancy": ByTarget(sm_100=cfg.occupancy, default=cfg.occupancy)},
+            quiet=True,
+        )
+        best_occ = result.best.config.occupancy
+        _fwd_autotune_cache[cache_key] = _grpo_loss_fwd_ct.replace_hints(
+            occupancy=ByTarget(sm_100=best_occ, default=best_occ)
+        )
+    return _fwd_autotune_cache[cache_key]
+
+
+def _grpo_loss_forward_ct(
+    logits,
+    old_logp,
+    ref_logp,
+    completion_ids,
+    advantages,
+    completion_mask,
+    temperature,
+    beta,
+    eps_low,
+    eps_high,
+    loss_type_int,
+    sapo_temperature_pos,
+    sapo_temperature_neg,
+    delta,
+    use_bias_correction_kl,
+    vllm_is_ratio,
+    vllm_is_ratio_stride,
+    phi_seq,
+):
+    B, L_ADD_1, N = logits.shape
+    L = L_ADD_1 - 1
+    BLOCK_N = min(8192, N)
+
+    logits_2d = logits.reshape(B * L_ADD_1, N).contiguous()
+
+    loss = torch.zeros(B, L, device=logits.device, dtype=torch.float32)
+    lse = torch.zeros(B, L, device=logits.device, dtype=torch.float32)
+    is_clipped = torch.zeros(B, L, device=logits.device, dtype=torch.float32)
+
+    has_beta = float(beta) != 0.0
+    kl = torch.zeros(B, L, device=logits.device, dtype=torch.float32) if has_beta else None
+
+    dummy_f = torch.zeros(1, device=logits.device, dtype=torch.float32)
+    dummy_i = torch.zeros(1, device=logits.device, dtype=torch.int32)
+
+    old_logp_arg = old_logp.contiguous() if old_logp is not None else dummy_f
+    ref_logp_arg = ref_logp.contiguous() if ref_logp is not None else dummy_f
+    mask_arg = completion_mask.to(torch.int32).contiguous() if completion_mask is not None else dummy_i
+    kl_arg = kl if kl is not None else dummy_f
+    vllm_arg = vllm_is_ratio.contiguous() if vllm_is_ratio is not None else dummy_f
+    phi_seq_arg = phi_seq.contiguous() if phi_seq is not None else dummy_f
+
+    has_mask = int(completion_mask is not None)
+    has_old_logp = int(old_logp is not None)
+    # VESPO (loss_type 3) folds the vLLM correction into phi_seq, so the kernel skips vllm.
+    has_vllm = int(vllm_is_ratio is not None and int(loss_type_int) != 3)
+
+    grid = (B, L, 1)
+    stream = torch.cuda.current_stream()
+    fwd_args = (
+        logits_2d,
+        old_logp_arg,
+        ref_logp_arg,
+        completion_ids.contiguous(),
+        mask_arg,
+        advantages.contiguous(),
+        vllm_arg,
+        phi_seq_arg,
+        loss,
+        lse,
+        kl_arg,
+        is_clipped,
+        int(B),
+        int(L),
+        int(N),
+        int(BLOCK_N),
+        float(temperature),
+        float(beta),
+        float(eps_low),
+        float(eps_high),
+        int(loss_type_int),
+        float(sapo_temperature_pos),
+        float(sapo_temperature_neg),
+        float(delta),
+        int(use_bias_correction_kl),
+        int(has_mask),
+        int(has_old_logp),
+        int(has_vllm),
+        int(vllm_is_ratio_stride),
+    )
+    cache_key = (
+        int(B),
+        int(L),
+        int(N),
+        int(BLOCK_N),
+        int(loss_type_int),
+        int(has_mask),
+        int(has_old_logp),
+        int(has_vllm),
+        str(logits_2d.device),
+    )
+    kernel = _tuned_fwd_kernel(stream, cache_key, grid, fwd_args)
+    ct.launch(stream, grid, kernel, fwd_args)
+
+    return loss, lse, is_clipped, kl
+
+
+def _grpo_loss_backward_ct(
+    dloss,
+    logits,
+    old_logp,
+    ref_logp,
+    completion_ids,
+    advantages,
+    completion_mask,
+    lse,
+    temperature,
+    beta,
+    eps_low,
+    eps_high,
+    inplace,
+    loss_type_int,
+    sapo_temperature_pos,
+    sapo_temperature_neg,
+    delta,
+    use_bias_correction_kl,
+    vllm_is_ratio,
+    vllm_is_ratio_stride,
+    phi_seq,
+):
+    B, L_ADD_1, N = logits.shape
+    L = L_ADD_1 - 1
+    BLOCK_N = min(4096, N)
+
+    logits_2d = logits.reshape(B * L_ADD_1, N).contiguous()
+    dlogits_2d = logits.data.reshape(B * L_ADD_1, N) if inplace else torch.empty_like(logits_2d)
+
+    dummy_f = torch.zeros(1, device=logits.device, dtype=torch.float32)
+    dummy_i = torch.zeros(1, device=logits.device, dtype=torch.int32)
+
+    old_logp_arg = old_logp.contiguous() if old_logp is not None else dummy_f
+    ref_logp_arg = ref_logp.contiguous() if ref_logp is not None else dummy_f
+    mask_arg = completion_mask.to(torch.int32).contiguous() if completion_mask is not None else dummy_i
+    vllm_arg = vllm_is_ratio.contiguous() if vllm_is_ratio is not None else dummy_f
+    phi_seq_arg = phi_seq.contiguous() if phi_seq is not None else dummy_f
+
+    has_mask = int(completion_mask is not None)
+    has_old_logp = int(old_logp is not None)
+    has_vllm = int(vllm_is_ratio is not None and int(loss_type_int) != 3)
+
+    grid = (B, L, 1)
+    bwd_kernel = _bwd_occ_small if B <= 2 else _bwd_occ_large
+    ct.launch(
+        torch.cuda.current_stream(),
+        grid,
+        bwd_kernel,
+        (
+            dloss.contiguous(),
+            dlogits_2d,
+            logits_2d,
+            old_logp_arg,
+            ref_logp_arg,
+            completion_ids.contiguous(),
+            advantages.contiguous(),
+            mask_arg,
+            lse,
+            vllm_arg,
+            phi_seq_arg,
+            int(B),
+            int(L),
+            int(N),
+            int(BLOCK_N),
+            float(temperature),
+            float(beta),
+            float(eps_low),
+            float(eps_high),
+            int(loss_type_int),
+            float(sapo_temperature_pos),
+            float(sapo_temperature_neg),
+            float(delta),
+            int(use_bias_correction_kl),
+            int(has_mask),
+            int(has_old_logp),
+            int(has_vllm),
+            int(vllm_is_ratio_stride),
+        ),
+    )
+
+    dlogits = dlogits_2d.reshape(B, L_ADD_1, N)
+    dlogits[:, -1, :] = 0
+    return dlogits
+
+
+# ---------------------------------------------------------------------------
+# Sequence-level importance sampling (GSPO): per-sequence coef_1 precomputed on host.
+# ---------------------------------------------------------------------------
+
+
+@ct.kernel
+def _grpo_loss_fwd_seq_ct(
+    logits_input,  # (B*(L+1), N)
+    ref_logp_input,  # (B, L) or dummy (1,)
+    input_ids,  # (B, L) int64
+    completion_mask,  # (B, L) int32 or dummy (1,)
+    advantages,  # (B,) float32
+    coef_1,  # (B,) per-sequence importance weight, post delta-clamp
+    coef_1_raw,  # (B,) per-sequence importance weight, pre delta-clamp (for bias-corrected KL)
+    coef_2,  # (B,) clipped coef
+    is_clipped_seq,  # (B,) clipping indicator
+    vllm_is_ratio,  # (B, L)/(B, 1) or dummy (1,)
+    loss_output,  # (B, L)
+    lse_cache,  # (B, L)
+    kl_output,  # (B, L) or dummy (1,)
+    is_clipped_output,  # (B, L)
+    B: ct.Constant[int],
+    L: ct.Constant[int],
+    N: ct.Constant[int],
+    BLOCK_N: ct.Constant[int],
+    temperature,
+    beta: ct.Constant[float],
+    use_bias_correction_kl: ct.Constant[int],
+    HAS_COMPLETION_MASK: ct.Constant[int],
+    HAS_VLLM_IS_RATIO: ct.Constant[int],
+    vllm_is_ratio_stride,
+):
+    """Sequence-level GRPO forward. Grid: (B, L). Uses precomputed per-sequence coefficients."""
+    off_b = ct.bid(0)
+    off_l = ct.bid(1)
+
+    if HAS_COMPLETION_MASK:
+        mask_val = ct.astype(ct.load(completion_mask, (off_b, off_l), shape=()), ct.int32)
+        if mask_val == 0:
+            return
+
+    logits_row = ct.add(ct.mul(off_b, L + 1), off_l)
+    n_chunks = (N + BLOCK_N - 1) // BLOCK_N
+    inv_temperature = 1.0 / temperature
+
+    m_i = ct.full((), -math.inf, dtype=ct.float32)
+    l_i = ct.full((), 0.0, dtype=ct.float32)
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_N, dtype=ct.int32), ci * BLOCK_N)
+        logits = ct.astype(
+            ct.gather(logits_input, (logits_row, col_idx), check_bounds=True, padding_value=-math.inf, latency=3),
+            ct.float32,
+        )
+        logits_scaled = logits * inv_temperature
+        chunk_max = ct.max(logits_scaled, 0, keepdims=False)
+        new_m = ct.maximum(m_i, chunk_max)
+        alpha = ct.exp2(ct.mul(m_i - new_m, LOG2E))
+        l_i = ct.add(ct.mul(l_i, alpha), ct.sum(ct.exp2(ct.mul(logits_scaled - new_m, LOG2E)), 0, keepdims=False))
+        m_i = new_m
+    lse = m_i + ct.log(l_i)
+
+    idx = ct.astype(ct.load(input_ids, (off_b, off_l), shape=()), ct.int32)
+    idx_tile = ct.add(ct.arange(1, dtype=ct.int32), idx)
+    x = (
+        ct.sum(
+            ct.astype(ct.gather(logits_input, (logits_row, idx_tile), check_bounds=False), ct.float32),
+            0,
+            keepdims=False,
+        )
+        * inv_temperature
+    )
+    logp = x - lse
+
+    coef_1_v = ct.astype(ct.load(coef_1, off_b, shape=()), ct.float32)
+    coef_2_v = ct.astype(ct.load(coef_2, off_b, shape=()), ct.float32)
+    is_clip_v = ct.astype(ct.load(is_clipped_seq, off_b, shape=()), ct.float32)
+    advantage = ct.astype(ct.load(advantages, off_b, shape=()), ct.float32)
+
+    per_token_loss = -ct.minimum(coef_1_v * advantage, coef_2_v * advantage)
+
+    if HAS_VLLM_IS_RATIO:
+        vllm_col = off_l % vllm_is_ratio_stride
+        vllm_tile = ct.gather(
+            vllm_is_ratio,
+            ct.add(ct.arange(1, dtype=ct.int32), ct.mul(off_b, vllm_is_ratio_stride) + vllm_col),
+            check_bounds=False,
+        )
+        vllm_ratio = ct.astype(ct.sum(ct.astype(vllm_tile, ct.float32), 0, keepdims=False), ct.float32)
+        per_token_loss = per_token_loss * vllm_ratio
+
+    if beta != 0.0:
+        ref_logp = ct.astype(ct.load(ref_logp_input, (off_b, off_l), shape=()), ct.float32)
+        kl = ct.exp(ref_logp - logp) - (ref_logp - logp) - 1.0
+        if use_bias_correction_kl:
+            kl = kl * ct.astype(ct.load(coef_1_raw, off_b, shape=()), ct.float32)
+        per_token_loss = per_token_loss + beta * kl
+        ct.scatter(kl_output, (off_b, off_l), ct.astype(kl, kl_output.dtype))
+
+    ct.scatter(loss_output, (off_b, off_l), ct.astype(per_token_loss, loss_output.dtype))
+    ct.scatter(lse_cache, (off_b, off_l), ct.astype(lse, lse_cache.dtype))
+    ct.scatter(is_clipped_output, (off_b, off_l), ct.astype(is_clip_v, is_clipped_output.dtype))
+
+
+@ct.kernel
+def _grpo_loss_bwd_seq_ct(
+    dloss_input,  # (B, L) per-token upstream grad (for KL term)
+    dloss_sum_input,  # (B,) per-sequence sum of dloss (for policy grad)
+    dlogits_output,  # (B*(L+1), N)
+    logits_input,  # (B*(L+1), N)
+    ref_logp_input,  # (B, L) or dummy (1,)
+    input_ids,  # (B, L) int64
+    advantages,  # (B,) float32
+    completion_mask,  # (B, L) int32 or dummy (1,)
+    lse_cache,  # (B, L)
+    coef_1,  # (B,) per-sequence importance weight (pre delta-clamp)
+    seq_len,  # (B,) valid tokens per sequence
+    B: ct.Constant[int],
+    L: ct.Constant[int],
+    N: ct.Constant[int],
+    BLOCK_N: ct.Constant[int],
+    temperature,
+    beta: ct.Constant[float],
+    use_bias_correction_kl: ct.Constant[int],
+    eps_low,
+    eps_high,
+    delta,
+    HAS_COMPLETION_MASK: ct.Constant[int],
+):
+    """Sequence-level GRPO backward. Grid: (B, L)."""
+    off_b = ct.bid(0)
+    off_l = ct.bid(1)
+    logits_row = ct.add(ct.mul(off_b, L + 1), off_l)
+    n_chunks = (N + BLOCK_N - 1) // BLOCK_N
+    inv_temperature = 1.0 / temperature
+
+    if HAS_COMPLETION_MASK:
+        mask_val = ct.astype(ct.load(completion_mask, (off_b, off_l), shape=()), ct.int32)
+        if mask_val == 0:
+            for ci in range(n_chunks):
+                col_idx = ct.add(ct.arange(BLOCK_N, dtype=ct.int32), ci * BLOCK_N)
+                ct.scatter(
+                    dlogits_output,
+                    (logits_row, col_idx),
+                    ct.full((BLOCK_N,), 0.0, dtype=dlogits_output.dtype),
+                    check_bounds=True,
+                )
+            return
+
+    dloss = ct.astype(ct.load(dloss_input, (off_b, off_l), shape=()), ct.float32)
+    dloss_sum = ct.astype(ct.load(dloss_sum_input, off_b, shape=()), ct.float32)
+    lse = ct.astype(ct.load(lse_cache, (off_b, off_l), shape=()), ct.float32)
+    coef_1_v = ct.astype(ct.load(coef_1, off_b, shape=()), ct.float32)
+    seq_len_v = ct.astype(ct.load(seq_len, off_b, shape=()), ct.float32)
+
+    idx = ct.astype(ct.load(input_ids, (off_b, off_l), shape=()), ct.int32)
+    idx_tile = ct.add(ct.arange(1, dtype=ct.int32), idx)
+    x = (
+        ct.sum(
+            ct.astype(ct.gather(logits_input, (logits_row, idx_tile), check_bounds=False), ct.float32),
+            0,
+            keepdims=False,
+        )
+        * inv_temperature
+    )
+    logp = x - lse
+    advantage = ct.astype(ct.load(advantages, off_b, shape=()), ct.float32)
+
+    coef_2 = ct.minimum(ct.maximum(coef_1_v, 1.0 - eps_low), 1.0 + eps_high)
+    if delta != 0.0:
+        coef_1_for_loss = ct.minimum(coef_1_v, ct.full((), delta, dtype=ct.float32))
+    else:
+        coef_1_for_loss = coef_1_v
+    is_unclipped = ct.astype((coef_2 * advantage) >= (coef_1_for_loss * advantage), ct.float32)
+
+    dlogp = -coef_1_v * advantage / seq_len_v * is_unclipped * dloss_sum
+    if delta != 0.0:
+        dlogp = dlogp * ct.astype(coef_1_v <= ct.full((), delta, dtype=ct.float32), ct.float32)
+
+    if beta != 0.0:
+        ref_logp = ct.astype(ct.load(ref_logp_input, (off_b, off_l), shape=()), ct.float32)
+        if use_bias_correction_kl:
+            dlogp = dlogp + beta * coef_1_v * (logp - ref_logp) * dloss
+        else:
+            dlogp = dlogp + beta * (1.0 - ct.exp(ref_logp - logp)) * dloss
+
+    dlogp_scaled = dlogp * inv_temperature
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_N, dtype=ct.int32), ci * BLOCK_N)
+        logits = ct.astype(
+            ct.gather(logits_input, (logits_row, col_idx), check_bounds=True, padding_value=-math.inf, latency=10),
+            ct.float32,
+        )
+        probs = ct.exp(logits * inv_temperature - lse)
+        is_target = ct.astype(col_idx == idx, ct.float32)
+        dlogits = (is_target - probs) * dlogp_scaled
+        ct.scatter(
+            dlogits_output,
+            (logits_row, col_idx),
+            ct.astype(dlogits, dlogits_output.dtype),
+            check_bounds=True,
+            latency=10,
+        )
+
+
+_bwd_seq_occ_small = _grpo_loss_bwd_seq_ct.replace_hints(occupancy=ByTarget(sm_100=4, default=4))
+_bwd_seq_occ_large = _grpo_loss_bwd_seq_ct.replace_hints(occupancy=ByTarget(sm_100=12, default=12))
+
+
+def _compute_dapo_normalizer(completion_mask, num_items_in_batch=None):
+    """Per-process normalizer for DAPO/CISPO/VESPO."""
+    world_size = 1
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        world_size = torch.distributed.get_world_size()
+
+    if num_items_in_batch is not None:
+        if isinstance(num_items_in_batch, torch.Tensor):
+            normalizer = num_items_in_batch.to(device=completion_mask.device, dtype=torch.float32)
+        else:
+            normalizer = torch.as_tensor(float(num_items_in_batch), device=completion_mask.device, dtype=torch.float32)
+        normalizer = normalizer / world_size
+        return torch.clamp(normalizer, min=1.0)
+
+    normalizer = completion_mask.to(torch.float32).sum()
+    if world_size > 1:
+        normalizer = normalizer.clone()
+        torch.distributed.all_reduce(normalizer, op=torch.distributed.ReduceOp.SUM)
+        normalizer = normalizer / world_size
+    return torch.clamp(normalizer, min=1.0)
+
+
+def _reduce_loss(per_token_loss, mask, loss_type, max_completion_length, B, L, num_items_in_batch=None):
+    """Apply loss reduction based on loss_type."""
+    if loss_type == "grpo" or loss_type == "sapo":
+        return ((per_token_loss * mask).sum(-1) / mask.sum(-1).clamp(min=1.0)).mean()
+    elif loss_type == "bnpo":
+        return (per_token_loss * mask).sum() / mask.sum().clamp(min=1.0)
+    elif loss_type == "dr_grpo":
+        max_len = max_completion_length if max_completion_length is not None else L
+        return (per_token_loss * mask).sum() / (B * max_len)
+    elif loss_type == "dapo" or loss_type == "cispo" or loss_type == "vespo":
+        return (per_token_loss * mask).sum() / _compute_dapo_normalizer(mask, num_items_in_batch=num_items_in_batch)
+    elif loss_type == "luspo":
+        return (per_token_loss * mask.sum(-1, keepdim=True)).mean()
+    raise ValueError(f"Unknown loss_type: {loss_type}. Expected one of: grpo, bnpo, dr_grpo, dapo, cispo, sapo, luspo")
+
+
+def _grpo_loss_forward_seq_ct(
+    logits,
+    old_logp,
+    ref_logp,
+    completion_ids,
+    advantages,
+    completion_mask,
+    temperature,
+    beta,
+    eps_low,
+    eps_high,
+    delta_val,
+    use_bias_correction_kl,
+    vllm_is_ratio,
+    vllm_is_ratio_stride,
+):
+    B, L_ADD_1, N = logits.shape
+    L = L_ADD_1 - 1
+    BLOCK_N = min(4096, N)
+    device = logits.device
+    mask = completion_mask.float() if completion_mask is not None else torch.ones(B, L, device=device)
+
+    # Per-token log-probs (host) → per-sequence importance weights (GSPO).
+    lg = logits[:, :L, :].float() / temperature
+    lse_pt = torch.logsumexp(lg, dim=-1)
+    tgt = torch.gather(lg, -1, completion_ids.long().unsqueeze(-1)).squeeze(-1)
+    per_token_logps = tgt - lse_pt
+    log_ratio = torch.zeros_like(per_token_logps) if old_logp is None else (per_token_logps - old_logp)
+    seq_lens = mask.sum(-1).clamp(min=1.0)  # (B,)
+    coef_1 = torch.exp((log_ratio * mask).sum(-1) / seq_lens)  # (B,)
+    coef_2 = torch.clamp(coef_1, 1.0 - eps_low, 1.0 + eps_high)
+    is_clipped_seq = (
+        ((coef_1 < 1.0 - eps_low) & (advantages < 0)) | ((coef_1 > 1.0 + eps_high) & (advantages > 0))
+    ).float()
+    coef_1_for_loss = torch.clamp(coef_1, max=delta_val) if delta_val != 0.0 else coef_1
+
+    logits_2d = logits.reshape(B * L_ADD_1, N).contiguous()
+    loss = torch.zeros(B, L, device=device, dtype=torch.float32)
+    lse = torch.zeros(B, L, device=device, dtype=torch.float32)
+    is_clipped = torch.zeros(B, L, device=device, dtype=torch.float32)
+    has_beta = float(beta) != 0.0
+    kl = torch.zeros(B, L, device=device, dtype=torch.float32) if has_beta else None
+
+    dummy_f = torch.zeros(1, device=device, dtype=torch.float32)
+    dummy_i = torch.zeros(1, device=device, dtype=torch.int32)
+    ref_arg = ref_logp.contiguous() if ref_logp is not None else dummy_f
+    mask_arg = completion_mask.to(torch.int32).contiguous() if completion_mask is not None else dummy_i
+    kl_arg = kl if kl is not None else dummy_f
+    vllm_arg = vllm_is_ratio.contiguous() if vllm_is_ratio is not None else dummy_f
+    has_mask = int(completion_mask is not None)
+    has_vllm = int(vllm_is_ratio is not None)
+
+    ct.launch(
+        torch.cuda.current_stream(),
+        (B, L, 1),
+        _grpo_loss_fwd_seq_ct,
+        (
+            logits_2d,
+            ref_arg,
+            completion_ids.contiguous(),
+            mask_arg,
+            advantages.contiguous(),
+            coef_1_for_loss.contiguous(),
+            coef_1.contiguous(),
+            coef_2.contiguous(),
+            is_clipped_seq.contiguous(),
+            vllm_arg,
+            loss,
+            lse,
+            kl_arg,
+            is_clipped,
+            int(B),
+            int(L),
+            int(N),
+            int(BLOCK_N),
+            float(temperature),
+            float(beta),
+            int(use_bias_correction_kl),
+            has_mask,
+            has_vllm,
+            int(vllm_is_ratio_stride),
+        ),
+    )
+    return loss, lse, is_clipped, kl, coef_1, seq_lens
+
+
+def _grpo_loss_backward_seq_ct(
+    dloss,
+    logits,
+    ref_logp,
+    completion_ids,
+    advantages,
+    completion_mask,
+    lse,
+    coef_1,
+    seq_lens,
+    temperature,
+    beta,
+    eps_low,
+    eps_high,
+    delta_val,
+    use_bias_correction_kl,
+    inplace,
+    vllm_is_ratio,
+):
+    B, L_ADD_1, N = logits.shape
+    L = L_ADD_1 - 1
+    BLOCK_N = min(4096, N)
+    if vllm_is_ratio is None:
+        dloss_sum = dloss.sum(-1).contiguous()
+    else:
+        ratio = vllm_is_ratio.unsqueeze(-1) if vllm_is_ratio.dim() == 1 else vllm_is_ratio
+        dloss_sum = (dloss * ratio).sum(-1).contiguous()
+
+    logits_2d = logits.reshape(B * L_ADD_1, N).contiguous()
+    dlogits_2d = logits.data.reshape(B * L_ADD_1, N) if inplace else torch.empty_like(logits_2d)
+    dummy_f = torch.zeros(1, device=logits.device, dtype=torch.float32)
+    dummy_i = torch.zeros(1, device=logits.device, dtype=torch.int32)
+    ref_arg = ref_logp.contiguous() if ref_logp is not None else dummy_f
+    mask_arg = completion_mask.to(torch.int32).contiguous() if completion_mask is not None else dummy_i
+    has_mask = int(completion_mask is not None)
+
+    bwd_kernel = _bwd_seq_occ_small if B <= 2 else _bwd_seq_occ_large
+    ct.launch(
+        torch.cuda.current_stream(),
+        (B, L, 1),
+        bwd_kernel,
+        (
+            dloss.contiguous(),
+            dloss_sum,
+            dlogits_2d,
+            logits_2d,
+            ref_arg,
+            completion_ids.contiguous(),
+            advantages.contiguous(),
+            mask_arg,
+            lse,
+            coef_1.contiguous(),
+            seq_lens.contiguous(),
+            int(B),
+            int(L),
+            int(N),
+            int(BLOCK_N),
+            float(temperature),
+            float(beta),
+            int(use_bias_correction_kl),
+            float(eps_low),
+            float(eps_high),
+            float(delta_val),
+            has_mask,
+        ),
+    )
+    dlogits = dlogits_2d.reshape(B, L_ADD_1, N)
+    dlogits[:, -1, :] = 0
+    return dlogits
+
+
+class GrpoLossCuTileFunction(torch.autograd.Function):
+    """CuTile autograd wrapper for GRPO loss (token-level).
+
+    Full feature parity across all loss types and token/sequence-level IS.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        logits,
+        old_logp,
+        ref_logp,
+        completion_ids,
+        advantages,
+        completion_mask,
+        temperature,
+        beta,
+        eps_low,
+        eps_high,
+        inplace,
+        loss_type="grpo",
+        max_completion_length=None,
+        reduce=True,
+        importance_sampling_level="token",
+        sapo_temperature_pos=1.0,
+        sapo_temperature_neg=1.05,
+        vllm_is_ratio=None,
+        delta=None,
+        use_bias_correction_kl=False,
+        num_items_in_batch=None,
+        phi_seq=None,
+    ):
+        assert logits.is_contiguous() and completion_ids.is_contiguous()
+        if loss_type not in _str_to_loss_type:
+            raise ValueError(f"Unknown loss_type '{loss_type}'. Supported: {list(_str_to_loss_type.keys())}")
+        assert importance_sampling_level in ("token", "sequence"), (
+            f"importance_sampling_level must be 'token' or 'sequence', got {importance_sampling_level}"
+        )
+        if importance_sampling_level == "sequence" and loss_type in ("cispo", "sapo", "vespo"):
+            raise ValueError(
+                f"Sequence-level importance sampling is not supported for loss_type='{loss_type}'. "
+                f"Use importance_sampling_level='token' instead."
+            )
+        if delta is not None and loss_type in ("cispo", "sapo", "vespo"):
+            raise ValueError(f"delta (two-sided clipping) is not supported for loss_type='{loss_type}'.")
+        if loss_type == "sapo":
+            if sapo_temperature_pos <= 0 or sapo_temperature_neg <= 0:
+                raise ValueError("sapo_temperature_pos/neg must be positive.")
+
+        loss_type_int = _str_to_loss_type[loss_type]
+        delta_val = 0.0 if delta is None else float(delta)
+
+        B, L_ADD_1, N = logits.shape
+        L = L_ADD_1 - 1
+
+        # VESPO requires a caller-precomputed per-sequence gamma weight phi_seq (B,).
+        if loss_type == "vespo":
+            if phi_seq is None:
+                raise ValueError("loss_type='vespo' requires phi_seq precomputed by the caller (B,) or (B, 1).")
+            assert phi_seq.shape in ((B,), (B, 1)), f"phi_seq must be (B,) or (B, 1), got {tuple(phi_seq.shape)}"
+            phi_seq = phi_seq.reshape(-1).contiguous()
+        else:
+            phi_seq = None
+
+        vllm_is_ratio_stride = L
+        if vllm_is_ratio is not None:
+            assert vllm_is_ratio.dim() in (1, 2)
+            if vllm_is_ratio.dim() == 2:
+                assert vllm_is_ratio.shape[0] == B and vllm_is_ratio.shape[1] in (1, L)
+            else:
+                assert vllm_is_ratio.shape[0] == B
+            vllm_is_ratio = vllm_is_ratio.contiguous()
+            vllm_is_ratio_stride = vllm_is_ratio.shape[1] if vllm_is_ratio.dim() > 1 else 1
+
+        if importance_sampling_level == "sequence":
+            loss, lse, is_clipped, kl, coef_1, seq_lens = _grpo_loss_forward_seq_ct(
+                logits,
+                old_logp,
+                ref_logp,
+                completion_ids,
+                advantages,
+                completion_mask,
+                temperature,
+                beta,
+                eps_low,
+                eps_high,
+                delta_val,
+                int(use_bias_correction_kl),
+                vllm_is_ratio,
+                vllm_is_ratio_stride,
+            )
+            ctx.save_for_backward(logits, ref_logp, completion_ids, advantages, completion_mask, lse, coef_1, seq_lens)
+        else:
+            loss, lse, is_clipped, kl = _grpo_loss_forward_ct(
+                logits,
+                old_logp,
+                ref_logp,
+                completion_ids,
+                advantages,
+                completion_mask,
+                temperature,
+                beta,
+                eps_low,
+                eps_high,
+                loss_type_int,
+                sapo_temperature_pos,
+                sapo_temperature_neg,
+                delta_val,
+                int(use_bias_correction_kl),
+                vllm_is_ratio,
+                vllm_is_ratio_stride,
+                phi_seq,
+            )
+            ctx.save_for_backward(logits, old_logp, ref_logp, completion_ids, advantages, completion_mask, lse)
+
+        ctx.importance_sampling_level = importance_sampling_level
+        ctx.vllm_is_ratio = vllm_is_ratio
+        ctx.phi_seq = phi_seq
+        ctx.infos = (
+            temperature,
+            beta,
+            eps_low,
+            eps_high,
+            inplace,
+            loss_type,
+            loss_type_int,
+            sapo_temperature_pos,
+            sapo_temperature_neg,
+            max_completion_length,
+            reduce,
+            delta_val,
+            use_bias_correction_kl,
+            vllm_is_ratio_stride,
+            num_items_in_batch,
+        )
+
+        mask = completion_mask.float() if completion_mask is not None else torch.ones(B, L, device=logits.device)
+        mask_sum = mask.sum().clamp(min=1.0)
+        kl_mean = (kl * mask).sum() / mask_sum if kl is not None else None
+        clip_ratio = (is_clipped.float() * mask).sum() / mask_sum
+
+        if not reduce:
+            loss_out = loss * mask
+            kl_out = kl * mask if kl is not None else None
+            is_clipped_out = is_clipped * mask
+            return loss_out, kl_out, is_clipped_out
+
+        reduced_loss = _reduce_loss(
+            loss, mask, loss_type, max_completion_length, B, L, num_items_in_batch=num_items_in_batch
+        )
+        return reduced_loss, kl_mean, clip_ratio
+
+    @staticmethod
+    def backward(ctx, *args):
+        dloss_input = args[0]
+        level = ctx.importance_sampling_level
+        if level == "sequence":
+            logits, ref_logp, completion_ids, advantages, completion_mask, lse, coef_1, seq_lens = ctx.saved_tensors
+            old_logp = None
+        else:
+            logits, old_logp, ref_logp, completion_ids, advantages, completion_mask, lse = ctx.saved_tensors
+        (
+            temperature,
+            beta,
+            eps_low,
+            eps_high,
+            inplace,
+            loss_type,
+            loss_type_int,
+            sapo_temp_pos,
+            sapo_temp_neg,
+            max_completion_length,
+            reduce,
+            delta_val,
+            use_bias_correction_kl,
+            vllm_is_ratio_stride,
+            num_items_in_batch,
+        ) = ctx.infos
+        vllm_is_ratio = ctx.vllm_is_ratio
+        phi_seq = ctx.phi_seq
+
+        B, L_ADD_1, N = logits.shape
+        L = L_ADD_1 - 1
+        mask = completion_mask.float() if completion_mask is not None else torch.ones(B, L, device=logits.device)
+
+        if not reduce:
+            dloss = dloss_input
+        elif loss_type == "grpo" or loss_type == "sapo":
+            seq_lens_bwd = mask.sum(-1, keepdim=True).clamp(min=1.0)
+            dloss = dloss_input * mask / (seq_lens_bwd * B)
+        elif loss_type == "bnpo":
+            dloss = dloss_input * mask / mask.sum().clamp(min=1.0)
+        elif loss_type == "dr_grpo":
+            max_len = max_completion_length if max_completion_length is not None else L
+            dloss = dloss_input * mask / (B * max_len)
+        elif loss_type == "dapo" or loss_type == "cispo" or loss_type == "vespo":
+            dloss = dloss_input * mask / _compute_dapo_normalizer(mask, num_items_in_batch=num_items_in_batch)
+        elif loss_type == "luspo":
+            seq_lens_bwd = mask.sum(-1, keepdim=True).clamp(min=1.0)
+            # d(loss)/d(per_token_loss[b,l]) = seq_len[b] / (B*L), constant within a sequence.
+            # Broadcast the (B, 1) scale to (B, L). NOTE: this intentionally diverges from a
+            # naive path that passes the (B, 1) tensor with stride (1, 1) and reads
+            # dloss[off_b + off_l] — out of bounds (wrong) for B < L. The cuTile result is the
+            # mathematically correct per-sequence gradient.
+            dloss = (dloss_input * seq_lens_bwd / (B * L)).expand(B, L)
+        else:
+            raise ValueError(f"Unknown loss_type: {loss_type}")
+
+        if level == "sequence":
+            dlogits = _grpo_loss_backward_seq_ct(
+                dloss,
+                logits,
+                ref_logp,
+                completion_ids,
+                advantages,
+                completion_mask,
+                lse,
+                coef_1,
+                seq_lens,
+                temperature,
+                beta,
+                eps_low,
+                eps_high,
+                delta_val,
+                use_bias_correction_kl,
+                inplace,
+                vllm_is_ratio,
+            )
+        else:
+            dlogits = _grpo_loss_backward_ct(
+                dloss,
+                logits,
+                old_logp,
+                ref_logp,
+                completion_ids,
+                advantages,
+                completion_mask,
+                lse,
+                temperature,
+                beta,
+                eps_low,
+                eps_high,
+                inplace,
+                loss_type_int,
+                sapo_temp_pos,
+                sapo_temp_neg,
+                delta_val,
+                use_bias_correction_kl,
+                vllm_is_ratio,
+                vllm_is_ratio_stride,
+                phi_seq,
+            )
+        # 22 forward inputs -> dlogits + 21 None
+        return (dlogits, None, None, None, None, None, None, None, None, None, None, None,
+                None, None, None, None, None, None, None, None, None, None)  # fmt: skip
+
+
+@register_impl("liger.grpo_loss", backend="cutile")
+def grpo_loss(
+    logits: torch.Tensor,
+    old_logp,
+    ref_logp,
+    completion_ids: torch.Tensor,
+    advantages: torch.Tensor,
+    completion_mask=None,
+    temperature: float = 0.9,
+    beta: float = 0.0,
+    eps_low: float = 0.2,
+    eps_high: float = 0.2,
+    inplace: bool = True,
+    loss_type: str = "grpo",
+    max_completion_length=None,
+    reduce: bool = False,
+    importance_sampling_level: str = "token",
+    sapo_temperature_pos: float = 1.0,
+    sapo_temperature_neg: float = 1.05,
+    vllm_is_ratio=None,
+    delta=None,
+    use_bias_correction_kl: bool = False,
+    num_items_in_batch=None,
+    phi_seq=None,
+    **kwargs,
+):
+    return GrpoLossCuTileFunction.apply(
+        logits,
+        old_logp,
+        ref_logp,
+        completion_ids,
+        advantages,
+        completion_mask,
+        temperature,
+        beta,
+        eps_low,
+        eps_high,
+        inplace,
+        loss_type,
+        max_completion_length,
+        reduce,
+        importance_sampling_level,
+        sapo_temperature_pos,
+        sapo_temperature_neg,
+        vllm_is_ratio,
+        delta,
+        int(use_bias_correction_kl),
+        num_items_in_batch,
+        phi_seq,
+    )

--- a/src/tilegym/suites/liger/cutile/llama4_rope.py
+++ b/src/tilegym/suites/liger/cutile/llama4_rope.py
@@ -144,6 +144,7 @@ def _llama4_rope_forward_ct(q, k, freqs_cis, BLOCK_SIZE=None, imag_sign=1.0):
         # (seq_len, head_dim_half, 2) → (seq_len, head_dim)
         freqs_cis = freqs_cis.reshape(freqs_cis.shape[0], -1)
 
+    # Align dtype — keep freqs_cis in float32 for precision
     compute_dtype = torch.float32 if q.dtype == torch.float32 else q.dtype
     if k.dtype != q.dtype:
         k = k.to(q.dtype)

--- a/src/tilegym/suites/liger/cutile/multi_token_attention.py
+++ b/src/tilegym/suites/liger/cutile/multi_token_attention.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: MIT
+
 import cuda.tile as ct
 import torch
 import torch.nn.functional as F
@@ -268,24 +269,24 @@ class MultiTokenAttentionCuTileFunction(torch.autograd.Function):
         if stride == (1, 1) and padding == (0, 0) and dilation == (1, 1) and groups == 1:
             grad_probs, grad_weight = _conv1x1_backward(grad_conv, probs, weight)
         else:
-            # cudnn.benchmark=True is critical here: with the default heuristic, cuDNN
-            # picks a pathologically slow algorithm for the weight-gradient on large
-            # spatial dims (>=4096) — we measured 1.3s at L=4096 and 5.5s at L=8192
-            # with the default vs 10ms / 40ms with benchmark enabled (~130x speedup).
-            with torch.backends.cudnn.flags(benchmark=True):
-                grad_probs, grad_weight, _ = torch.ops.aten.convolution_backward(
-                    grad_conv,
-                    probs,
-                    weight,
-                    None,
-                    list(stride),
-                    list(padding),
-                    list(dilation),
-                    False,
-                    [0, 0],
-                    groups,
-                    [True, True, False],
-                )
+            # Default cuDNN heuristic — do NOT force cudnn.benchmark=True here. The
+            # per-call flag context adds fixed overhead that dominates small spatial
+            # dims (L=32: 59µs vs 18µs without) and it is a net loss at every size
+            # except L=256; on the current CUDA stack the default heuristic is also
+            # faster on large dims (L=4096: 12.8ms vs 17.2ms with benchmark on).
+            grad_probs, grad_weight, _ = torch.ops.aten.convolution_backward(
+                grad_conv,
+                probs,
+                weight,
+                None,
+                list(stride),
+                list(padding),
+                list(dilation),
+                False,
+                [0, 0],
+                groups,
+                [True, True, False],
+            )
 
         grad_bias = None
         if bias is not None:

--- a/src/tilegym/suites/liger/cutile/poly_norm.py
+++ b/src/tilegym/suites/liger/cutile/poly_norm.py
@@ -1,0 +1,434 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+PolyNorm normalization kernel (CuTile backend).
+
+Formula: y = w₀·norm(x³) + w₁·norm(x²) + w₂·norm(x) + b
+where norm(u) = u / sqrt(mean(u²) + ε)
+
+Reference:
+1. https://github.com/BryceZhuo/PolyCom/
+2. https://arxiv.org/pdf/2411.03884
+"""
+
+import cuda.tile as ct
+import torch
+
+from tilegym.backend import register_impl
+
+from .utils import next_power_of_2
+
+MAX_FUSED_SIZE = 65536
+
+
+@ct.kernel(occupancy=4)
+def _poly_norm_fwd_kernel(
+    x_input,  # (n_rows, n_cols) input
+    y_output,  # (n_rows, n_cols) output
+    weights,  # (3,) weights [w0, w1, w2]
+    bias,  # (1,) scalar bias
+    rstd3,  # (n_rows,) cached rstd for x^3 power
+    rstd2,  # (n_rows,) cached rstd for x^2 power
+    rstd1,  # (n_rows,) cached rstd for x^1 power
+    N_COLS: ct.Constant[int],
+    eps,
+    BLOCK_SIZE: ct.Constant[int],
+    ALIGNED: ct.Constant[bool],
+):
+    """
+    PolyNorm forward kernel (row-parallel).
+
+    Two passes per row:
+    1. Accumulate sum-of-squares for each power, compute rstd, cache it.
+    2. Compute output y = w0*norm(x^3) + w1*norm(x^2) + w2*norm(x) + b.
+
+    ALIGNED=True: n_cols is a power of 2, so BLOCK_SIZE==n_cols and no partial
+    chunk exists. Uses check_bounds=False (hardware TMA path, ~10% faster).
+    ALIGNED=False: general case with software bounds checking.
+    """
+    row_idx = ct.bid(0)
+
+    # Load scalar weights and bias
+    w0 = ct.astype(ct.load(weights, 0, shape=()), ct.float32)
+    w1 = ct.astype(ct.load(weights, 1, shape=()), ct.float32)
+    w2 = ct.astype(ct.load(weights, 2, shape=()), ct.float32)
+    b = ct.astype(ct.load(bias, 0, shape=()), ct.float32)
+
+    # Pass 1: accumulate sum-of-squares for each power using "fold" trick
+    # sum_sq_p[i] accumulates sum over col-chunks at position i within BLOCK_SIZE
+    sum_sq_3 = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+    sum_sq_2 = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+    sum_sq_1 = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+
+    num_chunks = (N_COLS + BLOCK_SIZE - 1) // BLOCK_SIZE
+    for ci in range(num_chunks):
+        col_indices = ct.arange(BLOCK_SIZE, dtype=ct.int32) + ci * BLOCK_SIZE
+        if ALIGNED:
+            x_tile = ct.gather(x_input, (row_idx, col_indices), check_bounds=False)
+        else:
+            x_tile = ct.gather(x_input, (row_idx, col_indices), check_bounds=True, padding_value=0.0)
+        x_f32 = ct.astype(x_tile, ct.float32)
+        # x4-path: reuse x2 for sum_sq_1 and x4 for sum_sq_2; x^6 = x4*x2 inline.
+        # Saves 2 FMUL/element vs computing x3=x^3 separately.
+        x2 = x_f32 * x_f32  # x^2
+        x4 = x2 * x2  # x^4
+        sum_sq_1 = sum_sq_1 + x2  # sum x^2
+        sum_sq_2 = sum_sq_2 + x4  # sum x^4
+        sum_sq_3 = sum_sq_3 + x4 * x2  # sum x^6 = x^4 * x^2
+
+    # Compute rstd = rsqrt(mean(u^2) + eps) for each power
+    rstd_3 = ct.rsqrt(ct.sum(sum_sq_3, axis=0, keepdims=False) / N_COLS + eps)
+    rstd_2 = ct.rsqrt(ct.sum(sum_sq_2, axis=0, keepdims=False) / N_COLS + eps)
+    rstd_1 = ct.rsqrt(ct.sum(sum_sq_1, axis=0, keepdims=False) / N_COLS + eps)
+
+    # Cache rstd values for backward pass
+    ct.scatter(rstd3, row_idx, rstd_3)
+    ct.scatter(rstd2, row_idx, rstd_2)
+    ct.scatter(rstd1, row_idx, rstd_1)
+
+    # Precompute loop-invariant scalar products (w × rstd) before pass 2.
+    # Horner form: y = x2*(w0r3*x + w1r2) + w2r1*x + b  — avoids materialising x3 tile.
+    w0r3 = w0 * rstd_3
+    w1r2 = w1 * rstd_2
+    w2r1 = w2 * rstd_1
+
+    # Pass 2: compute output
+    for ci in range(num_chunks):
+        col_indices = ct.arange(BLOCK_SIZE, dtype=ct.int32) + ci * BLOCK_SIZE
+        if ALIGNED:
+            x_tile = ct.gather(x_input, (row_idx, col_indices), check_bounds=False)
+        else:
+            x_tile = ct.gather(x_input, (row_idx, col_indices), check_bounds=True, padding_value=0.0)
+        x_f32 = ct.astype(x_tile, ct.float32)
+        x2 = x_f32 * x_f32
+        # Horner: y = x2*(w0r3*x + w1r2) + w2r1*x + b
+        inner = w0r3 * x_f32 + w1r2
+        y_f32 = x2 * inner + w2r1 * x_f32 + b
+        if ALIGNED:
+            ct.scatter(y_output, (row_idx, col_indices), ct.astype(y_f32, x_tile.dtype), check_bounds=False)
+        else:
+            ct.scatter(y_output, (row_idx, col_indices), ct.astype(y_f32, x_tile.dtype), check_bounds=True)
+
+
+_poly_norm_fwd_kernel_occ8 = _poly_norm_fwd_kernel.replace_hints(occupancy=8)
+
+
+@ct.kernel(occupancy=4)
+def _poly_norm_fwd_kernel_sc_large(
+    x_input,
+    y_output,
+    weights,
+    bias,
+    rstd3,
+    rstd2,
+    rstd1,
+    N_COLS: ct.Constant[int],
+    eps,
+    BLOCK_SIZE: ct.Constant[int],
+    ALIGNED: ct.Constant[bool],
+):
+    """Single-chunk: re-gather x in pass2, latency=2 on both gathers."""
+    row_idx = ct.bid(0)
+
+    w0 = ct.astype(ct.load(weights, 0, shape=()), ct.float32)
+    w1 = ct.astype(ct.load(weights, 1, shape=()), ct.float32)
+    w2 = ct.astype(ct.load(weights, 2, shape=()), ct.float32)
+    b = ct.astype(ct.load(bias, 0, shape=()), ct.float32)
+
+    col_indices = ct.arange(BLOCK_SIZE, dtype=ct.int32)
+    if ALIGNED:
+        x_tile = ct.gather(x_input, (row_idx, col_indices), check_bounds=False, latency=2)
+    else:
+        x_tile = ct.gather(x_input, (row_idx, col_indices), check_bounds=True, padding_value=0.0, latency=2)
+    x_f32 = ct.astype(x_tile, ct.float32)
+    x2 = x_f32 * x_f32
+    x4 = x2 * x2
+
+    rstd_3 = ct.rsqrt(ct.sum(x4 * x2, axis=0, keepdims=False) / N_COLS + eps)
+    rstd_2 = ct.rsqrt(ct.sum(x4, axis=0, keepdims=False) / N_COLS + eps)
+    rstd_1 = ct.rsqrt(ct.sum(x2, axis=0, keepdims=False) / N_COLS + eps)
+
+    ct.scatter(rstd3, row_idx, rstd_3)
+    ct.scatter(rstd2, row_idx, rstd_2)
+    ct.scatter(rstd1, row_idx, rstd_1)
+
+    w0r3 = w0 * rstd_3
+    w1r2 = w1 * rstd_2
+    w2r1 = w2 * rstd_1
+
+    if ALIGNED:
+        x_tile2 = ct.gather(x_input, (row_idx, col_indices), check_bounds=False, latency=2)
+    else:
+        x_tile2 = ct.gather(x_input, (row_idx, col_indices), check_bounds=True, padding_value=0.0, latency=2)
+    x2_f32 = ct.astype(x_tile2, ct.float32)
+    x2sq = x2_f32 * x2_f32
+    inner = w0r3 * x2_f32 + w1r2
+    y_f32 = x2sq * inner + w2r1 * x2_f32 + b
+    if ALIGNED:
+        ct.scatter(y_output, (row_idx, col_indices), ct.astype(y_f32, x_tile2.dtype), check_bounds=False)
+    else:
+        ct.scatter(y_output, (row_idx, col_indices), ct.astype(y_f32, x_tile2.dtype), check_bounds=True)
+
+
+_poly_norm_fwd_kernel_sc_large_occ4 = _poly_norm_fwd_kernel_sc_large.replace_hints(occupancy=4)
+_poly_norm_fwd_kernel_sc_large_occ8 = _poly_norm_fwd_kernel_sc_large.replace_hints(occupancy=8)
+_poly_norm_fwd_kernel_sc_large_occ16 = _poly_norm_fwd_kernel_sc_large.replace_hints(occupancy=16)
+
+
+@ct.kernel(occupancy=2)
+def _poly_norm_bwd_kernel(
+    dy,  # (n_rows, n_cols) output gradient
+    dx,  # (n_rows, n_cols) input gradient (output)
+    x_input,  # (n_rows, n_cols) saved input
+    weights,  # (3,) weights [w0, w1, w2]
+    rstd3,  # (n_rows,) cached rstd for x^3 power
+    rstd2,  # (n_rows,) cached rstd for x^2 power
+    rstd1,  # (n_rows,) cached rstd for x^1 power
+    dwdb_output,  # (4,) global atomic reduction target [dW0, dW1, dW2, dB]
+    N_COLS: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    ALIGNED: ct.Constant[bool],
+):
+    """
+    PolyNorm backward kernel (row-parallel).
+
+    Two passes per row:
+    1. Compute S_p = sum(dy * x^p) for each power p, and dB = sum(dy).
+    2. Compute dx using closed-form gradient formula.
+
+    dW/dB contributions are atomically reduced into a single (4,) output tensor
+    directly inside the kernel — eliminates a separate host-side .sum(dim=1)
+    + .to(W.dtype) launch chain.
+
+    ALIGNED=True uses check_bounds=False (hardware TMA, ~10% faster) when
+    n_cols is a power of 2 and BLOCK_SIZE==n_cols.
+    """
+    row_idx = ct.bid(0)
+
+    # Load weights and cached rstd values
+    w0 = ct.astype(ct.load(weights, 0, shape=()), ct.float32)
+    w1 = ct.astype(ct.load(weights, 1, shape=()), ct.float32)
+    w2 = ct.astype(ct.load(weights, 2, shape=()), ct.float32)
+
+    rstd_3 = ct.load(rstd3, row_idx, shape=())
+    rstd_2 = ct.load(rstd2, row_idx, shape=())
+    rstd_1 = ct.load(rstd1, row_idx, shape=())
+
+    S_3_acc = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+    S_2_acc = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+    S_1_acc = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+    dB_acc = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+
+    num_chunks = (N_COLS + BLOCK_SIZE - 1) // BLOCK_SIZE
+    for ci in range(num_chunks):
+        col_indices = ct.arange(BLOCK_SIZE, dtype=ct.int32) + ci * BLOCK_SIZE
+        if ALIGNED:
+            dy_t = ct.astype(ct.gather(dy, (row_idx, col_indices), check_bounds=False), ct.float32)
+            x = ct.astype(ct.gather(x_input, (row_idx, col_indices), check_bounds=False), ct.float32)
+        else:
+            dy_t = ct.astype(ct.gather(dy, (row_idx, col_indices), check_bounds=True, padding_value=0.0), ct.float32)
+            x = ct.astype(ct.gather(x_input, (row_idx, col_indices), check_bounds=True, padding_value=0.0), ct.float32)
+        S_3_acc = S_3_acc + dy_t * (x * x * x)
+        S_2_acc = S_2_acc + dy_t * (x * x)
+        S_1_acc = S_1_acc + dy_t * x
+        dB_acc = dB_acc + dy_t
+
+    S_3 = ct.sum(S_3_acc, axis=0, keepdims=False)
+    S_2 = ct.sum(S_2_acc, axis=0, keepdims=False)
+    S_1 = ct.sum(S_1_acc, axis=0, keepdims=False)
+    dB_row = ct.sum(dB_acc, axis=0, keepdims=False)
+
+    ct.atomic_add(dwdb_output, 0, rstd_3 * S_3, check_bounds=False)
+    ct.atomic_add(dwdb_output, 1, rstd_2 * S_2, check_bounds=False)
+    ct.atomic_add(dwdb_output, 2, rstd_1 * S_1, check_bounds=False)
+    ct.atomic_add(dwdb_output, 3, dB_row, check_bounds=False)
+
+    for ci in range(num_chunks):
+        col_indices = ct.arange(BLOCK_SIZE, dtype=ct.int32) + ci * BLOCK_SIZE
+        if ALIGNED:
+            dy_t = ct.astype(ct.gather(dy, (row_idx, col_indices), check_bounds=False), ct.float32)
+            x = ct.astype(ct.gather(x_input, (row_idx, col_indices), check_bounds=False), ct.float32)
+        else:
+            dy_t = ct.astype(ct.gather(dy, (row_idx, col_indices), check_bounds=True, padding_value=0.0), ct.float32)
+            x = ct.astype(ct.gather(x_input, (row_idx, col_indices), check_bounds=True, padding_value=0.0), ct.float32)
+        x2 = x * x
+        x3 = x2 * x
+
+        rstd3_cu = rstd_3 * rstd_3 * rstd_3
+        grad_3 = w0 * (3.0 * x2 * rstd_3 * dy_t - (3.0 / N_COLS) * x2 * x3 * rstd3_cu * S_3)
+
+        rstd2_cu = rstd_2 * rstd_2 * rstd_2
+        grad_2 = w1 * (2.0 * x * rstd_2 * dy_t - (2.0 / N_COLS) * x3 * rstd2_cu * S_2)
+
+        rstd1_cu = rstd_1 * rstd_1 * rstd_1
+        grad_1 = w2 * (rstd_1 * dy_t - (1.0 / N_COLS) * x * rstd1_cu * S_1)
+
+        dx_t = grad_3 + grad_2 + grad_1
+        if ALIGNED:
+            ct.scatter(dx, (row_idx, col_indices), ct.astype(dx_t, dx.dtype), check_bounds=False)
+        else:
+            ct.scatter(dx, (row_idx, col_indices), ct.astype(dx_t, dx.dtype), check_bounds=True)
+
+
+# Large-N variant (n_cols >= 8192): higher occupancy + 8 worker warps to widen
+# parallelism on latency-bound 2-pass multi-chunk path.
+_poly_norm_bwd_kernel_large = _poly_norm_bwd_kernel.replace_hints(occupancy=4, num_worker_warps=8)
+
+
+class PolyNormCuTileFunction(torch.autograd.Function):
+    """
+    PolyNorm autograd function with CuTile forward and backward kernels.
+
+    Formula: y = w₀·norm(x³) + w₁·norm(x²) + w₂·norm(x) + b
+    where norm(u) = u / sqrt(mean(u²) + ε)
+    """
+
+    @staticmethod
+    def forward(ctx, X, W, B, eps):
+        shape = X.shape
+        dim = shape[-1]
+        X_2d = X.contiguous().view(-1, dim)
+        n_rows, n_cols = X_2d.shape
+
+        # B is a scalar bias — accept 0-dim (torch.tensor(1.0)) or (1,); the kernel reads
+        # bias[0], so flatten to a 1-element tensor and restore B's shape for the dB gradient.
+        bias_shape = B.shape
+        B = B.reshape(1)
+
+        # Per-shape BLOCK_SIZE & kernel variant. Single-chunk uses the SC kernel
+        # (re-gather, lower live-tile pressure); multi-chunk uses the fold-accumulator kernel.
+        # n_cols=2048 keeps BLOCK=1024 (multi-chunk) because BLOCK=2048 single-chunk
+        # spills the 3 fp32 accumulators (sum_sq_3/2/1).
+        if n_cols <= 1024:
+            BLOCK_SIZE = next_power_of_2(n_cols)
+        elif n_cols == 2048:
+            BLOCK_SIZE = 1024
+        elif n_cols <= 8192:
+            BLOCK_SIZE = 4096
+        else:
+            BLOCK_SIZE = min(MAX_FUSED_SIZE, next_power_of_2(n_cols))
+        aligned = (n_cols % BLOCK_SIZE) == 0
+        single_chunk = n_cols <= BLOCK_SIZE
+
+        if n_cols <= 1024:
+            fwd_kernel = _poly_norm_fwd_kernel_sc_large_occ16
+        elif n_cols == 2048:
+            fwd_kernel = _poly_norm_fwd_kernel
+        elif n_cols == 4096:
+            fwd_kernel = _poly_norm_fwd_kernel_sc_large_occ8
+        elif n_cols <= 8192:
+            fwd_kernel = _poly_norm_fwd_kernel_occ8
+        elif single_chunk:
+            fwd_kernel = _poly_norm_fwd_kernel_sc_large_occ4
+        else:
+            fwd_kernel = _poly_norm_fwd_kernel
+
+        Y = torch.empty_like(X_2d)
+        RSTD3 = torch.empty(n_rows, dtype=torch.float32, device=X.device)
+        RSTD2 = torch.empty(n_rows, dtype=torch.float32, device=X.device)
+        RSTD1 = torch.empty(n_rows, dtype=torch.float32, device=X.device)
+
+        grid = (n_rows, 1, 1)
+        ct.launch(
+            torch.cuda.current_stream(),
+            grid,
+            fwd_kernel,
+            (
+                X_2d,
+                Y,
+                W.contiguous(),
+                B.contiguous(),
+                RSTD3,
+                RSTD2,
+                RSTD1,
+                int(n_cols),
+                float(eps),
+                int(BLOCK_SIZE),
+                bool(aligned),
+            ),
+        )
+
+        ctx.save_for_backward(X_2d, W, RSTD3, RSTD2, RSTD1)
+        ctx.BLOCK_SIZE = BLOCK_SIZE
+        ctx.aligned = aligned
+        ctx.shape = shape
+        ctx.bias_shape = bias_shape
+
+        return Y.view(*shape)
+
+    @staticmethod
+    def backward(ctx, dy):
+        X_2d, W, RSTD3, RSTD2, RSTD1 = ctx.saved_tensors
+        shape = ctx.shape
+
+        dim = shape[-1]
+        dY_2d = dy.contiguous().view(-1, dim)
+        n_rows, n_cols = dY_2d.shape
+
+        # Bwd has 4 fp32 accumulators (S_3, S_2, S_1, dB) of BLOCK_SIZE each.
+        # Cap BLOCK_SIZE at 4096 to keep accumulators in registers (16KB per tile)
+        # and avoid spills observed at BLOCK_SIZE >= 16384 on norm-like bwd kernels.
+        BWD_MAX_BLOCK = 4096
+        BLOCK_SIZE = min(BWD_MAX_BLOCK, next_power_of_2(n_cols))
+        aligned = (n_cols % BLOCK_SIZE) == 0
+
+        dx = torch.empty_like(dY_2d)
+        # The kernel atomically accumulates dW/dB contributions across all rows
+        # directly into this 4-element fp32 buffer — eliminates the host-side
+        # .sum(dim=1) + .to(W.dtype) launch chain.
+        dwdb_output = torch.zeros(4, dtype=torch.float32, device=W.device)
+
+        # Medium/large-N (n_cols>=8192) is latency-bound on the 2-pass multi-chunk
+        # IR; the occ=4/nww=8 variant closes the gap.
+        kernel_choice = _poly_norm_bwd_kernel_large if n_cols >= 8192 else _poly_norm_bwd_kernel
+
+        grid = (n_rows, 1, 1)
+        ct.launch(
+            torch.cuda.current_stream(),
+            grid,
+            kernel_choice,
+            (
+                dY_2d,
+                dx,
+                X_2d,
+                W,
+                RSTD3,
+                RSTD2,
+                RSTD1,
+                dwdb_output,
+                int(n_cols),
+                int(BLOCK_SIZE),
+                bool(aligned),
+            ),
+        )
+
+        sums = dwdb_output.to(W.dtype)  # (4,) cast to W.dtype
+        dW = sums[:3]
+        dB = sums[3:4].reshape(ctx.bias_shape)  # match B's original shape (scalar or (1,))
+
+        return dx.view(*shape), dW, dB, None
+
+
+@register_impl("liger.poly_norm", backend="cutile")
+def poly_norm(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    eps: float = 1e-6,
+    **kwargs,
+) -> torch.Tensor:
+    """
+    PolyNorm normalization (CuTile backend).
+
+    Args:
+        input: Input tensor of shape (*, H)
+        weight: Weight tensor of shape (3,) for [w0, w1, w2]
+        bias: Scalar bias tensor of shape (1,)
+        eps: Epsilon for numerical stability. Default: 1e-6
+
+    Returns:
+        Output tensor of same shape as input
+    """
+    return PolyNormCuTileFunction.apply(input, weight, bias, eps)

--- a/src/tilegym/suites/liger/cutile/qwen2vl_mrope.py
+++ b/src/tilegym/suites/liger/cutile/qwen2vl_mrope.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-# Adapted from https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/qwen2vl_mrope.py
-
 """
 Qwen2VL Multimodal Rotary Position Embedding (M-RoPE) kernel (CuTile backend).
 
@@ -100,15 +98,18 @@ def _qwen2vl_mrope_kernel(
     if BACKWARD:
         sin_row = -sin_row
 
-    cos_q = cos_row.astype(query.dtype)
-    sin_q = sin_row.astype(query.dtype)
-    new_q_r = q_r * cos_q - q_i * sin_q
-    new_q_i = q_i * cos_q + q_r * sin_q
+    # Rotate in fp32 (cos_row/sin_row are fp32) and round only the final result,
+    # Casting cos/sin down to bf16 first would
+    # round the intermediate product/subtraction and fail bf16 tolerance.
+    q_r_f = q_r.astype(ct.float32)
+    q_i_f = q_i.astype(ct.float32)
+    new_q_r = (q_r_f * cos_row - q_i_f * sin_row).astype(query.dtype)
+    new_q_i = (q_i_f * cos_row + q_r_f * sin_row).astype(query.dtype)
 
     # Reuse Q's cos_row when FLAT_K <= FLAT (common case: TILE_KH <= TILE_QH).
     if TILE_KH <= TILE_QH:
-        cos_k = ct.extract(cos_row, (0,), shape=(FLAT_K,)).astype(key.dtype)
-        sin_k = ct.extract(sin_row, (0,), shape=(FLAT_K,)).astype(key.dtype)
+        cos_k = ct.extract(cos_row, (0,), shape=(FLAT_K,))
+        sin_k = ct.extract(sin_row, (0,), shape=(FLAT_K,))
     else:
         t_idx_k = k_flat_col + token_cs_off
         h_idx_k = t_idx_k + slab_stride
@@ -125,10 +126,13 @@ def _qwen2vl_mrope_kernel(
         sin_k_raw = ct.where(in_t_k, t_sin_k, ct.where(in_h_k, h_sin_k, w_sin_k))
         if BACKWARD:
             sin_k_raw = -sin_k_raw
-        cos_k = cos_k_raw.astype(key.dtype)
-        sin_k = sin_k_raw.astype(key.dtype)
-    new_k_r = k_r * cos_k - k_i * sin_k
-    new_k_i = k_i * cos_k + k_r * sin_k
+        cos_k = cos_k_raw
+        sin_k = sin_k_raw
+    # Rotate in fp32 (cos_k/sin_k are fp32), round only the final result.
+    k_r_f = k_r.astype(ct.float32)
+    k_i_f = k_i.astype(ct.float32)
+    new_k_r = (k_r_f * cos_k - k_i_f * sin_k).astype(key.dtype)
+    new_k_i = (k_i_f * cos_k + k_r_f * sin_k).astype(key.dtype)
     ct.scatter(query, q_r_idx, new_q_r, mask=q_mask, check_bounds=False, latency=1)
     ct.scatter(query, q_i_idx, new_q_i, mask=q_mask, check_bounds=False, latency=1)
     ct.scatter(key, k_r_idx, new_k_r, mask=k_mask, check_bounds=False, latency=1)

--- a/src/tilegym/suites/liger/cutile/rms_norm.py
+++ b/src/tilegym/suites/liger/cutile/rms_norm.py
@@ -1,0 +1,429 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+RMS Normalization kernel (CuTile backend).
+
+Y = X / RMS(X) * (W + offset), RMS = sqrt(mean(x^2) + eps).
+
+Forward kernel: row-parallel (one block per row), single pass.
+  col_idx = arange(BLOCK_SIZE); gather X (check_bounds=True pads OOB to 0),
+  compute rstd, scatter Y.
+
+Backward kernel: SM-count partitioned, single DRAM pass per row (all BLOCK_SIZE).
+  - W loaded once per block; dW accumulated in registers, scattered once at end.
+  - dW_partial shape: (sm_count, n_cols) instead of (n_rows, n_cols).
+
+Casting modes:
+  - "llama" (0): X cast to fp32 for RMS; X*rstd cast BACK to X.dtype before W multiply.
+                 RSTD stored as fp32.
+  - "gemma" (1): Both X and W cast to fp32; Y cast back to X.dtype.
+                 RSTD stored as fp32.
+  - "none" (-1): No casting. Everything in X.dtype. RSTD stored in X.dtype.
+"""
+
+import math
+
+import cuda.tile as ct
+import torch
+
+from tilegym.backend import register_impl
+
+from .utils import next_power_of_2
+
+_CASTING_MODE_NONE = -1
+_CASTING_MODE_LLAMA = 0
+_CASTING_MODE_GEMMA = 1
+
+_str_to_casting_mode = {
+    "llama": _CASTING_MODE_LLAMA,
+    "gemma": _CASTING_MODE_GEMMA,
+    "none": _CASTING_MODE_NONE,
+}
+
+
+def _calculate_settings(n_cols):
+    BLOCK_SIZE = next_power_of_2(n_cols)
+    if BLOCK_SIZE > 65536:
+        raise RuntimeError(f"Feature dimension {n_cols} exceeds maximum supported (65536)")
+    return BLOCK_SIZE
+
+
+# ---------------------------------------------------------------------------
+# Forward kernel (row-parallel)
+# ---------------------------------------------------------------------------
+
+
+@ct.kernel
+def _rms_norm_fwd_ct(
+    Y,  # (n_rows, n_cols) output
+    X,  # (n_rows, n_cols) input
+    W,  # (n_cols,) affine weight (dummy 1-element tensor when elementwise_affine=False)
+    RSTD,  # (n_rows,) cached rstd
+    n_cols,
+    eps,  # runtime float
+    offset,  # runtime float
+    BLOCK_SIZE: ct.Constant[int],
+    casting_mode: ct.Constant[int],
+    elementwise_affine: ct.Constant[bool],
+):
+    """
+    RMS norm forward (unified, single pass).
+
+    Row-parallel forward pass:
+      col_idx = arange(BLOCK_SIZE)   # BLOCK_SIZE = next_power_of_2(n_cols)
+      load X (check_bounds=True → OOB elements zero-padded, harmless for RMS sum)
+      compute rstd, store RSTD
+      scale X; optionally multiply by (W + offset)
+      store Y
+
+    elementwise_affine is a compile-time constant — the W gather/multiply is
+    dead-code-eliminated when False, so the no-weight path has zero overhead.
+
+    casting_mode:
+      llama (0): X cast to fp32 for RMS; X*rstd cast BACK to X.dtype before W multiply.
+      gemma (1): Both X and W cast to fp32; Y cast back to X.dtype.
+      none (-1): Compute in X.dtype (no upcast). x*x accumulated in X.dtype;
+        division by n_cols promotes to fp32. eps/offset rounded to X.dtype before
+        arithmetic.
+    """
+    row_idx = ct.bid(0)
+    col_idx = ct.arange(BLOCK_SIZE, dtype=ct.int32)
+
+    if casting_mode == _CASTING_MODE_NONE:
+        x_val = ct.gather(X, (row_idx, col_idx), check_bounds=True, padding_value=0.0)
+        if elementwise_affine:
+            w_val = ct.gather(W, col_idx, check_bounds=True, padding_value=0.0)
+        mean_sq = ct.astype(ct.sum(x_val * x_val, 0, keepdims=False), ct.float32) / n_cols
+        eps_rounded = ct.astype(ct.astype(eps, x_val.dtype), ct.float32)
+        rstd = ct.rsqrt(mean_sq + eps_rounded)  # fp32
+        ct.scatter(RSTD, row_idx, ct.astype(rstd, x_val.dtype), check_bounds=False)
+        x_scaled = ct.astype(x_val, ct.float32) * rstd  # fp32 (upcast x for RMS computation)
+        if elementwise_affine:
+            offset_native = ct.astype(offset, x_val.dtype)  # round offset to X.dtype precision
+            w_plus_offset_f32 = ct.astype(w_val + offset_native, ct.float32)
+            ct.scatter(Y, (row_idx, col_idx), ct.astype(x_scaled * w_plus_offset_f32, x_val.dtype), check_bounds=True)
+        else:
+            ct.scatter(Y, (row_idx, col_idx), ct.astype(x_scaled, x_val.dtype), check_bounds=True)
+
+    elif casting_mode == _CASTING_MODE_LLAMA:
+        x_val = ct.gather(X, (row_idx, col_idx), check_bounds=True, padding_value=0.0)
+        if elementwise_affine:
+            w_val = ct.gather(W, col_idx, check_bounds=True, padding_value=0.0)
+        x_f32 = ct.astype(x_val, ct.float32)
+        mean_sq = ct.sum(ct.mul(x_f32, x_f32, flush_to_zero=True), 0, keepdims=False) / n_cols
+        rstd = ct.rsqrt(mean_sq + eps)
+        ct.scatter(RSTD, row_idx, rstd, check_bounds=False)
+        # Cast X*rstd back to X.dtype before W multiply (llama behaviour)
+        x_scaled = ct.astype(x_f32 * rstd, X.dtype)
+        if elementwise_affine:
+            ct.scatter(Y, (row_idx, col_idx), ct.astype(x_scaled * (w_val + offset), Y.dtype), check_bounds=True)
+        else:
+            ct.scatter(Y, (row_idx, col_idx), ct.astype(x_scaled, Y.dtype), check_bounds=True)
+
+    else:
+        # gemma: both X and W to fp32, Y cast back to X.dtype
+        x_f32 = ct.astype(ct.gather(X, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+        if elementwise_affine:
+            w_f32 = ct.astype(ct.gather(W, col_idx, check_bounds=True, padding_value=0.0), ct.float32)
+        mean_sq = ct.sum(x_f32 * x_f32, 0, keepdims=False) / n_cols
+        rstd = ct.rsqrt(mean_sq + eps)
+        ct.scatter(RSTD, row_idx, rstd, check_bounds=False)
+        x_scaled = x_f32 * rstd
+        if elementwise_affine:
+            ct.scatter(Y, (row_idx, col_idx), ct.astype(x_scaled * (w_f32 + offset), Y.dtype), check_bounds=True)
+        else:
+            ct.scatter(Y, (row_idx, col_idx), ct.astype(x_scaled, Y.dtype), check_bounds=True)
+
+
+_rms_norm_fwd_large_ct = _rms_norm_fwd_ct.replace_hints(num_worker_warps=8)
+
+
+# ---------------------------------------------------------------------------
+# Backward kernels — SM-count grid, single DRAM pass
+# ---------------------------------------------------------------------------
+
+
+@ct.kernel
+def _rms_norm_bwd_large_ct(
+    dY,  # (n_rows, n_cols) upstream gradient
+    dX,  # (n_rows, n_cols) output gradient
+    X,  # (n_rows, n_cols) saved input
+    RSTD,  # (n_rows,) cached rstd; OOB-safe via bounds-checked gather
+    n_cols: ct.Constant[int],
+    rows_per_program: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    casting_mode: ct.Constant[int],
+):
+    """
+    RMS norm backward without affine weight. SM-count partitioned, single DRAM pass.
+
+    Grid: (sm_count,). Block b processes rows [b*rpp, (b+1)*rpp).
+    Single pass: load dY and X once; sum_mX via register reduction; no re-read.
+    OOB rows return 0 via check_bounds; RSTD zero-padded for safe scalar load.
+    """
+    block_id = ct.bid(0)
+    col_idx = ct.arange(BLOCK_SIZE, dtype=ct.int32)
+    inv_n_cols = 1.0 / n_cols
+
+    for ri in range(rows_per_program):
+        row_idx = block_id * rows_per_program + ri
+
+        rstd = ct.astype(ct.gather(RSTD, (row_idx,), padding_value=0.0).item(), ct.float32)
+        dy_f32 = ct.astype(
+            ct.gather(dY, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=3), ct.float32
+        )
+        x_f32 = ct.astype(ct.gather(X, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=3), ct.float32)
+
+        sum_mX = ct.sum(dy_f32 * x_f32, 0, keepdims=False)
+        coeff = rstd * rstd * rstd * inv_n_cols * sum_mX
+        dx_f32 = rstd * dy_f32 - coeff * x_f32
+        ct.scatter(dX, (row_idx, col_idx), ct.astype(dx_f32, dX.dtype), check_bounds=True)
+
+
+@ct.kernel
+def _rms_norm_bwd_w_large_ct(
+    dY,  # (n_rows, n_cols) upstream gradient
+    dX,  # (n_rows, n_cols) output gradient
+    X,  # (n_rows, n_cols) saved input
+    W,  # (n_cols,) affine weight
+    RSTD,  # (n_rows,) cached rstd; OOB-safe via bounds-checked gather
+    dW_partial,  # (sm_count, n_cols) per-block dW accumulation (host reduces)
+    n_cols: ct.Constant[int],
+    offset: ct.Constant[float],
+    rows_per_program: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    casting_mode: ct.Constant[int],
+):
+    """
+    RMS norm backward with affine weight. SM-count partitioned, single DRAM pass.
+
+    Grid: (sm_count,). Block b processes rows [b*rpp, (b+1)*rpp).
+    W loaded once per block and reused across all rows.
+    dW accumulated in registers throughout the row loop; scattered once at the end.
+    dW_partial shape: (sm_count, n_cols) — vastly smaller than (n_rows, n_cols).
+    OOB rows return 0 via check_bounds; RSTD zero-padded.
+
+    casting_mode:
+      llama (0): load W in original dtype once; per row: dY in orig dtype,
+                 m = (dY*(W+offset)) cast to fp32; dW += dy_orig*(X*rstd cast to X.dtype).
+      gemma (1): W loaded in fp32; per row: dY in fp32, m = dy_f32*(w_f32+offset);
+                 dW += dy_f32 * x_f32 * rstd.
+      none (-1): load W in original dtype once; per row: dY in orig dtype,
+                 m = dy_orig*(w_orig+offset) without cast to fp32 (cast for sum);
+                 dW += dy_orig * (x_orig * rstd) without extra fp32 cast.
+    """
+    block_id = ct.bid(0)
+    col_idx = ct.arange(BLOCK_SIZE, dtype=ct.int32)
+
+    # Per-block dW accumulator in registers; scattered to dW_partial once at end
+    dW_acc = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+    inv_n_cols = 1.0 / n_cols
+
+    # Load W once; dtype depends on mode (gemma keeps fp32; llama/none keep original).
+    if casting_mode == _CASTING_MODE_GEMMA:
+        w_f32 = ct.astype(ct.gather(W, col_idx, check_bounds=True, padding_value=0.0), ct.float32)
+    else:
+        w_orig = ct.gather(W, col_idx, check_bounds=True, padding_value=0.0)
+
+    for ri in range(rows_per_program):
+        row_idx = block_id * rows_per_program + ri
+
+        # Bounds-checked scalar read on RSTD (avoids host-side cat-padding).
+        rstd = ct.astype(ct.gather(RSTD, (row_idx,), padding_value=0.0).item(), ct.float32)
+        x_f32 = ct.astype(ct.gather(X, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=3), ct.float32)
+
+        if casting_mode == _CASTING_MODE_GEMMA:
+            dy_f32 = ct.astype(
+                ct.gather(dY, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=3), ct.float32
+            )
+            m_f32 = dy_f32 * (w_f32 + offset)
+            dW_term_f32 = dy_f32 * x_f32 * rstd
+        else:
+            dy_orig = ct.gather(dY, (row_idx, col_idx), check_bounds=True, padding_value=0.0, latency=3)
+            m_f32 = ct.astype(dy_orig * (w_orig + offset), ct.float32)
+            if casting_mode == _CASTING_MODE_LLAMA:
+                # x*rstd computed in fp32, then downcast for the dy multiply
+                dW_term_f32 = ct.astype(dy_orig * ct.astype(x_f32 * rstd, dY.dtype), ct.float32)
+            else:
+                # none: downcast x first, then multiply by rstd (mixed-precision)
+                x_orig = ct.astype(x_f32, dY.dtype)
+                dW_term_f32 = ct.astype(dy_orig * (x_orig * rstd), ct.float32)
+
+        sum_mX = ct.sum(m_f32 * x_f32, 0, keepdims=False)
+        coeff = rstd * rstd * rstd * inv_n_cols * sum_mX
+        dx_f32 = rstd * m_f32 - coeff * x_f32
+        ct.scatter(dX, (row_idx, col_idx), ct.astype(dx_f32, dX.dtype), check_bounds=True)
+
+        # OOB rows contribute 0 (dy=0, x=0 via check_bounds)
+        dW_acc = ct.add(dW_acc, dW_term_f32)
+
+    # Write this block's partial dW once (block_id < sm_count, always in-bounds)
+    ct.scatter(dW_partial, (block_id, col_idx), dW_acc, check_bounds=True)
+
+
+_rms_norm_bwd_large_ct_nww8 = _rms_norm_bwd_large_ct.replace_hints(num_worker_warps=8)
+_rms_norm_bwd_w_large_ct_nww8 = _rms_norm_bwd_w_large_ct.replace_hints(num_worker_warps=8)
+
+
+# ---------------------------------------------------------------------------
+# Python launch wrappers
+# ---------------------------------------------------------------------------
+
+
+def _rms_norm_forward_ct(X, W, eps, offset, casting_mode_int):
+    shape = X.shape
+    dim = shape[-1]
+    X2d = X.view(-1, dim).contiguous()
+    n_rows, n_cols = X2d.shape
+    BLOCK_SIZE = _calculate_settings(n_cols)
+
+    Y = torch.empty_like(X2d)
+    # RSTD dtype: fp32 for llama/gemma, X.dtype for none
+    rstd_dtype = torch.float32 if casting_mode_int in (_CASTING_MODE_LLAMA, _CASTING_MODE_GEMMA) else X.dtype
+    RSTD = torch.empty(n_rows, dtype=rstd_dtype, device=X.device)
+    elementwise_affine = W is not None
+
+    grid = (n_rows, 1, 1)
+    # When no weight, pass a 1-element dummy tensor; elementwise_affine=False causes the compiler
+    # to dead-code-eliminate every ct.gather(W, ...) so the dummy is never accessed.
+    W_tensor = W.contiguous() if elementwise_affine else X2d.new_empty(1)
+    fwd_kernel = _rms_norm_fwd_large_ct if BLOCK_SIZE >= 16384 else _rms_norm_fwd_ct
+    ct.launch(
+        torch.cuda.current_stream(),
+        grid,
+        fwd_kernel,
+        (
+            Y,
+            X2d,
+            W_tensor,
+            RSTD,
+            int(n_cols),
+            float(eps),
+            float(offset) if elementwise_affine else 0.0,
+            int(BLOCK_SIZE),
+            int(casting_mode_int),
+            bool(elementwise_affine),
+        ),
+    )
+
+    return Y.view(*shape), X2d, RSTD, int(BLOCK_SIZE)
+
+
+def _rms_norm_backward_ct(dY, X, W, RSTD, offset, BLOCK_SIZE, casting_mode_int, in_place):
+    shape = dY.shape
+    dim = shape[-1]
+    dY2d = dY.view(-1, dim).contiguous()
+    n_rows, n_cols = dY2d.shape
+    elementwise_affine = W is not None
+
+    sm_count = torch.cuda.get_device_properties(X.device).multi_processor_count
+    rows_per_program = math.ceil(n_rows / sm_count)
+    grid = (sm_count, 1, 1)
+
+    # When in_place=True, reuse dY2d buffer in-place for dX (safe: each row is processed
+    # independently, and within a row the load precedes the store in every kernel pass).
+    dX = dY2d if in_place else torch.zeros_like(dY2d)
+
+    if elementwise_affine:
+        # Every (block_id, col) in dW_partial is written exactly once by the scatter at
+        # kernel end, so zero-init is unnecessary.
+        dW_partial = torch.empty(sm_count, n_cols, dtype=torch.float32, device=W.device)
+        # Larger hidden dims spill registers under the default nww=4; nww=8 fixes that.
+        bwd_w_kernel = _rms_norm_bwd_w_large_ct_nww8 if BLOCK_SIZE >= 8192 else _rms_norm_bwd_w_large_ct
+        ct.launch(
+            torch.cuda.current_stream(),
+            grid,
+            bwd_w_kernel,
+            (
+                dY2d,
+                dX,
+                X.contiguous(),
+                W.contiguous(),
+                RSTD,
+                dW_partial,
+                int(n_cols),
+                float(offset),
+                int(rows_per_program),
+                int(BLOCK_SIZE),
+                int(casting_mode_int),
+            ),
+        )
+        dW = dW_partial.sum(dim=0).to(W.dtype)
+    else:
+        bwd_kernel = _rms_norm_bwd_large_ct_nww8 if BLOCK_SIZE >= 8192 else _rms_norm_bwd_large_ct
+        ct.launch(
+            torch.cuda.current_stream(),
+            grid,
+            bwd_kernel,
+            (
+                dY2d,
+                dX,
+                X.contiguous(),
+                RSTD,
+                int(n_cols),
+                int(rows_per_program),
+                int(BLOCK_SIZE),
+                int(casting_mode_int),
+            ),
+        )
+        dW = None
+
+    return dX.view(*shape), dW
+
+
+class RMSNormCuTileFunction(torch.autograd.Function):
+    """CuTile autograd wrapper for RMS normalization."""
+
+    @staticmethod
+    def forward(ctx, X, W, eps, offset, casting_mode, in_place, row_mode):
+        X = X.contiguous()
+        if W is not None:
+            W = W.contiguous()
+
+        # Resolve casting_mode string → int
+        if isinstance(casting_mode, int):
+            casting_mode_int = casting_mode
+        else:
+            assert casting_mode in _str_to_casting_mode, f"Invalid casting_mode: {casting_mode}"
+            casting_mode_int = _str_to_casting_mode[casting_mode]
+
+        Y, X_saved, RSTD, BLOCK_SIZE = _rms_norm_forward_ct(X, W, eps, offset, casting_mode_int)
+
+        ctx.offset = offset
+        ctx.casting_mode = casting_mode_int
+        ctx.in_place = in_place
+        ctx.BLOCK_SIZE = BLOCK_SIZE
+        ctx.elementwise_affine = W is not None
+        if W is not None:
+            ctx.save_for_backward(X_saved, W, RSTD)
+        else:
+            ctx.save_for_backward(X_saved, RSTD)
+        return Y
+
+    @staticmethod
+    def backward(ctx, dY):
+        dY = dY.contiguous()
+        if ctx.elementwise_affine:
+            X, W, RSTD = ctx.saved_tensors
+        else:
+            X, RSTD = ctx.saved_tensors
+            W = None
+
+        dX, dW = _rms_norm_backward_ct(dY, X, W, RSTD, ctx.offset, ctx.BLOCK_SIZE, ctx.casting_mode, ctx.in_place)
+        return dX, dW, None, None, None, None, None
+
+
+@register_impl("liger.rms_norm", backend="cutile")
+def rms_norm(
+    X: torch.Tensor,
+    W,
+    eps: float,
+    offset: float = 0.0,
+    casting_mode: str = "llama",
+    in_place: bool = True,
+    row_mode=None,
+    **kwargs,
+) -> torch.Tensor:
+    return RMSNormCuTileFunction.apply(X, W, eps, offset, casting_mode, in_place, row_mode)

--- a/src/tilegym/suites/liger/cutile/softmax.py
+++ b/src/tilegym/suites/liger/cutile/softmax.py
@@ -1,0 +1,352 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Softmax kernel (CuTile backend).
+
+Row-wise softmax with an exp2-based online formulation. Two regimes, all autotuned
+(occupancy + num_worker_warps) and cached per shape:
+  - single-chunk: whole row in one tile. f32 uses a TMA load; bf16/fp16 use gather (aligned
+    fast path when n_cols is a power of 2).
+  - multi-chunk: 2-pass online softmax that re-reads the row; block size chosen for L2 reuse.
+
+The single-chunk threshold and multi-chunk block size both differ by direction. Forward (light:
+max/sum/exp/div) scales to a 32768 tile; backward (holds y+dy+dot+dx) spills past 16384, so larger
+rows use the multi-chunk path. The multi-chunk backward re-read is L2-bound, so it uses a larger
+block (8192 vs the forward's 4096) to shrink the pass1->pass2 gap. Backward: dx = y*(dy - dot),
+dot = sum(y*dy).
+
+Grid: (n_rows, 1, 1) — row-parallel.
+"""
+
+import math
+from types import SimpleNamespace
+
+import cuda.tile as ct
+import torch
+from cuda.tile.tune import exhaustive_search
+
+from tilegym.backend import register_impl
+
+from .utils import next_power_of_2
+
+INV_LOG2 = 1.0 / math.log(2)
+
+# Single-chunk handles the whole row in one tile. Forward is light (max/sum/exp/div over one
+# tile) and scales to a 32768 tile; backward holds y+dy+dot+dx and spills past 16384, so it
+# uses a lower threshold and routes larger rows to the (autotuned) multi-chunk online loop.
+_SINGLE_CHUNK_MAX_N_FWD = 32768
+_SINGLE_CHUNK_MAX_N_BWD = 16384
+
+# Forward autotune: exp2+APPROX kernel has different register profile; nww=8/occ>=5
+# cause register spills at large N. Safe space: occ=[2,3,4], nww=4 only.
+_SOFTMAX_FWD_TUNE_CONFIGS = [SimpleNamespace(occ=o, nww=4) for o in [2, 3, 4]]
+
+# Backward autotune: no exp, lighter register pressure — nww=8 beneficial at large N.
+_SOFTMAX_BWD_TUNE_CONFIGS = [SimpleNamespace(occ=o, nww=n) for o in [2, 3, 4, 5, 6, 8] for n in [4, 8]]
+_MULTI_CHUNK_BLOCK_SIZE_FWD = 4096
+_MULTI_CHUNK_BLOCK_SIZE_BWD = 8192
+_SOFTMAX_MULTI_TUNE_CONFIGS = [SimpleNamespace(occ=o, nww=n) for o in [2, 3, 4, 6, 8] for n in [4, 8]]
+
+# Per-process cache: (path, n_cols, BLOCK_SIZE[, aligned]) -> tuned kernel
+_SOFTMAX_FWD_TUNE_CACHE: dict = {}
+_SOFTMAX_BWD_TUNE_CACHE: dict = {}
+_SOFTMAX_MULTI_TUNE_CACHE: dict = {}
+
+
+# ---------------------------------------------------------------------------
+# Single-chunk forward kernels (plain functions, wrapped by ct.kernel below).
+# No hardcoded occupancy — autotuned at runtime.
+# ---------------------------------------------------------------------------
+
+
+@ct.kernel
+def _softmax_single_tma(Y, X, n_cols: ct.Constant[int], BLOCK_SIZE: ct.Constant[int]):
+    """f32, TMA load with NEG_INF padding. Scatter for write (check_bounds=True handles tail)."""
+    row_idx = ct.bid(0)
+    x_tile = ct.astype(
+        ct.load(X, index=(row_idx, 0), shape=(1, BLOCK_SIZE), padding_mode=ct.PaddingMode.NEG_INF).reshape(
+            (BLOCK_SIZE,)
+        ),
+        ct.float32,
+    )
+    global_max = ct.max(x_tile, 0, keepdims=False)
+    exp_tile = ct.exp2(ct.mul(x_tile - global_max, INV_LOG2, flush_to_zero=True), flush_to_zero=True)
+    y_tile = ct.truediv(
+        exp_tile, ct.sum(exp_tile, 0, keepdims=False), rounding_mode=ct.RoundingMode.APPROX, flush_to_zero=True
+    )
+    ct.scatter(Y, (row_idx, ct.arange(BLOCK_SIZE, dtype=ct.int32)), ct.astype(y_tile, Y.dtype), check_bounds=True)
+
+
+@ct.kernel
+def _softmax_single_gather(Y, X, n_cols: ct.Constant[int], BLOCK_SIZE: ct.Constant[int], ALIGNED: ct.Constant[bool]):
+    """bf16/fp16. ALIGNED=True: check_bounds=False (power-of-2 n_cols). ALIGNED=False: padded gather."""
+    row_idx = ct.bid(0)
+    col_idx = ct.arange(BLOCK_SIZE, dtype=ct.int32)
+    if ALIGNED:
+        x_tile = ct.astype(ct.gather(X, (row_idx, col_idx), check_bounds=False), ct.float32)
+    else:
+        x_tile = ct.astype(ct.gather(X, (row_idx, col_idx), check_bounds=True, padding_value=-math.inf), ct.float32)
+    global_max = ct.max(x_tile, 0, keepdims=False)
+    exp_tile = ct.exp2(ct.mul(x_tile - global_max, INV_LOG2, flush_to_zero=True), flush_to_zero=True)
+    y_tile = ct.truediv(
+        exp_tile, ct.sum(exp_tile, 0, keepdims=False), rounding_mode=ct.RoundingMode.APPROX, flush_to_zero=True
+    )
+    if ALIGNED:
+        ct.scatter(Y, (row_idx, col_idx), ct.astype(y_tile, Y.dtype), check_bounds=False)
+    else:
+        ct.scatter(Y, (row_idx, col_idx), ct.astype(y_tile, Y.dtype), check_bounds=True)
+
+
+def _get_tuned_single_kernel(n_cols: int, BLOCK_SIZE: int, n_rows: int, dtype: torch.dtype, stream, y2d, x2d):
+    """Autotune occupancy+nww on first call; return cached kernel on subsequent calls."""
+    is_tma = dtype == torch.float32
+    is_aligned = n_cols == BLOCK_SIZE
+
+    if is_tma:
+        key = ("tma", n_cols, BLOCK_SIZE)
+        base, args_fn = _softmax_single_tma, lambda cfg: (y2d, x2d, int(n_cols), int(BLOCK_SIZE))
+    else:
+        key = ("gather", n_cols, BLOCK_SIZE, is_aligned)
+        base = _softmax_single_gather
+        args_fn = lambda cfg: (y2d, x2d, int(n_cols), int(BLOCK_SIZE), is_aligned)
+
+    if key in _SOFTMAX_FWD_TUNE_CACHE:
+        return _SOFTMAX_FWD_TUNE_CACHE[key]
+
+    result = exhaustive_search(
+        _SOFTMAX_FWD_TUNE_CONFIGS,
+        stream,
+        lambda cfg: (n_rows, 1, 1),
+        base,
+        args_fn,
+        lambda cfg: {"occupancy": cfg.occ, "num_worker_warps": cfg.nww},
+        quiet=True,
+    )
+    best = result.best.config
+    _SOFTMAX_FWD_TUNE_CACHE[key] = base.replace_hints(occupancy=best.occ, num_worker_warps=best.nww)
+    return _SOFTMAX_FWD_TUNE_CACHE[key]
+
+
+# ---------------------------------------------------------------------------
+# Multi-chunk forward kernel (n_cols > _SINGLE_CHUNK_MAX_N)
+# ---------------------------------------------------------------------------
+
+
+@ct.kernel
+def _softmax_fwd_ct(Y, X, n_cols: ct.Constant[int], BLOCK_SIZE: ct.Constant[int]):
+    """2-pass online softmax. BLOCK_SIZE=4096 caps register pressure regardless of n_cols."""
+    row_idx = ct.bid(0)
+    n_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    running_max = ct.full((1,), -math.inf, dtype=ct.float32)
+    running_sum = ct.full((1,), 0.0, dtype=ct.float32)
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+        x_tile = ct.astype(ct.gather(X, (row_idx, col_idx), check_bounds=True, padding_value=-math.inf), ct.float32)
+        blk_max = ct.max(x_tile, 0, keepdims=True)
+        new_max = ct.maximum(running_max, blk_max)
+        running_sum = running_sum * ct.exp2((running_max - new_max) * INV_LOG2) + ct.sum(
+            ct.exp2((x_tile - new_max) * INV_LOG2), 0, keepdims=True
+        )
+        running_max = new_max
+
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+        x_tile = ct.astype(ct.gather(X, (row_idx, col_idx), check_bounds=True, padding_value=-math.inf), ct.float32)
+        y_tile = ct.exp2((x_tile - running_max) * INV_LOG2) / running_sum
+        ct.scatter(Y, (row_idx, col_idx), ct.astype(y_tile, Y.dtype), check_bounds=True)
+
+
+# ---------------------------------------------------------------------------
+# Backward kernels
+# ---------------------------------------------------------------------------
+
+
+@ct.kernel
+def _softmax_bwd_ct(DX, DY, Y, n_cols: ct.Constant[int], BLOCK_SIZE: ct.Constant[int], ALIGNED: ct.Constant[bool]):
+    """Multi-chunk backward. dx = y * (dy - dot), dot = sum(y*dy). 2-pass fold."""
+    row_idx = ct.bid(0)
+    n_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    dot_tile = ct.full((BLOCK_SIZE,), 0.0, dtype=ct.float32)
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+        if ALIGNED:
+            y_tile = ct.astype(ct.gather(Y, (row_idx, col_idx), check_bounds=False), ct.float32)
+            dy_tile = ct.astype(ct.gather(DY, (row_idx, col_idx), check_bounds=False), ct.float32)
+        else:
+            y_tile = ct.astype(ct.gather(Y, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+            dy_tile = ct.astype(ct.gather(DY, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+        dot_tile = ct.add(dot_tile, y_tile * dy_tile)
+
+    dot = ct.sum(dot_tile, 0, keepdims=False)
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+        if ALIGNED:
+            y_tile = ct.astype(ct.gather(Y, (row_idx, col_idx), check_bounds=False), ct.float32)
+            dy_tile = ct.astype(ct.gather(DY, (row_idx, col_idx), check_bounds=False), ct.float32)
+            ct.scatter(DX, (row_idx, col_idx), ct.astype(y_tile * (dy_tile - dot), DX.dtype), check_bounds=False)
+        else:
+            y_tile = ct.astype(ct.gather(Y, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+            dy_tile = ct.astype(ct.gather(DY, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+            ct.scatter(DX, (row_idx, col_idx), ct.astype(y_tile * (dy_tile - dot), DX.dtype), check_bounds=True)
+
+
+@ct.kernel
+def _softmax_bwd_fused(DX, DY, Y, n_cols: ct.Constant[int], BLOCK_SIZE: ct.Constant[int], ALIGNED: ct.Constant[bool]):
+    """Single-chunk fused backward: loads Y+DY once, computes dot in registers, then dx.
+
+    ALIGNED=True (power-of-2 n_cols): check_bounds=False eliminates predicate overhead.
+    """
+    row_idx = ct.bid(0)
+    col_idx = ct.arange(BLOCK_SIZE, dtype=ct.int32)
+    if ALIGNED:
+        y_tile = ct.astype(ct.gather(Y, (row_idx, col_idx), check_bounds=False), ct.float32)
+        dy_tile = ct.astype(ct.gather(DY, (row_idx, col_idx), check_bounds=False), ct.float32)
+        dot = ct.sum(y_tile * dy_tile, 0, keepdims=False)
+        ct.scatter(DX, (row_idx, col_idx), ct.astype(y_tile * (dy_tile - dot), DX.dtype), check_bounds=False)
+    else:
+        y_tile = ct.astype(ct.gather(Y, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+        dy_tile = ct.astype(ct.gather(DY, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+        dot = ct.sum(y_tile * dy_tile, 0, keepdims=False)
+        ct.scatter(DX, (row_idx, col_idx), ct.astype(y_tile * (dy_tile - dot), DX.dtype), check_bounds=True)
+
+
+def _get_tuned_bwd_kernel(n_cols: int, BLOCK_SIZE: int, n_rows: int, dtype: torch.dtype, device):
+    """Autotune occupancy+nww for single-chunk backward; cache by (n_cols, BLOCK_SIZE, aligned)."""
+    is_aligned = n_cols == BLOCK_SIZE
+    key = (n_cols, BLOCK_SIZE, is_aligned)
+    if key in _SOFTMAX_BWD_TUNE_CACHE:
+        return _SOFTMAX_BWD_TUNE_CACHE[key]
+
+    # Use a fresh stream for timing — autograd backward stream is not safe for exhaustive_search.
+    tune_stream = torch.cuda.Stream(device=device)
+    dx = torch.empty(n_rows, BLOCK_SIZE, dtype=dtype, device=device)
+    dy = torch.empty(n_rows, BLOCK_SIZE, dtype=dtype, device=device)
+    y = torch.empty(n_rows, BLOCK_SIZE, dtype=dtype, device=device)
+
+    result = exhaustive_search(
+        _SOFTMAX_BWD_TUNE_CONFIGS,
+        tune_stream,
+        lambda cfg: (n_rows, 1, 1),
+        _softmax_bwd_fused,
+        lambda cfg: (dx, dy, y, int(n_cols), int(BLOCK_SIZE), is_aligned),
+        lambda cfg: {"occupancy": cfg.occ, "num_worker_warps": cfg.nww},
+        quiet=True,
+    )
+    best = result.best.config
+    _SOFTMAX_BWD_TUNE_CACHE[key] = _softmax_bwd_fused.replace_hints(occupancy=best.occ, num_worker_warps=best.nww)
+    return _SOFTMAX_BWD_TUNE_CACHE[key]
+
+
+def _get_tuned_multi_fwd_kernel(n_cols: int, BLOCK_SIZE: int, n_rows: int, stream, y2d, x2d):
+    """Autotune occupancy+nww for the multi-chunk forward; cache by (n_cols, BLOCK_SIZE)."""
+    key = ("multi_fwd", n_cols, BLOCK_SIZE)
+    if key in _SOFTMAX_MULTI_TUNE_CACHE:
+        return _SOFTMAX_MULTI_TUNE_CACHE[key]
+    result = exhaustive_search(
+        _SOFTMAX_MULTI_TUNE_CONFIGS,
+        stream,
+        lambda cfg: (n_rows, 1, 1),
+        _softmax_fwd_ct,
+        lambda cfg: (y2d, x2d, int(n_cols), int(BLOCK_SIZE)),
+        lambda cfg: {"occupancy": cfg.occ, "num_worker_warps": cfg.nww},
+        quiet=True,
+    )
+    best = result.best.config
+    _SOFTMAX_MULTI_TUNE_CACHE[key] = _softmax_fwd_ct.replace_hints(occupancy=best.occ, num_worker_warps=best.nww)
+    return _SOFTMAX_MULTI_TUNE_CACHE[key]
+
+
+def _get_tuned_multi_bwd_kernel(n_cols: int, BLOCK_SIZE: int, n_rows: int, aligned: bool, dtype, device):
+    """Autotune occupancy+nww for the multi-chunk backward; cache by (n_cols, BLOCK_SIZE, aligned)."""
+    key = ("multi_bwd", n_cols, BLOCK_SIZE, aligned)
+    if key in _SOFTMAX_MULTI_TUNE_CACHE:
+        return _SOFTMAX_MULTI_TUNE_CACHE[key]
+    tune_stream = torch.cuda.Stream(device=device)
+    dx = torch.empty(n_rows, n_cols, dtype=dtype, device=device)
+    dy = torch.empty(n_rows, n_cols, dtype=dtype, device=device)
+    y = torch.empty(n_rows, n_cols, dtype=dtype, device=device)
+    result = exhaustive_search(
+        _SOFTMAX_MULTI_TUNE_CONFIGS,
+        tune_stream,
+        lambda cfg: (n_rows, 1, 1),
+        _softmax_bwd_ct,
+        lambda cfg: (dx, dy, y, int(n_cols), int(BLOCK_SIZE), aligned),
+        lambda cfg: {"occupancy": cfg.occ, "num_worker_warps": cfg.nww},
+        quiet=True,
+    )
+    best = result.best.config
+    _SOFTMAX_MULTI_TUNE_CACHE[key] = _softmax_bwd_ct.replace_hints(occupancy=best.occ, num_worker_warps=best.nww)
+    return _SOFTMAX_MULTI_TUNE_CACHE[key]
+
+
+# ---------------------------------------------------------------------------
+# Host-side dispatch
+# ---------------------------------------------------------------------------
+
+
+def _softmax_forward_ct(x: torch.Tensor):
+    *batch, n_cols = x.shape
+    x2d = x.contiguous().view(-1, n_cols)
+    n_rows = x2d.shape[0]
+    y2d = torch.empty_like(x2d)
+    stream = torch.cuda.current_stream()
+
+    if n_cols <= _SINGLE_CHUNK_MAX_N_FWD:
+        BLOCK_SIZE = min(next_power_of_2(n_cols), 65536)
+        is_tma = x2d.dtype == torch.float32
+        is_aligned = n_cols == BLOCK_SIZE
+        kernel = _get_tuned_single_kernel(n_cols, BLOCK_SIZE, n_rows, x2d.dtype, stream, y2d, x2d)
+        if is_tma:
+            ct.launch(stream, (n_rows, 1, 1), kernel, (y2d, x2d, int(n_cols), int(BLOCK_SIZE)))
+        else:
+            ct.launch(stream, (n_rows, 1, 1), kernel, (y2d, x2d, int(n_cols), int(BLOCK_SIZE), is_aligned))
+    else:
+        kernel = _get_tuned_multi_fwd_kernel(n_cols, _MULTI_CHUNK_BLOCK_SIZE_FWD, n_rows, stream, y2d, x2d)
+        ct.launch(stream, (n_rows, 1, 1), kernel, (y2d, x2d, int(n_cols), _MULTI_CHUNK_BLOCK_SIZE_FWD))
+
+    return y2d.view(*batch, n_cols)
+
+
+def _softmax_backward_ct(dy: torch.Tensor, y: torch.Tensor):
+    *batch, n_cols = dy.shape
+    dy2d = dy.contiguous().view(-1, n_cols)
+    y2d = y.contiguous().view(-1, n_cols)
+    n_rows = dy2d.shape[0]
+    dx2d = torch.empty_like(dy2d)
+    stream = torch.cuda.current_stream()
+
+    if n_cols <= _SINGLE_CHUNK_MAX_N_BWD:
+        BLOCK_SIZE = min(next_power_of_2(n_cols), 65536)
+        aligned = n_cols == BLOCK_SIZE
+        kernel = _get_tuned_bwd_kernel(n_cols, BLOCK_SIZE, n_rows, dx2d.dtype, dx2d.device)
+        ct.launch(stream, (n_rows, 1, 1), kernel, (dx2d, dy2d, y2d, int(n_cols), int(BLOCK_SIZE), aligned))
+    else:
+        aligned = (n_cols % _MULTI_CHUNK_BLOCK_SIZE_BWD) == 0
+        kernel = _get_tuned_multi_bwd_kernel(
+            n_cols, _MULTI_CHUNK_BLOCK_SIZE_BWD, n_rows, aligned, dx2d.dtype, dx2d.device
+        )
+        ct.launch(stream, (n_rows, 1, 1), kernel, (dx2d, dy2d, y2d, int(n_cols), _MULTI_CHUNK_BLOCK_SIZE_BWD, aligned))
+
+    return dx2d.view(*batch, n_cols)
+
+
+class SoftmaxCuTileFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input_):
+        y = _softmax_forward_ct(input_)
+        ctx.save_for_backward(y)
+        return y
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (y,) = ctx.saved_tensors
+        return _softmax_backward_ct(grad_output, y)
+
+
+@register_impl("liger.softmax", backend="cutile")
+def softmax(input: torch.Tensor, **kwargs) -> torch.Tensor:
+    return SoftmaxCuTileFunction.apply(input.contiguous())

--- a/src/tilegym/suites/liger/cutile/sparsemax.py
+++ b/src/tilegym/suites/liger/cutile/sparsemax.py
@@ -1,79 +1,74 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: MIT
+
+from types import SimpleNamespace
+
 import cuda.tile as ct
 import torch
+from cuda.tile.tune import exhaustive_search
 
 from tilegym.backend import register_impl
 
 from .utils import next_power_of_2
 
-# 20 bisections give fp32-scale tau precision (~1e-6 relative interval).
-_BSEARCH_ITER = 20
+# Forward autotune space (occupancy × num_worker_warps): the cumsum scan over the
+# whole row is thread-parallel, so large n_cols favour nww=8 (256 threads) while
+# small n_cols favour nww=4. exhaustive_search picks the per-shape best on first
+# launch and caches it.
+_SPARSEMAX_FWD_TUNE_CONFIGS = [SimpleNamespace(occ=o, nww=n) for o in [2, 4, 8] for n in [4, 8]]
+_SPARSEMAX_FWD_TUNE_CACHE: dict = {}
+
+# Backward autotune space. Same occ×nww sweep, but occ=1 is EXCLUDED: the bwd kernel
+# scatters inside a loop and occupancy=1 there causes intermittent hangs. The best
+# config is shape-dependent (e.g. occ4/nww8 wins at n_cols=8192, occ2/nww8 at 32768),
+# which is exactly why a per-shape autotune is needed rather than a fixed hint.
+_SPARSEMAX_BWD_TUNE_CONFIGS = [SimpleNamespace(occ=o, nww=n) for o in [2, 4, 8] for n in [4, 8]]
+_SPARSEMAX_BWD_TUNE_CACHE: dict = {}
 
 
-def _select_block_size(n_cols: int) -> int:
-    return min(next_power_of_2(n_cols), 4096)
-
-
-@ct.kernel(occupancy=4)
-def _sparsemax_bsearch_kernel(
+# Exact sparsemax threshold (Martins & Astudillo 2016, Alg. 1):
+# on the descending-sorted row z, find support size k = max{ j : z_(j) > (cssv_j - 1)/j },
+# then tau = (sum_{i<=k} z_(i) - 1)/k. The whole row lives in one BLOCK_SIZE tile so ct.cumsum
+# gives the running prefix sum.
+@ct.kernel
+def _sparsemax_fwd_kernel(
     y_output,
     x_input,
+    x_sorted,  # row-wise descending sort of x_input (fp32), produced by torch.sort
     N_COLS: ct.Constant[int],
-    BLOCK_SIZE: ct.Constant[int],
-    BSEARCH_ITER: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],  # = next_pow2(N_COLS): whole row in one tile for the cumsum
 ):
     row_idx = ct.bid(0)
-    n_chunks = (N_COLS + BLOCK_SIZE - 1) // BLOCK_SIZE
+    col_idx = ct.arange(BLOCK_SIZE, dtype=ct.int32)
+    one_b = ct.full((BLOCK_SIZE,), 1.0, ct.float32)
+    zero_b = ct.full((BLOCK_SIZE,), 0.0, ct.float32)
+    valid_mask = col_idx < N_COLS
+    valid_f = ct.astype(valid_mask, ct.float32)
 
-    x_max = ct.full((1,), -1e38, dtype=ct.float32)
+    z_sorted = ct.astype(
+        ct.gather(x_sorted, (row_idx, col_idx), check_bounds=True, padding_value=0.0),
+        ct.float32,
+    )
+    # Masked entries (col >= N_COLS) contribute 0 to the prefix sum / are excluded from support.
+    z_valid = z_sorted * valid_f
+    cssv = ct.cumsum(z_valid, 0)
+    r = ct.astype(col_idx, ct.float32) + one_b
+    t_vec = (cssv - one_b) / r
+    support = (z_sorted > t_vec) & valid_mask
 
-    for ci in range(n_chunks):
-        col_idx = ct.arange(BLOCK_SIZE, dtype=ct.int32) + ci * BLOCK_SIZE
-        x_tile = ct.astype(
-            ct.gather(x_input, (row_idx, col_idx), check_bounds=True, padding_value=-1e38),
-            ct.float32,
-        )
-        x_max = ct.maximum(x_max, ct.max(x_tile, 0, keepdims=True))
+    # Support size k, clamped to >= 1.
+    k_int = ct.maximum(ct.sum(ct.astype(support, ct.int32), 0, keepdims=True), ct.full((1,), 1, ct.int32))
+    k = ct.astype(k_int, ct.float32)
+    s = ct.sum(ct.where(support, z_sorted, zero_b), 0, keepdims=True)
+    tau = (s - ct.full((1,), 1.0, ct.float32)) / k
 
-    tau_lo = x_max - ct.full((1,), 1.0, ct.float32)
-    tau_hi = x_max
-
-    one = ct.full((1,), 1.0, ct.float32)
-    half = ct.full((1,), 0.5, ct.float32)
-
-    for _ in range(BSEARCH_ITER):
-        tau_mid = half * (tau_lo + tau_hi)
-        f = ct.full((1,), 0.0, ct.float32)
-
-        for ci in range(n_chunks):
-            col_idx = ct.arange(BLOCK_SIZE, dtype=ct.int32) + ci * BLOCK_SIZE
-            x_tile = ct.astype(
-                ct.gather(x_input, (row_idx, col_idx), check_bounds=True, padding_value=-1e38),
-                ct.float32,
-            )
-            valid_mask = ct.astype(col_idx < N_COLS, ct.float32)
-            in_supp = ct.astype(x_tile > tau_mid, ct.float32) * valid_mask
-            f = f + ct.sum(in_supp * (x_tile - tau_mid), 0, keepdims=True)
-
-        tau_lo = ct.where(f >= one, tau_mid, tau_lo)
-        tau_hi = ct.where(f < one, tau_mid, tau_hi)
-
-    tau = half * (tau_lo + tau_hi)
-
-    zero = ct.full((BLOCK_SIZE,), 0.0, ct.float32)
-    for ci in range(n_chunks):
-        col_idx = ct.arange(BLOCK_SIZE, dtype=ct.int32) + ci * BLOCK_SIZE
-        x_tile = ct.astype(
-            ct.gather(x_input, (row_idx, col_idx), check_bounds=True, padding_value=0.0),
-            ct.float32,
-        )
-        y_tile = ct.maximum(x_tile - tau, zero)
-        ct.scatter(y_output, (row_idx, col_idx), ct.astype(y_tile, y_output.dtype), check_bounds=True)
-
-
-_sparsemax_bsearch_kernel_large = _sparsemax_bsearch_kernel.replace_hints(occupancy=2)
+    x_row = ct.astype(
+        ct.gather(x_input, (row_idx, col_idx), check_bounds=True, padding_value=0.0),
+        ct.float32,
+    )
+    y = ct.maximum(x_row - tau, ct.full((BLOCK_SIZE,), 0.0, ct.float32))
+    ct.scatter(y_output, (row_idx, col_idx), ct.astype(y, y_output.dtype), check_bounds=True)
 
 
 @ct.kernel
@@ -115,25 +110,82 @@ def _sparsemax_bwd_kernel(
         ct.scatter(grad_input, (row_idx, col_idx), ct.astype(gi_tile, grad_input.dtype), check_bounds=True)
 
 
+def _get_tuned_fwd_kernel(n_cols, BLOCK_SIZE, n_rows, stream, out_flat, x_flat, x_sorted):
+    """Autotune occupancy+nww on first call per shape; return cached kernel afterwards."""
+    key = (n_cols, BLOCK_SIZE)
+    if key in _SPARSEMAX_FWD_TUNE_CACHE:
+        return _SPARSEMAX_FWD_TUNE_CACHE[key]
+
+    result = exhaustive_search(
+        _SPARSEMAX_FWD_TUNE_CONFIGS,
+        stream,
+        lambda cfg: (n_rows, 1, 1),
+        _sparsemax_fwd_kernel,
+        lambda cfg: (out_flat, x_flat, x_sorted, int(n_cols), int(BLOCK_SIZE)),
+        lambda cfg: {"occupancy": cfg.occ, "num_worker_warps": cfg.nww},
+        quiet=True,
+    )
+    best = result.best.config
+    _SPARSEMAX_FWD_TUNE_CACHE[key] = _sparsemax_fwd_kernel.replace_hints(occupancy=best.occ, num_worker_warps=best.nww)
+    return _SPARSEMAX_FWD_TUNE_CACHE[key]
+
+
 def _sparsemax_forward_ct(x: torch.Tensor, dim: int):
+    """Exact, sort-based sparsemax forward.
+
+    Sort each row descending (torch.sort), then one kernel computes the exact threshold tau
+    via prefix sums and applies max(x - tau, 0). The whole row must fit in one tile
+    (BLOCK = next_pow2(n_cols)) so ct.cumsum yields the running prefix sum.
+    """
     if dim < 0:
         dim += x.dim()
     x_sw = x.transpose(dim, -1).contiguous()
     n_cols = x_sw.size(-1)
     n_rows = x_sw.numel() // n_cols
     x_flat = x_sw.view(n_rows, n_cols)
+    x_sorted = torch.sort(x_flat.float(), dim=-1, descending=True).values
 
-    BLOCK_SIZE = _select_block_size(n_cols)
+    BLOCK_SIZE = next_power_of_2(n_cols)  # whole row in one tile (required for the cumsum)
     out_flat = torch.empty_like(x_flat)
-    kernel = _sparsemax_bsearch_kernel_large if n_cols > 16384 else _sparsemax_bsearch_kernel
+    stream = torch.cuda.current_stream()
+    kernel = _get_tuned_fwd_kernel(n_cols, BLOCK_SIZE, n_rows, stream, out_flat, x_flat, x_sorted)
     ct.launch(
-        torch.cuda.current_stream(),
+        stream,
         (n_rows, 1, 1),
         kernel,
-        (out_flat, x_flat, int(n_cols), int(BLOCK_SIZE), int(_BSEARCH_ITER)),
+        (out_flat, x_flat, x_sorted, int(n_cols), int(BLOCK_SIZE)),
     )
 
     return out_flat.view_as(x_sw).transpose(dim, -1).contiguous(), out_flat
+
+
+def _get_tuned_bwd_kernel(n_cols, BLOCK_SIZE, n_rows, dtype, device):
+    """Autotune occupancy+nww per shape on first call; cache afterwards.
+
+    Uses a fresh stream + dummy tensors — the autograd backward stream is not safe
+    for exhaustive_search.
+    """
+    key = (n_cols, BLOCK_SIZE)
+    if key in _SPARSEMAX_BWD_TUNE_CACHE:
+        return _SPARSEMAX_BWD_TUNE_CACHE[key]
+
+    tune_stream = torch.cuda.Stream(device=device)
+    dx = torch.empty(n_rows, n_cols, dtype=dtype, device=device)
+    o = torch.empty(n_rows, n_cols, dtype=dtype, device=device)
+    go = torch.empty(n_rows, n_cols, dtype=dtype, device=device)
+
+    result = exhaustive_search(
+        _SPARSEMAX_BWD_TUNE_CONFIGS,
+        tune_stream,
+        lambda cfg: (n_rows, 1, 1),
+        _sparsemax_bwd_kernel,
+        lambda cfg: (dx, o, go, int(n_cols), int(BLOCK_SIZE)),
+        lambda cfg: {"occupancy": cfg.occ, "num_worker_warps": cfg.nww},
+        quiet=True,
+    )
+    best = result.best.config
+    _SPARSEMAX_BWD_TUNE_CACHE[key] = _sparsemax_bwd_kernel.replace_hints(occupancy=best.occ, num_worker_warps=best.nww)
+    return _SPARSEMAX_BWD_TUNE_CACHE[key]
 
 
 def _sparsemax_backward_ct(grad_out: torch.Tensor, out_flat: torch.Tensor, dim: int):
@@ -142,12 +194,13 @@ def _sparsemax_backward_ct(grad_out: torch.Tensor, out_flat: torch.Tensor, dim: 
     n_rows = grad_sw.numel() // n_cols
     go_flat = grad_sw.view(n_rows, n_cols).contiguous()
 
-    BLOCK_SIZE = _select_block_size(n_cols)
+    BLOCK_SIZE = min(next_power_of_2(n_cols), 4096)
     dx_flat = torch.empty_like(go_flat)
+    kernel = _get_tuned_bwd_kernel(n_cols, BLOCK_SIZE, n_rows, go_flat.dtype, go_flat.device)
     ct.launch(
         torch.cuda.current_stream(),
         (n_rows, 1, 1),
-        _sparsemax_bwd_kernel,
+        kernel,
         (dx_flat, out_flat, go_flat, int(n_cols), int(BLOCK_SIZE)),
     )
 

--- a/src/tilegym/suites/liger/cutile/swiglu.py
+++ b/src/tilegym/suites/liger/cutile/swiglu.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+SwiGLU activation kernel (CuTile backend).
+
+Computes: c = silu(a * gate_multiplier) * b  where silu(x) = x * sigmoid(x)
+
+Row-parallel: grid = (n_rows, 1, 1). Each block handles one row.
+Backward writes da into A and db into B in-place (memory optimization).
+
+gate_multiplier: applied inside the kernel as ct.Constant[float] (compile-time
+  constant; scales a before SiLU; chain rule applies extra factor in backward).
+  Matches Liger-Kernel convention.
+down_multiplier: applied at the Python wrapper level only (multiplied onto output
+  in forward; multiplied onto dc before backward kernel dispatch). Not in kernel.
+
+PERF NOTES
+==========
+- Two kernel variants per direction (fwd/bwd):
+    *_aligned: check_bounds=False — used when n_cols % BLOCK_SIZE == 0
+               (all power-of-2 n_cols up to MAX_FUSED_SIZE, e.g. 4096, 8192)
+               ~17-20% faster vs check_bounds=True on B200.
+    *_ct:      check_bounds=True  — fallback for non-aligned n_cols
+- Forward: @ct.kernel(occupancy=1) → 8 warps. scatter-in-loop works stably.
+  Uses exp2 trick: sigmoid via exp2(-a * LOG2E) → FMUL+EX2 on Blackwell.
+  Requires occupancy=1 for correct exp2→EX2 lowering (~8% speedup vs exp).
+- Backward: NO occupancy=1 — scatter inside loop on a backward kernel risks hangs
+  (see MEMORY.md grpo_loss bwd warning). Uses exp(-a) (not exp2) since occupancy=1
+  is not safe here; exp2 without occupancy=1 doubles the MUFU count.
+- gate_multiplier as ct.Constant[float]: compiler folds away FMUL when value is 1.0;
+  different values produce separately-compiled kernels (fine for fixed arch constants).
+"""
+
+import cuda.tile as ct
+import torch
+
+from tilegym.backend import register_impl
+
+from .utils import next_power_of_2
+
+MAX_FUSED_SIZE_FWD = 4096  # Forward: larger tile fits; forward is compute-bound, no register spill observed
+MAX_FUSED_SIZE_BWD = 1024  # Backward: 14 chunks at n_cols=14336 (vs 28 at 512); stable without occupancy=1
+
+# exp2 trick: sigmoid(x) = 1 / (1 + exp(-x)) = 1 / (1 + exp2(-x * LOG2E))
+# Using exp2(x * LOG2E) instead of exp(x) avoids Cody-Waite 4-FFMA range reduction
+# and maps to FMUL+EX2 on Blackwell.
+# CRITICAL: Only effective with @ct.kernel(occupancy=1) — without it, ct.exp2 calls exp internally.
+LOG2E: float = 1.4426950408889634  # log2(e) = 1/ln(2)
+
+
+@ct.kernel(occupancy=1, num_worker_warps=8)
+def _swiglu_fwd_ct_aligned(
+    A,  # (n_rows, n_cols) input a
+    B,  # (n_rows, n_cols) input b
+    C,  # (n_rows, n_cols) output c
+    n_cols: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    gate_multiplier: ct.Constant[float],
+):
+    """
+    SwiGLU forward — aligned fast path (check_bounds=False).
+
+    Safe only when n_cols % BLOCK_SIZE == 0 (no out-of-bounds accesses).
+    ~17-20% faster than the bounds-checked variant on B200.
+    Computes: c = silu(a * gate_multiplier) * b
+    """
+    row_idx = ct.bid(0)
+    n_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+
+        a = ct.astype(ct.gather(A, (row_idx, col_idx), check_bounds=False, padding_value=0.0), ct.float32)
+        b = ct.gather(B, (row_idx, col_idx), check_bounds=False, padding_value=0.0)
+
+        # Apply gate_multiplier before SiLU (Liger convention)
+        a_scaled = a * gate_multiplier
+
+        # exp2 trick + flush_to_zero: sigmoid via exp2(-a*LOG2E) — FMUL+EX2 (avoids Cody-Waite range reduction).
+        # flush_to_zero=True skips denormal handling; sigmoid range is well above the denormal threshold.
+        # Requires occupancy=1 for correct exp2→EX2 lowering.
+        sig_a = ct.truediv(
+            1.0,
+            1.0 + ct.exp2(ct.mul(-a_scaled, LOG2E), flush_to_zero=True),
+            flush_to_zero=True,
+            rounding_mode=ct.RoundingMode.APPROX,
+        )
+        silu_a = a_scaled * sig_a
+
+        c = ct.astype(silu_a, b.dtype) * b
+        ct.scatter(C, (row_idx, col_idx), c, check_bounds=False)
+
+
+@ct.kernel(occupancy=1, num_worker_warps=8)
+def _swiglu_fwd_ct(
+    A,  # (n_rows, n_cols) input a
+    B,  # (n_rows, n_cols) input b
+    C,  # (n_rows, n_cols) output c
+    n_cols: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    gate_multiplier: ct.Constant[float],
+):
+    """
+    SwiGLU forward — general path (check_bounds=True).
+
+    Handles arbitrary n_cols. Used as fallback when n_cols % BLOCK_SIZE != 0.
+    Computes: c = silu(a * gate_multiplier) * b
+    """
+    row_idx = ct.bid(0)
+    n_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+
+        a = ct.astype(ct.gather(A, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+        b = ct.gather(B, (row_idx, col_idx), check_bounds=True, padding_value=0.0)
+
+        # Apply gate_multiplier before SiLU (Liger convention)
+        a_scaled = a * gate_multiplier
+
+        # exp2 trick + flush_to_zero: sigmoid via exp2(-a*LOG2E) — FMUL+EX2 (avoids Cody-Waite range reduction).
+        # flush_to_zero=True skips denormal handling; sigmoid range is well above the denormal threshold.
+        # Requires occupancy=1 for correct exp2→EX2 lowering.
+        sig_a = ct.truediv(
+            1.0,
+            1.0 + ct.exp2(ct.mul(-a_scaled, LOG2E), flush_to_zero=True),
+            flush_to_zero=True,
+            rounding_mode=ct.RoundingMode.APPROX,
+        )
+        silu_a = a_scaled * sig_a
+
+        c = ct.astype(silu_a, b.dtype) * b
+        ct.scatter(C, (row_idx, col_idx), c, check_bounds=True)
+
+
+@ct.kernel
+def _swiglu_bwd_ct_aligned(
+    DC,  # (n_rows, n_cols) upstream gradient
+    A,  # (n_rows, n_cols) saved input a — DA written in-place
+    B,  # (n_rows, n_cols) saved input b — DB written in-place
+    n_cols: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    gate_multiplier: ct.Constant[float],
+):
+    """
+    SwiGLU backward — aligned fast path (check_bounds=False).
+
+    Safe only when n_cols % BLOCK_SIZE == 0. da/db written in-place to A/B.
+    NOTE: No occupancy=1 — scatter inside a backward loop risks hangs (MEMORY.md).
+
+    Chain rule: fwd computes c = silu(a * gm) * b
+      db = dc * silu(a * gm)
+      da = dc * d_silu(a*gm)/d(a*gm) * gm * b
+         = dc * (silu(a*gm) * (1 - sig(a*gm)) + sig(a*gm)) * gm * b
+    """
+    row_idx = ct.bid(0)
+    n_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+
+        dc = ct.astype(ct.gather(DC, (row_idx, col_idx), check_bounds=False, padding_value=0.0), ct.float32)
+        # A holds original a (forward did not write back); reapply gate_multiplier
+        a = ct.astype(ct.gather(A, (row_idx, col_idx), check_bounds=False, padding_value=0.0), ct.float32)
+        b = ct.astype(ct.gather(B, (row_idx, col_idx), check_bounds=False, padding_value=0.0), ct.float32)
+
+        a_scaled = a * gate_multiplier
+        sig_a = ct.truediv(1.0, 1.0 + ct.exp(0.0 - a_scaled), rounding_mode=ct.RoundingMode.APPROX)
+        silu_a = a_scaled * sig_a
+
+        db = dc * silu_a
+        da = dc * (silu_a * (1.0 - sig_a) + sig_a) * b * gate_multiplier
+
+        ct.scatter(A, (row_idx, col_idx), ct.astype(da, A.dtype), check_bounds=False)
+        ct.scatter(B, (row_idx, col_idx), ct.astype(db, B.dtype), check_bounds=False)
+
+
+@ct.kernel
+def _swiglu_bwd_ct(
+    DC,  # (n_rows, n_cols) upstream gradient
+    A,  # (n_rows, n_cols) saved input a — DA written in-place
+    B,  # (n_rows, n_cols) saved input b — DB written in-place
+    n_cols: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    gate_multiplier: ct.Constant[float],
+):
+    """
+    SwiGLU backward — general path (check_bounds=True).
+
+    Recomputes sigmoid for memory efficiency (no saved activations).
+    da/db written in-place to A/B. Grid: (n_rows, 1, 1).
+    NOTE: No occupancy=1 — scatter inside a backward loop risks hangs (MEMORY.md).
+    """
+    row_idx = ct.bid(0)
+    n_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+
+        dc = ct.astype(ct.gather(DC, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+        # A holds original a (forward did not write back); reapply gate_multiplier
+        a = ct.astype(ct.gather(A, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+        b = ct.astype(ct.gather(B, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+
+        a_scaled = a * gate_multiplier
+        # Recompute sigmoid (APPROX division: no FCHK + software-fallback CALL)
+        sig_a = ct.truediv(1.0, 1.0 + ct.exp(0.0 - a_scaled), rounding_mode=ct.RoundingMode.APPROX)
+        silu_a = a_scaled * sig_a
+
+        db = dc * silu_a
+        da = dc * (silu_a * (1.0 - sig_a) + sig_a) * b * gate_multiplier
+
+        ct.scatter(A, (row_idx, col_idx), ct.astype(da, A.dtype), check_bounds=True)
+        ct.scatter(B, (row_idx, col_idx), ct.astype(db, B.dtype), check_bounds=True)
+
+
+def _calculate_block_size(n_cols, max_fused_size):
+    # Cap the tile at max_fused_size (or next_pow2(n_cols) if smaller).
+    block = max(min(next_power_of_2(n_cols), max_fused_size), 128)
+    # Largest power-of-2 tile <= block that evenly divides n_cols — this enables the
+    # check_bounds=False aligned fast path (which dispatch selects when block % n_cols == 0).
+    aligned = block
+    while aligned > 128 and n_cols % aligned != 0:
+        aligned //= 2
+    # Prefer the aligned block only when it stays large (>= half the cap). For sizes with small
+    # odd factors (e.g. 11008 = 256*43, 13824 = 512*27) the largest aligned block collapses to a
+    # tiny tile with dozens of chunks; there, keep the full block and let the masked
+    # (check_bounds=True) kernel cover the remainder in far fewer chunks (~10% faster).
+    # 14336 = 2048*7 keeps a large aligned block (2048) and stays on the fast path.
+    if n_cols % aligned == 0 and aligned >= block // 2:
+        return aligned
+    return block
+
+
+class SwiGLUCuTileFunction(torch.autograd.Function):
+    """CuTile autograd wrapper for SwiGLU (silu(a * gate_multiplier) * b * down_multiplier).
+
+    gate_multiplier is applied inside the kernel (consistent with Liger-Kernel).
+    down_multiplier is applied at the Python wrapper level.
+    """
+
+    @staticmethod
+    def forward(ctx, a, b, gate_multiplier: float = 1.0, down_multiplier: float = 1.0):
+        gate_multiplier = float(gate_multiplier)
+        down_multiplier = float(down_multiplier)
+        ori_shape = a.shape
+        n_cols = ori_shape[-1]
+        a = a.view(-1, n_cols).contiguous()
+        b = b.view(-1, n_cols).contiguous()
+        n_rows = a.shape[0]
+
+        c = torch.empty_like(a)
+        BLOCK_SIZE = _calculate_block_size(n_cols, MAX_FUSED_SIZE_FWD)
+        fwd_kernel = _swiglu_fwd_ct_aligned if n_cols % BLOCK_SIZE == 0 else _swiglu_fwd_ct
+
+        ct.launch(
+            torch.cuda.current_stream(),
+            (n_rows, 1, 1),
+            fwd_kernel,
+            (a, b, c, int(n_cols), int(BLOCK_SIZE), gate_multiplier),
+        )
+        c_out = c.view(*ori_shape)
+        if down_multiplier != 1.0:
+            c_out = c_out * down_multiplier
+        ctx.save_for_backward(a, b)
+        ctx.ori_shape = ori_shape
+        ctx.gate_multiplier = gate_multiplier
+        ctx.down_multiplier = down_multiplier
+        return c_out
+
+    @staticmethod
+    def backward(ctx, dc):
+        a, b = ctx.saved_tensors
+        ori_shape = ctx.ori_shape
+        n_cols = ori_shape[-1]
+        dc = dc.view(-1, n_cols).contiguous()
+        n_rows = dc.shape[0]
+        if ctx.down_multiplier != 1.0:
+            dc = dc * ctx.down_multiplier
+        BLOCK_SIZE = _calculate_block_size(n_cols, MAX_FUSED_SIZE_BWD)
+        bwd_kernel = _swiglu_bwd_ct_aligned if n_cols % BLOCK_SIZE == 0 else _swiglu_bwd_ct
+
+        ct.launch(
+            torch.cuda.current_stream(),
+            (n_rows, 1, 1),
+            bwd_kernel,
+            (dc, a, b, int(n_cols), int(BLOCK_SIZE), ctx.gate_multiplier),
+        )
+        return a.view(*ori_shape), b.view(*ori_shape), None, None
+
+
+@register_impl("liger.swiglu", backend="cutile")
+def swiglu(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    gate_multiplier: float = 1.0,
+    down_multiplier: float = 1.0,
+) -> torch.Tensor:
+    return SwiGLUCuTileFunction.apply(a, b, gate_multiplier, down_multiplier)

--- a/src/tilegym/suites/liger/cutile/tiled_mlp.py
+++ b/src/tilegym/suites/liger/cutile/tiled_mlp.py
@@ -9,6 +9,7 @@ Pure Python implementation — no GPU kernel.
 Shards input along sequence dimension (dim=-2), applies fn on each shard,
 and concatenates. Backward re-computes forward per shard to save memory.
 
+Implemented as a pure Python chunked wrapper (torch.chunk + cuBLAS + autograd).
 """
 
 import math

--- a/src/tilegym/suites/liger/cutile/tvd.py
+++ b/src/tilegym/suites/liger/cutile/tvd.py
@@ -1,0 +1,369 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Total Variation Distance loss kernel (CuTile backend).
+
+TVD(P || Q) = 0.5 * |P - Q|
+Gradient w.r.t. P: 0.5 if P > Q, -0.5 if P <= Q
+
+Optional shift_labels for ignore_index masking (zeros out grads for ignored rows).
+Reduction modes: none, sum, mean, batchmean.
+
+PERF NOTES
+==========
+- TMA (ct.load) instead of gather for loads of P and Q.
+  TMA is hardware-accelerated and avoids per-element index computation.
+- Aligned fast path: when n_cols % BLOCK_SIZE == 0, use TMA store for GRADS/LOSS.
+  Unaligned path: ct.scatter with check_bounds=True for GRADS/LOSS writes.
+- Stride-misaligned V ((V * itemsize) % 16 != 0): TMA descriptor can't be built and ct.load
+  falls back to a serialized per-element path; route to the ct.gather kernel (indexed LDG,
+  BLOCK=4096, occupancy=2) instead — reaches ~48% SM throughput and beats the TMA fallback.
+- @ct.kernel(occupancy=3): TMA kernels; occupancy=2 for the gather kernel.
+- BLOCK_SIZE=8192: fewer loop iterations, TMA handles large tiles efficiently.
+  At V=128256: ceil(128256/8192)=16 chunks per row vs 128 at baseline.
+- Reduction scale (1/n_non_ignore etc.) is fused into the kernel (grads/loss written
+  pre-scaled) — no host-side division pass.
+- Grid: (BT, 1, 1) — one block per token row, with persistent scheduling over rows.
+"""
+
+from typing import Optional
+
+import cuda.tile as ct
+import torch
+
+from tilegym.backend import register_impl
+
+from .utils import next_power_of_2
+
+_REDUCTION_MODE_NONE = 0
+_REDUCTION_MODE_SUM = 1
+_REDUCTION_MODE_MEAN = 2
+_REDUCTION_MODE_BATCHMEAN = 3
+
+_str_to_reduction_mode = {
+    "none": _REDUCTION_MODE_NONE,
+    "sum": _REDUCTION_MODE_SUM,
+    "mean": _REDUCTION_MODE_MEAN,
+    "batchmean": _REDUCTION_MODE_BATCHMEAN,
+}
+
+
+@ct.kernel(occupancy=3)
+def _tv_distance_kernel_ct_aligned(
+    P,  # (BT, V) first distribution
+    Q,  # (BT, V) second distribution
+    LOSS,  # (BT, V) when reduction=none, else (BT,)
+    GRADS,  # (BT, V) gradient output
+    LABEL,  # (BT,) label tensor, or dummy 1-elem tensor when HAS_LABEL=0
+    scale,  # runtime float: fused reduction scale (1/n_non_ignore etc.); 1.0 for sum/none
+    n_rows: ct.Constant[int],
+    n_cols: ct.Constant[int],
+    ignore_index: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    HAS_LABEL: ct.Constant[int],
+    reduction: ct.Constant[int],
+):
+    """
+    TVD forward -- aligned fast path (n_cols % BLOCK_SIZE == 0).
+
+    Uses TMA (ct.load/ct.store) for all 2D accesses.
+    Persistent scheduling: each block handles multiple rows.
+    """
+    pid = ct.bid(0)
+    num_programs = ct.num_blocks(0)
+    n_chunks = n_cols // BLOCK_SIZE
+
+    for row_idx in range(pid, n_rows, num_programs):
+        if HAS_LABEL:
+            lbl = ct.load(LABEL, row_idx, shape=())
+            if lbl == ignore_index:
+                for ci in range(n_chunks):
+                    ct.store(GRADS, index=(row_idx, ci), tile=ct.full((1, BLOCK_SIZE), 0.0, GRADS.dtype))
+                    if reduction == _REDUCTION_MODE_NONE:
+                        ct.store(LOSS, index=(row_idx, ci), tile=ct.full((1, BLOCK_SIZE), 0.0, LOSS.dtype))
+                if reduction != _REDUCTION_MODE_NONE:
+                    ct.scatter(LOSS, row_idx, ct.astype(0.0, LOSS.dtype))
+                continue
+
+        loss_acc = ct.full((BLOCK_SIZE,), 0.0, ct.float32)
+
+        for ci in range(n_chunks):
+            p = ct.astype(
+                ct.load(P, index=(row_idx, ci), shape=(1, BLOCK_SIZE), padding_mode=ct.PaddingMode.ZERO).reshape(
+                    (BLOCK_SIZE,)
+                ),
+                ct.float32,
+            )
+            q = ct.astype(
+                ct.load(Q, index=(row_idx, ci), shape=(1, BLOCK_SIZE), padding_mode=ct.PaddingMode.ZERO).reshape(
+                    (BLOCK_SIZE,)
+                ),
+                ct.float32,
+            )
+
+            diff = p - q
+            tv_loss = ct.maximum(diff, 0.0 - diff) * 0.5
+            p_gt_q = ct.astype(p > q, ct.float32)
+            # Fuse reduction scale into the gradient: grads written pre-scaled,
+            # so no host-side grads / n_non_ignore pass is needed. scale == 1.0 for sum/none.
+            grad = (2.0 * p_gt_q - 1.0) * 0.5 * scale
+
+            ct.store(GRADS, index=(row_idx, ci), tile=ct.astype(grad, GRADS.dtype).reshape((1, BLOCK_SIZE)))
+
+            if reduction == _REDUCTION_MODE_NONE:
+                ct.store(LOSS, index=(row_idx, ci), tile=ct.astype(tv_loss, LOSS.dtype).reshape((1, BLOCK_SIZE)))
+            else:
+                loss_acc = loss_acc + tv_loss
+
+        if reduction != _REDUCTION_MODE_NONE:
+            row_sum = ct.sum(loss_acc, 0, keepdims=False)
+            ct.scatter(LOSS, row_idx, ct.astype(row_sum * scale, LOSS.dtype))
+
+
+@ct.kernel(occupancy=3)
+def _tv_distance_kernel_ct(
+    P,  # (BT, V) first distribution
+    Q,  # (BT, V) second distribution
+    LOSS,  # (BT, V) when reduction=none, else (BT,)
+    GRADS,  # (BT, V) gradient output
+    LABEL,  # (BT,) label tensor, or dummy 1-elem tensor when HAS_LABEL=0
+    scale,  # runtime float: fused reduction scale (1/n_non_ignore etc.); 1.0 for sum/none
+    n_rows: ct.Constant[int],
+    n_cols: ct.Constant[int],
+    ignore_index: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    HAS_LABEL: ct.Constant[int],
+    reduction: ct.Constant[int],
+):
+    """
+    TVD forward -- general path (arbitrary n_cols).
+
+    Uses TMA ct.load for P and Q (with zero padding for last chunk).
+    Uses ct.scatter for GRADS/LOSS writes (bounds-checked for partial last chunk).
+    Persistent scheduling: each block handles multiple rows.
+    """
+    pid = ct.bid(0)
+    num_programs = ct.num_blocks(0)
+    n_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    for row_idx in range(pid, n_rows, num_programs):
+        if HAS_LABEL:
+            lbl = ct.load(LABEL, row_idx, shape=())
+            if lbl == ignore_index:
+                for ci in range(n_chunks):
+                    col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+                    ct.scatter(GRADS, (row_idx, col_idx), ct.full((BLOCK_SIZE,), 0.0, GRADS.dtype), check_bounds=True)
+                    if reduction == _REDUCTION_MODE_NONE:
+                        ct.scatter(LOSS, (row_idx, col_idx), ct.full((BLOCK_SIZE,), 0.0, LOSS.dtype), check_bounds=True)
+                if reduction != _REDUCTION_MODE_NONE:
+                    ct.scatter(LOSS, row_idx, ct.astype(0.0, LOSS.dtype))
+                continue
+
+        loss_acc = ct.full((BLOCK_SIZE,), 0.0, ct.float32)
+
+        for ci in range(n_chunks):
+            col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+
+            p = ct.astype(
+                ct.load(P, index=(row_idx, ci), shape=(1, BLOCK_SIZE), padding_mode=ct.PaddingMode.ZERO).reshape(
+                    (BLOCK_SIZE,)
+                ),
+                ct.float32,
+            )
+            q = ct.astype(
+                ct.load(Q, index=(row_idx, ci), shape=(1, BLOCK_SIZE), padding_mode=ct.PaddingMode.ZERO).reshape(
+                    (BLOCK_SIZE,)
+                ),
+                ct.float32,
+            )
+
+            diff = p - q
+            tv_loss = ct.maximum(diff, 0.0 - diff) * 0.5
+            p_gt_q = ct.astype(p > q, ct.float32)
+            # Fuse reduction scale into the gradient: grads written pre-scaled,
+            # so no host-side grads / n_non_ignore pass is needed. scale == 1.0 for sum/none.
+            grad = (2.0 * p_gt_q - 1.0) * 0.5 * scale
+
+            ct.scatter(GRADS, (row_idx, col_idx), ct.astype(grad, GRADS.dtype), check_bounds=True)
+
+            if reduction == _REDUCTION_MODE_NONE:
+                ct.scatter(LOSS, (row_idx, col_idx), ct.astype(tv_loss, LOSS.dtype), check_bounds=True)
+            else:
+                loss_acc = loss_acc + tv_loss
+
+        if reduction != _REDUCTION_MODE_NONE:
+            row_sum = ct.sum(loss_acc, 0, keepdims=False)
+            ct.scatter(LOSS, row_idx, ct.astype(row_sum * scale, LOSS.dtype))
+
+
+@ct.kernel(occupancy=2)
+def _tv_distance_kernel_ct_gather(
+    P,  # (BT, V) first distribution
+    Q,  # (BT, V) second distribution
+    LOSS,  # (BT, V) when reduction=none, else (BT,)
+    GRADS,  # (BT, V) gradient output
+    LABEL,  # (BT,) label tensor, or dummy 1-elem tensor when HAS_LABEL=0
+    scale,  # runtime float: fused reduction scale (1/n_non_ignore etc.); 1.0 for sum/none
+    n_rows: ct.Constant[int],
+    n_cols: ct.Constant[int],
+    ignore_index: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+    HAS_LABEL: ct.Constant[int],
+    reduction: ct.Constant[int],
+):
+    """
+    TVD forward -- gather path for stride-misaligned V ((V * itemsize) % 16 != 0).
+
+    When rows are not 16-byte aligned, ct.load's TMA descriptor can't be built: it falls
+    back to per-element loads but keeps the tile-load structure (2x the loads + many CTA
+    BAR.SYNC barriers), which serializes the kernel to ~9% SM throughput. Reading via
+    ct.gather (plain indexed LDG, no TMA machinery) with a smaller BLOCK and occupancy=2
+    halves the barriers and loads and cuts L2 contention on the uncoalesced access — reaching
+    ~48% SM throughput and beating the TMA-fallback on odd V.
+    """
+    pid = ct.bid(0)
+    num_programs = ct.num_blocks(0)
+    n_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    for row_idx in range(pid, n_rows, num_programs):
+        if HAS_LABEL:
+            lbl = ct.load(LABEL, row_idx, shape=())
+            if lbl == ignore_index:
+                for ci in range(n_chunks):
+                    col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+                    ct.scatter(GRADS, (row_idx, col_idx), ct.full((BLOCK_SIZE,), 0.0, GRADS.dtype), check_bounds=True)
+                    if reduction == _REDUCTION_MODE_NONE:
+                        ct.scatter(LOSS, (row_idx, col_idx), ct.full((BLOCK_SIZE,), 0.0, LOSS.dtype), check_bounds=True)
+                if reduction != _REDUCTION_MODE_NONE:
+                    ct.scatter(LOSS, row_idx, ct.astype(0.0, LOSS.dtype))
+                continue
+
+        loss_acc = ct.full((BLOCK_SIZE,), 0.0, ct.float32)
+
+        for ci in range(n_chunks):
+            col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+            p = ct.astype(ct.gather(P, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+            q = ct.astype(ct.gather(Q, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+
+            diff = p - q
+            tv_loss = ct.maximum(diff, 0.0 - diff) * 0.5
+            p_gt_q = ct.astype(p > q, ct.float32)
+            grad = (2.0 * p_gt_q - 1.0) * 0.5 * scale
+
+            ct.scatter(GRADS, (row_idx, col_idx), ct.astype(grad, GRADS.dtype), check_bounds=True)
+
+            if reduction == _REDUCTION_MODE_NONE:
+                ct.scatter(LOSS, (row_idx, col_idx), ct.astype(tv_loss, LOSS.dtype), check_bounds=True)
+            else:
+                loss_acc = loss_acc + tv_loss
+
+        if reduction != _REDUCTION_MODE_NONE:
+            row_sum = ct.sum(loss_acc, 0, keepdims=False)
+            ct.scatter(LOSS, row_idx, ct.astype(row_sum * scale, LOSS.dtype))
+
+
+def _get_block_size(V: int) -> int:
+    # Use 8192 elements per block: fewer loop iterations with TMA.
+    # At V=128256: ceil(128256/8192)=16 chunks per row.
+    return min(8192, next_power_of_2(V))
+
+
+def _tvd_forward_ct(p, q, shift_labels, reduction, ignore_index, has_label):
+    BT, V = p.shape
+    reduction_int = _str_to_reduction_mode[reduction]
+
+    # Row-stride alignment drives the read path. When (V * itemsize) % 16 != 0 (e.g. odd V in
+    # bf16), rows aren't 16-byte aligned so ct.load's TMA falls back to a serialized per-element
+    # path (2x loads + many CTA barriers, ~9% SM throughput). Route those to the gather kernel
+    # (indexed LDG, BLOCK=4096, occ=2), which reaches ~48% SM throughput.
+    if (V * p.element_size()) % 16 != 0:
+        BLOCK_SIZE = min(4096, next_power_of_2(V))
+        kernel = _tv_distance_kernel_ct_gather
+    else:
+        BLOCK_SIZE = _get_block_size(V)
+        kernel = _tv_distance_kernel_ct_aligned if V % BLOCK_SIZE == 0 else _tv_distance_kernel_ct
+
+    label_tensor = shift_labels if has_label else torch.empty(1, device=p.device, dtype=torch.long)
+
+    # Only batchmean/mean need n_non_ignore; skip the .item() sync for sum/none.
+    # The scale is fused into the kernel (grads/loss written pre-scaled), so there is no
+    # host-side grads / n_non_ignore division pass.
+    if reduction_int == _REDUCTION_MODE_BATCHMEAN:
+        n_non_ignore = (shift_labels != ignore_index).sum().item() if has_label else BT
+        scale = 1.0 / n_non_ignore
+    elif reduction_int == _REDUCTION_MODE_MEAN:
+        n_non_ignore = (shift_labels != ignore_index).sum().item() if has_label else BT
+        scale = 1.0 / (n_non_ignore * V)
+    else:  # sum / none
+        scale = 1.0
+
+    # empty (not zeros): the kernel writes every position, zeroing ignore rows explicitly.
+    grads = torch.empty_like(p)
+    out_size = (BT, V) if reduction_int == _REDUCTION_MODE_NONE else (BT,)
+    output_tensor = torch.empty(out_size, device=p.device, dtype=torch.float32)
+
+    grid = (BT, 1, 1)
+
+    ct.launch(
+        torch.cuda.current_stream(),
+        grid,
+        kernel,
+        (
+            p,
+            q,
+            output_tensor,
+            grads,
+            label_tensor,
+            float(scale),
+            int(BT),
+            int(V),
+            int(ignore_index),
+            int(BLOCK_SIZE),
+            int(has_label),
+            int(reduction_int),
+        ),
+    )
+
+    # Loss and grads are already scaled inside the kernel — no separate division needed.
+    if reduction_int in (_REDUCTION_MODE_BATCHMEAN, _REDUCTION_MODE_MEAN):
+        return output_tensor.sum(), grads
+    elif reduction_int == _REDUCTION_MODE_SUM:
+        return output_tensor.sum(dim=0), grads
+    else:  # none
+        return output_tensor.to(p.dtype), grads
+
+
+class TVDLossCuTileFunction(torch.autograd.Function):
+    """CuTile autograd wrapper for Total Variation Distance loss."""
+
+    @staticmethod
+    def forward(ctx, p, q, shift_labels, reduction, ignore_index):
+        has_label = shift_labels is not None
+        if has_label:
+            assert shift_labels.shape == (p.shape[0],), f"shift_labels must have shape (BT,). Got: {shift_labels.shape}"
+            shift_labels = shift_labels.contiguous()
+
+        loss, grads = _tvd_forward_ct(p, q, shift_labels, reduction, ignore_index, has_label)
+        ctx.save_for_backward(grads)
+        return loss
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (grads,) = ctx.saved_tensors
+        if torch.equal(grad_output, torch.tensor(1.0, device=grad_output.device)):
+            return grads, None, None, None, None
+        return grads * grad_output, None, None, None, None
+
+
+@register_impl("liger.tvd", backend="cutile")
+def tvd(
+    p: torch.Tensor,
+    q: torch.Tensor,
+    shift_labels: Optional[torch.Tensor] = None,
+    reduction: str = "batchmean",
+    ignore_index: int = -100,
+    **kwargs,
+) -> torch.Tensor:
+    return TVDLossCuTileFunction.apply(p.contiguous(), q.contiguous(), shift_labels, reduction, ignore_index)

--- a/src/tilegym/suites/liger/ops.py
+++ b/src/tilegym/suites/liger/ops.py
@@ -48,6 +48,37 @@ def jsd(
 
 
 @dispatch(
+    "liger.poly_norm",
+)
+def poly_norm(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor,
+    eps: float = 1e-6,
+) -> torch.Tensor:
+    """
+    PolyNorm normalization.
+
+    Computes: y = w₀·norm(x³) + w₁·norm(x²) + w₂·norm(x) + b
+    where norm(u) = u / sqrt(mean(u²) + ε)
+
+    Reference:
+    1. https://github.com/BryceZhuo/PolyCom/
+    2. https://arxiv.org/pdf/2411.03884
+
+    Args:
+        input: Input tensor of shape (*, H)
+        weight: Weight tensor of shape (3,) for [w0, w1, w2]
+        bias: Scalar bias tensor of shape (1,)
+        eps: Epsilon for numerical stability. Default: 1e-6
+
+    Returns:
+        Output tensor of same shape as input
+    """
+    raise NotImplementedError(f"poly_norm is not implemented for {get_current_backend()}")
+
+
+@dispatch(
     "liger.fused_neighborhood_attention",
 )
 def fused_neighborhood_attention(
@@ -104,6 +135,99 @@ def cross_entropy(
         4-tuple (loss, z_loss, token_accuracy, predicted_tokens) when any RETURN_* flag is True.
     """
     raise NotImplementedError(f"cross_entropy is not implemented for {get_current_backend()}")
+
+
+@dispatch(
+    "liger.fused_add_rms_norm",
+)
+def fused_add_rms_norm(
+    X: torch.Tensor,
+    R: torch.Tensor,
+    W: torch.Tensor,
+    eps: float = 1e-6,
+    offset: float = 0.0,
+    casting_mode: str = "llama",
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Fused residual addition + RMS normalization.
+
+    Computes the following sequence (common in transformer decoder layers):
+      1. hidden_states = residual + hidden_states
+      2. residual = hidden_states  (updated residual)
+      3. hidden_states = rmsnorm(hidden_states)
+
+    Reference: https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/fused_add_rms_norm.py
+
+    Args:
+        X: Hidden states tensor of shape (*, H).
+        R: Residual tensor of same shape as X.
+        W: RMSNorm weight tensor of shape (H,).
+        eps: Epsilon for numerical stability. Default: 1e-6
+        offset: Constant offset added to W before scaling (e.g. 1.0 for Gemma). Default: 0.0
+        casting_mode: Casting mode for RMSNorm computation:
+            "llama" - only rstd computed in float32 (default)
+            "gemma" - everything cast to float32
+            "none"  - no casting; compute in original dtype
+
+    Returns:
+        Tuple (Y, S):
+            Y: Normalized output of same shape as X.
+            S: Updated residual (X + R) of same shape as X.
+    """
+    raise NotImplementedError(f"fused_add_rms_norm is not implemented for {get_current_backend()}")
+
+
+@dispatch(
+    "liger.fused_linear_cross_entropy",
+)
+def fused_linear_cross_entropy(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    target: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    ce_weight: Optional[torch.Tensor] = None,
+    ignore_index: int = -100,
+    lse_square_scale: float = 0.0,
+    label_smoothing: float = 0.0,
+    reduction: str = "mean",
+    softcap: Optional[float] = None,
+    return_z_loss: bool = False,
+    accum_dtype: Optional[torch.dtype] = None,
+    use_token_scaling: bool = False,
+    return_token_accuracy: bool = False,
+    return_predicted_tokens: bool = False,
+) -> torch.Tensor:
+    """
+    Fused linear + cross-entropy loss (chunked to avoid materializing logits).
+
+    Computes loss = cross_entropy(input @ weight.T + bias, target) without
+    materializing the full (BT, V) logit matrix.
+
+    Reference: https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/fused_linear_cross_entropy.py
+
+    Args:
+        input: Hidden states of shape (BT, H).
+        weight: Vocabulary weight of shape (V, H).
+        target: Target class indices of shape (BT,).
+        bias: Optional bias of shape (V,). Default: None
+        ce_weight: Optional per-class weight of shape (V,) for weighted CE. Default: None
+        ignore_index: Class index to ignore. Default: -100
+        lse_square_scale: Coefficient of the z-loss regularizer (lse^2). Default: 0.0
+        label_smoothing: Label smoothing factor in [0, 1). Default: 0.0
+        reduction: Reduction mode: "mean" | "sum" | "none". Default: "mean"
+        softcap: Optional logit soft-capping value (tanh cap). Default: None
+        return_z_loss: Also return the z-loss term. Default: False
+        accum_dtype: Optional accumulation dtype for grad_weight/grad_bias. Default: None
+        use_token_scaling: Scale each token's loss by its predicted probability. Default: False
+        return_token_accuracy: Also return per-batch token accuracy. Default: False
+        return_predicted_tokens: Also return the argmax predicted token ids. Default: False
+
+    Returns:
+        Scalar loss tensor by default (or per-token losses when reduction="none").
+        When any of return_z_loss / return_token_accuracy / return_predicted_tokens is set,
+        returns a tuple (loss, *extras) with the requested extras appended in that order.
+    """
+    raise NotImplementedError(f"fused_linear_cross_entropy is not implemented for {get_current_backend()}")
 
 
 @dispatch(
@@ -200,6 +324,32 @@ def group_norm(
 
 
 @dispatch(
+    "liger.dyt",
+)
+def dyt(
+    x: torch.Tensor,
+    alpha: torch.Tensor,
+    gamma: torch.Tensor,
+    beta: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """
+    Dynamic Tanh (DyT) activation: y = tanh(alpha * x) * gamma + beta
+
+    Reference: https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/dyt.py
+
+    Args:
+        x: Input tensor of shape (*, N)
+        alpha: Scalar learnable parameter, shape (1,)
+        gamma: Per-channel scale, shape (N,)
+        beta: Optional per-channel bias, shape (N,). If None, bias is omitted.
+
+    Returns:
+        Output tensor of same shape as x
+    """
+    raise NotImplementedError(f"dyt is not implemented for {get_current_backend()}")
+
+
+@dispatch(
     "liger.kl_div",
 )
 def kl_div(
@@ -289,6 +439,113 @@ def llama4_rope(
 
 
 @dispatch(
+    "liger.grpo_loss",
+)
+def grpo_loss(
+    logits: torch.Tensor,
+    old_logp: Optional[torch.Tensor],
+    ref_logp: Optional[torch.Tensor],
+    completion_ids: torch.Tensor,
+    advantages: torch.Tensor,
+    completion_mask: Optional[torch.Tensor] = None,
+    temperature: float = 0.9,
+    beta: float = 0.0,
+    eps_low: float = 0.2,
+    eps_high: float = 0.2,
+    inplace: bool = True,
+    loss_type: str = "grpo",
+    max_completion_length: Optional[int] = None,
+    reduce: bool = False,
+    importance_sampling_level: str = "token",
+    sapo_temperature_pos: float = 1.0,
+    sapo_temperature_neg: float = 1.05,
+    vllm_is_ratio: Optional[torch.Tensor] = None,
+    delta: Optional[float] = None,
+    use_bias_correction_kl: bool = False,
+    num_items_in_batch: Optional[torch.Tensor] = None,
+    phi_seq: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    """
+    GRPO / DAPO / BNPO / DR-GRPO / CISPO / SAPO / LUSPO / VESPO policy optimization loss.
+
+    Computes per-token policy gradient loss with optional KL penalty.
+    Logits shape: (B, L+1, N) where L is sequence length and N is vocab size.
+
+    Reference: https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/grpo_loss.py
+
+    Args:
+        logits: Logits of shape (B, L+1, N). The extra token is for the prefix position.
+        old_logp: Old log-probs of shape (B, L), or None to use current logits.
+        ref_logp: Reference log-probs of shape (B, L). Required when beta != 0.
+        completion_ids: Token ids of shape (B, L) (int64).
+        advantages: Per-sample advantages of shape (B,).
+        completion_mask: Optional binary mask of shape (B, L). 0 = skip token.
+        temperature: Softmax temperature. Default: 0.9
+        beta: KL penalty coefficient. Default: 0.0
+        eps_low: Lower clip epsilon for PPO. Default: 0.2
+        eps_high: Upper clip epsilon for PPO. Default: 0.2
+        inplace: Write gradient directly into logits buffer. Default: True
+        loss_type: Algorithm variant: "grpo"|"dapo"|"bnpo"|"dr_grpo"|"cispo"|"sapo"|"luspo"|"vespo".
+        max_completion_length: Maximum completion length for dr_grpo/luspo reduction. Default: None
+        reduce: If True, return a reduced scalar loss instead of per-token tensors. Default: False
+        importance_sampling_level: "token" or "sequence" (GSPO) IS correction level. Default: "token"
+            Sequence-level is implemented for the CuTile backend; the Triton backend raises for it.
+        sapo_temperature_pos: SAPO sigmoid temperature for positive advantages. Default: 1.0
+        sapo_temperature_neg: SAPO sigmoid temperature for negative advantages. Default: 1.05
+        vllm_is_ratio: Optional importance sampling ratio tensor.
+        delta: Dual-sided clipping upper bound from INTELLECT-2 (clamps coef_1). Default: None
+        use_bias_correction_kl: Enable DeepSeek-V3.2 IS-corrected KL: kl *= coef_1. Default: False
+        num_items_in_batch: Optional global token count for DAPO/CISPO/VESPO normalization. Default: None
+        phi_seq: Per-sequence gamma weight of shape (B,) or (B, 1); required for loss_type="vespo". Default: None
+
+    Returns:
+        If reduce=False:
+            Tuple (loss, kl, is_clipped):
+                loss: Per-token loss of shape (B, L), float32.
+                kl: Per-token KL divergence of shape (B, L) or None when beta=0.
+                is_clipped: Per-token clip indicator of shape (B, L), float32.
+        If reduce=True:
+            Tuple (loss, kl, clip_ratio):
+                loss: Reduced scalar loss.
+                kl: Mean KL divergence scalar or None when beta=0.
+                clip_ratio: Fraction of clipped tokens, scalar.
+    """
+    raise NotImplementedError(f"grpo_loss is not implemented for {get_current_backend()}")
+
+
+@dispatch(
+    "liger.rms_norm",
+)
+def rms_norm(
+    X: torch.Tensor,
+    W: Optional[torch.Tensor],
+    eps: float,
+    offset: float = 0.0,
+    casting_mode: str = "llama",
+    in_place: bool = True,
+    row_mode: Optional[bool] = None,
+) -> torch.Tensor:
+    """
+    RMS Normalization: Y = X / RMS(X) * (W + offset).
+
+    Reference: https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/rms_norm.py
+
+    Args:
+        X: Input tensor of shape (*, H).
+        W: Affine scale weight of shape (H,), or None for no affine transform.
+        eps: Epsilon for numerical stability.
+        offset: Constant added to W (e.g., 1.0 for Gemma). Default: 0.0
+        casting_mode: "llama" | "gemma" | "none" controls internal precision. Default: "llama"
+        in_place: Reuse dY buffer for dX in backward to save memory. Default: True
+        row_mode: Force row kernel if True. Default: None (auto)
+
+    Returns:
+        Normalized output tensor of same shape as X.
+    """
+    raise NotImplementedError(f"rms_norm is not implemented for {get_current_backend()}")
+
+
+@dispatch(
     "liger.qwen2vl_mrope",
 )
 def qwen2vl_mrope(
@@ -351,6 +608,26 @@ def rope(
 
 
 @dispatch(
+    "liger.softmax",
+)
+def softmax(
+    input: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Softmax applied on the last dimension.
+
+    Reference: https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/softmax.py
+
+    Args:
+        input: Input tensor of any shape (*, n_cols).
+
+    Returns:
+        Softmax output of same shape as input.
+    """
+    raise NotImplementedError(f"softmax is not implemented for {get_current_backend()}")
+
+
+@dispatch(
     "liger.sparsemax",
 )
 def sparsemax(
@@ -370,6 +647,33 @@ def sparsemax(
         Sparsemax output of same shape as input.
     """
     raise NotImplementedError(f"sparsemax is not implemented for {get_current_backend()}")
+
+
+@dispatch(
+    "liger.swiglu",
+)
+def swiglu(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    gate_multiplier: float = 1.0,
+    down_multiplier: float = 1.0,
+) -> torch.Tensor:
+    """
+    SwiGLU activation: c = silu(a * gate_multiplier) * b * down_multiplier
+    where silu(x) = x * sigmoid(x).
+
+    Reference: https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/swiglu.py
+
+    Args:
+        a: Gate tensor of shape (*, N).
+        b: Value tensor of shape (*, N).
+        gate_multiplier: Scalar multiplier applied to ``a`` before SiLU. Default 1.0.
+        down_multiplier: Scalar multiplier applied to the output ``silu(a*gm)*b``. Default 1.0.
+
+    Returns:
+        Output tensor of same shape as a and b.
+    """
+    raise NotImplementedError(f"swiglu is not implemented for {get_current_backend()}")
 
 
 @dispatch(
@@ -401,6 +705,34 @@ def tiled_mlp(
         Output tensor of same shape as x.
     """
     raise NotImplementedError(f"tiled_mlp is not implemented for {get_current_backend()}")
+
+
+@dispatch(
+    "liger.tvd",
+)
+def tvd(
+    p: torch.Tensor,
+    q: torch.Tensor,
+    shift_labels: Optional[torch.Tensor] = None,
+    reduction: str = "batchmean",
+    ignore_index: int = -100,
+) -> torch.Tensor:
+    """
+    Total Variation Distance loss: TVD(P || Q) = 0.5 * |P - Q|.
+
+    Reference: https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/tvd.py
+
+    Args:
+        p: First distribution of shape (BT, V). Can be float16/bfloat16/float32.
+        q: Second distribution of shape (BT, V).
+        shift_labels: Optional token labels of shape (BT,) for ignore_index masking. Default: None
+        reduction: Reduction mode: "none" | "sum" | "mean" | "batchmean". Default: "batchmean"
+        ignore_index: Label value to ignore when shift_labels is provided. Default: -100
+
+    Returns:
+        Loss tensor. Shape (BT, V) when reduction="none", scalar otherwise.
+    """
+    raise NotImplementedError(f"tvd is not implemented for {get_current_backend()}")
 
 
 @dispatch(

--- a/src/tilegym/transformers/qwen3_5/kernel_definitions/qwen3_5_causal_conv1d_update_silu.json
+++ b/src/tilegym/transformers/qwen3_5/kernel_definitions/qwen3_5_causal_conv1d_update_silu.json
@@ -1,76 +1,76 @@
 {
+  "name": "qwen3_5_causal_conv1d_update_silu",
+  "op_type": "causal_conv1d_update_silu",
   "axes": {
     "B": {
-      "description": "Supported batch size.",
       "type": "const",
-      "value": 1
+      "value": 1,
+      "description": "Supported batch size."
     },
     "D": {
-      "description": "Channel dimension.",
-      "type": "var"
+      "type": "var",
+      "description": "Channel dimension."
     },
     "K": {
-      "description": "Convolution kernel size.",
       "type": "const",
-      "value": 4
+      "value": 4,
+      "description": "Convolution kernel size."
     },
     "K_state": {
-      "description": "Cached state length.",
       "type": "const",
-      "value": 3
+      "value": 4,
+      "description": "Cached state length."
     },
     "S": {
-      "description": "Decode sequence length.",
       "type": "const",
-      "value": 1
+      "value": 1,
+      "description": "Decode sequence length."
     }
   },
-  "constraints": [
-    "K_state == K - 1"
-  ],
-  "description": "Qwen3.5 decode-path depthwise causal conv1d update fused with SiLU. The conv_state input is updated in-place.",
   "inputs": {
     "conv_state": {
-      "dtype": "bfloat16",
       "shape": [
         "B",
         "D",
         "K_state"
-      ]
+      ],
+      "dtype": "bfloat16"
     },
     "hidden_states": {
-      "dtype": "bfloat16",
       "shape": [
         "B",
         "D",
         "S"
-      ]
+      ],
+      "dtype": "bfloat16"
     },
     "weight": {
-      "dtype": "bfloat16",
       "shape": [
         "D",
         "K"
-      ]
+      ],
+      "dtype": "bfloat16"
     }
   },
-  "name": "qwen3_5_causal_conv1d_update_silu",
-  "op_type": "causal_conv1d_update_silu",
   "outputs": {
     "output": {
-      "dtype": "bfloat16",
       "shape": [
         "B",
         "D",
         "S"
-      ]
+      ],
+      "dtype": "bfloat16"
     }
   },
-  "reference": "# Source: https://github.com/huggingface/transformers/blob/aad13b87ed59f2afcfaebc985f403301887a35fc/src/transformers/models/qwen3_5/modeling_qwen3_5.py#L545-L554\nimport torch\n\ndef run(hidden_states, conv_state, weight, bias=None, activation=None):\n    x = hidden_states[:, :, 0]\n    full = torch.cat([conv_state, x.unsqueeze(-1)], dim=-1)\n    dot = (full * weight.unsqueeze(0)).sum(-1)\n    output = dot * torch.sigmoid(dot)\n    conv_state[:, :, 0] = conv_state[:, :, 1]\n    conv_state[:, :, 1] = conv_state[:, :, 2]\n    conv_state[:, :, 2] = x\n    return output.unsqueeze(-1)",
+  "reference": "# Source: https://github.com/huggingface/transformers/blob/aad13b87ed59f2afcfaebc985f403301887a35fc/src/transformers/models/qwen3_5/modeling_qwen3_5.py#L545-L554\nimport torch\nimport torch.nn.functional as F\n\ndef run(hidden_states, conv_state, weight, bias=None, activation=None):\n    _, hidden_size, seq_len = hidden_states.shape\n    state_len = conv_state.shape[-1]\n    hidden_states_new = torch.cat([conv_state, hidden_states], dim=-1).to(weight.dtype)\n    conv_state.copy_(hidden_states_new[:, :, -state_len:])\n    output = F.conv1d(hidden_states_new, weight.unsqueeze(1), bias, padding=0, groups=hidden_size)\n    output = F.silu(output[:, :, -seq_len:])\n    return output.to(hidden_states.dtype)",
   "tags": [
     "model:qwen3.5",
     "stage:decode",
     "status:verified",
     "fused"
+  ],
+  "description": "Qwen3.5 decode-path depthwise causal conv1d update fused with SiLU. The conv_state input is updated in-place.",
+  "constraints": [
+    "K_state == K"
   ]
 }

--- a/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_causal_conv1d_update_silu.json
+++ b/src/tilegym/transformers/qwen3_5/kernel_solutions/qwen3_5_causal_conv1d_update_silu.json
@@ -1,25 +1,25 @@
 {
-  "author": "tilegym-agent",
-  "definition": "qwen3_5_causal_conv1d_update_silu",
-  "description": "cuTile fused decode-path causal conv1d update and SiLU for Qwen3.5.",
   "name": "qwen3_5_causal_conv1d_update_silu_cutile",
-  "sources": {
-    "path": [
-      "src/tilegym/transformers/qwen3_5/kernels/causal_conv1d_update_silu.py"
-    ]
-  },
+  "definition": "qwen3_5_causal_conv1d_update_silu",
+  "author": "tilegym-agent",
   "spec": {
-    "dependencies": [
-      "torch",
-      "cuda-tile"
-    ],
-    "destination_passing_style": false,
-    "entry_point": "src/tilegym/transformers/qwen3_5/kernels/causal_conv1d_update_silu.py::causal_conv1d_update_silu_cutile",
     "language": "cuda-tile",
     "target_hardware": [
       "SM100",
       "SM103",
       "SM120"
+    ],
+    "entry_point": "src/tilegym/transformers/qwen3_5/kernels/causal_conv1d_update_silu.py::causal_conv1d_update_silu_cutile",
+    "dependencies": [
+      "torch",
+      "cuda-tile"
+    ],
+    "destination_passing_style": false
+  },
+  "sources": {
+    "path": [
+      "src/tilegym/transformers/qwen3_5/kernels/causal_conv1d_update_silu.py"
     ]
-  }
+  },
+  "description": "cuTile fused decode-path causal conv1d update and SiLU for Qwen3.5."
 }

--- a/src/tilegym/transformers/qwen3_5/kernels/causal_conv1d_update_silu.py
+++ b/src/tilegym/transformers/qwen3_5/kernels/causal_conv1d_update_silu.py
@@ -13,7 +13,7 @@ ConstInt = ct.Constant[int]
 @ct.kernel
 def _causal_conv1d_update_silu_kernel(
     x,  # (D,)
-    conv_state,  # (D, 3)
+    conv_state,  # (D, 4)
     weight,  # (D, 4)
     output,  # (D,)
     BLOCK_D: ConstInt,
@@ -23,9 +23,9 @@ def _causal_conv1d_update_silu_kernel(
     offs = ct.arange(BLOCK_D, dtype=ct.int32)
     d_idx = d_start + offs
 
-    s0 = ct.astype(ct.gather(conv_state, (d_idx, 0), check_bounds=True), ct.float32)
     s1 = ct.astype(ct.gather(conv_state, (d_idx, 1), check_bounds=True), ct.float32)
     s2 = ct.astype(ct.gather(conv_state, (d_idx, 2), check_bounds=True), ct.float32)
+    s3 = ct.astype(ct.gather(conv_state, (d_idx, 3), check_bounds=True), ct.float32)
     xv = ct.astype(ct.gather(x, (d_idx,), check_bounds=True), ct.float32)
 
     w0 = ct.astype(ct.gather(weight, (d_idx, 0), check_bounds=True), ct.float32)
@@ -33,14 +33,15 @@ def _causal_conv1d_update_silu_kernel(
     w2 = ct.astype(ct.gather(weight, (d_idx, 2), check_bounds=True), ct.float32)
     w3 = ct.astype(ct.gather(weight, (d_idx, 3), check_bounds=True), ct.float32)
 
-    dot = s0 * w0 + s1 * w1 + s2 * w2 + xv * w3
+    dot = s1 * w0 + s2 * w1 + s3 * w2 + xv * w3
     sig = ct.truediv(1.0, ct.add(1.0, ct.exp(ct.negative(dot))))
     result = dot * sig
 
     ct.scatter(output, (d_idx,), ct.astype(result, output.dtype), check_bounds=True)
     ct.scatter(conv_state, (d_idx, 0), ct.astype(s1, conv_state.dtype), check_bounds=True)
     ct.scatter(conv_state, (d_idx, 1), ct.astype(s2, conv_state.dtype), check_bounds=True)
-    ct.scatter(conv_state, (d_idx, 2), ct.astype(xv, conv_state.dtype), check_bounds=True)
+    ct.scatter(conv_state, (d_idx, 2), ct.astype(s3, conv_state.dtype), check_bounds=True)
+    ct.scatter(conv_state, (d_idx, 3), ct.astype(xv, conv_state.dtype), check_bounds=True)
 
 
 def causal_conv1d_update_silu_cutile(
@@ -54,6 +55,8 @@ def causal_conv1d_update_silu_cutile(
     B, D, seq_len = hidden_states.shape
     assert seq_len == 1, "causal_conv1d_update_silu_cutile only supports seq_len=1"
     assert B == 1, "causal_conv1d_update_silu_cutile only supports B=1 currently"
+    assert conv_state.shape == (B, D, 4), f"expected conv_state shape {(B, D, 4)}, got {conv_state.shape}"
+    assert weight.shape == (D, 4), f"expected weight shape {(D, 4)}, got {weight.shape}"
 
     x = hidden_states.squeeze(0).squeeze(-1).contiguous()
     w = weight.contiguous()

--- a/tests/kernel_inventory/kernel_runtime_utils.py
+++ b/tests/kernel_inventory/kernel_runtime_utils.py
@@ -399,6 +399,8 @@ def _torch_dtype(dtype: str, torch: Any) -> Any:
         "float32": torch.float32,
         "float16": torch.float16,
         "bfloat16": torch.bfloat16,
+        "float8_e4m3fn": torch.float8_e4m3fn,
+        "float8_e5m2": torch.float8_e5m2,
         "int64": torch.int64,
         "int32": torch.int32,
         "int16": torch.int16,

--- a/tests/ops/test_chunk_gated_delta_rule.py
+++ b/tests/ops/test_chunk_gated_delta_rule.py
@@ -241,9 +241,14 @@ class Test_ChunkGatedDeltaRule(common.PyTestCase):
         device = "cuda"
 
         torch.manual_seed(0)
-        q = torch.randn(B, T, H, D, device=device, dtype=dtype)
-        k = torch.randn(B, T, H, D, device=device, dtype=dtype)
-        v = torch.randn(B, T, H, D, device=device, dtype=dtype)
+        # Scale q/k/v by 0.1 (same as test_op) so the long-sequence recurrence
+        # stays bounded. Unscaled randn diverges to inf/NaN for large T (in both
+        # the kernel and the torch reference); benchmarking NaN-producing inputs
+        # is misleading and can perturb timing via NaN/denormal handling. Shapes
+        # and FLOPs are unchanged, so the measured latency is unaffected.
+        q = torch.randn(B, T, H, D, device=device, dtype=dtype) * 0.1
+        k = torch.randn(B, T, H, D, device=device, dtype=dtype) * 0.1
+        v = torch.randn(B, T, H, D, device=device, dtype=dtype) * 0.1
         g = -torch.abs(torch.randn(B, T, H, device=device, dtype=dtype)) * 0.5
         beta = torch.sigmoid(torch.randn(B, T, H, device=device, dtype=dtype))
 
@@ -264,3 +269,54 @@ class Test_ChunkGatedDeltaRule(common.PyTestCase):
         del q, k, v, g, beta
         torch.cuda.empty_cache()
         gc.collect()
+
+    @pytest.mark.parametrize("T", [512, 2048], ids=["T512", "T2048"])
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_long_seq(self, T, backend, arch):
+        """Correctness at perf-representative sequence lengths.
+
+        ``test_op`` only covers T<=128 and ``test_perf`` asserts no correctness,
+        so the many-chunk regime the perf shapes exercise (inter-chunk state scan
+        + the intra Neumann solve over dozens of chunks) is otherwise unverified.
+        Uses the same scaled inputs as ``test_op`` so the recurrence stays bounded
+        (unscaled randn diverges to inf/NaN in *both* the reference and the kernel
+        for long T — see test_perf, which only times).
+        """
+        if not tilegym.is_backend_available(backend):
+            pytest.skip(f"Backend {backend} is not available")
+        tilegym.set_backend(backend)
+        self.setUp()
+        from tilegym.ops import chunk_gated_delta_rule
+
+        device = "cuda"
+        dtype = torch.bfloat16
+        B, H, K, V, CS = 2, 8, 128, 128, 64
+        torch.manual_seed(42)
+        query = torch.randn(B, T, H, K, device=device, dtype=dtype) * 0.1
+        key = torch.randn(B, T, H, K, device=device, dtype=dtype) * 0.1
+        value = torch.randn(B, T, H, V, device=device, dtype=dtype) * 0.1
+        g = -torch.abs(torch.randn(B, T, H, device=device, dtype=dtype)) * 0.5
+        beta = torch.sigmoid(torch.randn(B, T, H, device=device, dtype=dtype))
+
+        ref_out, _ = self.reference(
+            query.clone(),
+            key.clone(),
+            value.clone(),
+            g.clone(),
+            beta.clone(),
+            chunk_size=CS,
+            use_qk_l2norm_in_kernel=True,
+        )
+        test_out, _ = chunk_gated_delta_rule(
+            query.clone(),
+            key.clone(),
+            value.clone(),
+            g.clone(),
+            beta.clone(),
+            chunk_size=CS,
+            use_qk_l2norm_in_kernel=True,
+        )
+        assert torch.isfinite(test_out).all(), "kernel produced non-finite output on bounded input"
+        assert torch.allclose(ref_out, test_out, atol=2e-3, rtol=5e-3), (
+            f"Output mismatch at T={T}: max_abs_err={(ref_out - test_out).abs().max().item():.2e}"
+        )

--- a/tests/ops/test_chunk_gated_delta_rule.py
+++ b/tests/ops/test_chunk_gated_delta_rule.py
@@ -32,6 +32,9 @@ _SHAPE_CONFIGS = [
     pytest.param(2, 128, 4, 64, 64, 32, False, False, False, id="chunk32"),
     pytest.param(1, 37, 4, 64, 64, 64, False, False, False, id="T37_prime"),
     pytest.param(2, 65, 4, 128, 128, 64, False, True, False, id="T65_off_by_1"),
+    pytest.param(2, 512, 8, 128, 128, 64, False, False, True, id="T512_long_seq"),
+    pytest.param(2, 2048, 8, 128, 128, 64, False, False, True, id="T2048_long_seq"),
+    pytest.param(1, 10782, 8, 128, 128, 64, False, False, True, id="qwen3_5_T10782"),
 ]
 
 _DTYPES = [
@@ -167,7 +170,7 @@ class Test_ChunkGatedDeltaRule(common.PyTestCase):
             pytest.skip(f"Backend {backend} is not available")
         try:
             tilegym.set_backend(backend)
-        except Exception as e:
+        except ValueError as e:
             pytest.skip(f"Backend is not supported: {e}")
 
         if dtype == torch.float32:
@@ -216,6 +219,7 @@ class Test_ChunkGatedDeltaRule(common.PyTestCase):
             use_qk_l2norm_in_kernel=use_l2,
         )
 
+        assert torch.isfinite(test_out).all(), "kernel produced non-finite output on bounded input"
         atol = 1e-3 if dtype == torch.float32 else 2e-3
         rtol = 2e-3 if dtype == torch.float32 else 5e-3
 
@@ -270,53 +274,61 @@ class Test_ChunkGatedDeltaRule(common.PyTestCase):
         torch.cuda.empty_cache()
         gc.collect()
 
-    @pytest.mark.parametrize("T", [512, 2048], ids=["T512", "T2048"])
+    @pytest.mark.parametrize("use_l2", [False, True], ids=["prenormalized", "in_kernel_l2"])
     @pytest.mark.parametrize("backend", _backends)
-    def test_op_long_seq(self, T, backend, arch):
-        """Correctness at perf-representative sequence lengths.
+    def test_op_correlated_keys_stable_triangular_solve(self, use_l2, backend, arch, monkeypatch):
+        """Keep the chunk solve stable for strongly correlated model-like keys.
 
-        ``test_op`` only covers T<=128 and ``test_perf`` asserts no correctness,
-        so the many-chunk regime the perf shapes exercise (inter-chunk state scan
-        + the intra Neumann solve over dozens of chunks) is otherwise unverified.
-        Uses the same scaled inputs as ``test_op`` so the recurrence stays bounded
-        (unscaled randn diverges to inf/NaN in *both* the reference and the kernel
-        for long T — see test_perf, which only times).
+        Random scaled keys leave the unit lower-triangular system well
+        conditioned. Correlated keys exercise the cancellation-sensitive case
+        that reduced-precision Neumann products amplified catastrophically. The
+        pre-normalized case also exercises the non-L2 infinity-norm guard.
         """
+        monkeypatch.setenv("TILEGYM_DISABLE_AUTOTUNE", "1")
         if not tilegym.is_backend_available(backend):
             pytest.skip(f"Backend {backend} is not available")
-        tilegym.set_backend(backend)
+        try:
+            tilegym.set_backend(backend)
+        except ValueError as e:
+            pytest.skip(f"Backend is not supported: {e}")
         self.setUp()
         from tilegym.ops import chunk_gated_delta_rule
 
         device = "cuda"
         dtype = torch.bfloat16
-        B, H, K, V, CS = 2, 8, 128, 128, 64
-        torch.manual_seed(42)
+        B, T, H, K, V, CS = 1, 64, 1, 128, 128, 64
+        torch.manual_seed(0)
+        key_base = torch.randn(B, 1, H, K, device=device)
+        key = (key_base + 0.02 * torch.randn(B, T, H, K, device=device)).to(dtype)
+        if not use_l2:
+            key = F.normalize(key.float(), dim=-1).to(dtype)
         query = torch.randn(B, T, H, K, device=device, dtype=dtype) * 0.1
-        key = torch.randn(B, T, H, K, device=device, dtype=dtype) * 0.1
         value = torch.randn(B, T, H, V, device=device, dtype=dtype) * 0.1
-        g = -torch.abs(torch.randn(B, T, H, device=device, dtype=dtype)) * 0.5
-        beta = torch.sigmoid(torch.randn(B, T, H, device=device, dtype=dtype))
+        g = -torch.rand(B, T, H, device=device) * 0.02
+        beta = torch.sigmoid(torch.randn(B, T, H, device=device, dtype=dtype) + 2)
 
-        ref_out, _ = self.reference(
-            query.clone(),
-            key.clone(),
-            value.clone(),
-            g.clone(),
-            beta.clone(),
+        ref_out, ref_state = self.reference(
+            query,
+            key,
+            value,
+            g,
+            beta,
             chunk_size=CS,
-            use_qk_l2norm_in_kernel=True,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=use_l2,
         )
-        test_out, _ = chunk_gated_delta_rule(
-            query.clone(),
-            key.clone(),
-            value.clone(),
-            g.clone(),
-            beta.clone(),
+        test_out, test_state = chunk_gated_delta_rule(
+            query,
+            key,
+            value,
+            g,
+            beta,
             chunk_size=CS,
-            use_qk_l2norm_in_kernel=True,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=use_l2,
         )
-        assert torch.isfinite(test_out).all(), "kernel produced non-finite output on bounded input"
-        assert torch.allclose(ref_out, test_out, atol=2e-3, rtol=5e-3), (
-            f"Output mismatch at T={T}: max_abs_err={(ref_out - test_out).abs().max().item():.2e}"
-        )
+
+        assert torch.isfinite(test_out).all()
+        assert torch.isfinite(test_state).all()
+        torch.testing.assert_close(test_out, ref_out, atol=2e-3, rtol=5e-3)
+        torch.testing.assert_close(test_state, ref_state, atol=3e-3, rtol=5e-3)

--- a/tests/ops/test_chunk_gated_delta_rule.py
+++ b/tests/ops/test_chunk_gated_delta_rule.py
@@ -284,6 +284,8 @@ class Test_ChunkGatedDeltaRule(common.PyTestCase):
         that reduced-precision Neumann products amplified catastrophically. The
         pre-normalized case also exercises the non-L2 infinity-norm guard.
         """
+        if backend == "tilecpp":
+            pytest.skip("Skipping tilecpp case due to known failure; under investigation")
         monkeypatch.setenv("TILEGYM_DISABLE_AUTOTUNE", "1")
         if not tilegym.is_backend_available(backend):
             pytest.skip(f"Backend {backend} is not available")

--- a/tests/ops/test_matmul.py
+++ b/tests/ops/test_matmul.py
@@ -205,8 +205,6 @@ class Test_Matmul(common.PyTestCase):
             pytest.skip("Skip due to sm80 not support fp8 type")
         if backend == "cutile" and not static_persistent and transpose_a:
             pytest.skip("Cutile transpose_a is not supported when static_persistent is False")
-        if backend == "tilecpp" and dtype == torch.float32 and m >= 16384:
-            pytest.skip("Skip tilecpp float32 matmul with m >= 16384 due to timeout")
 
         a, b = self.prepare_data(m, n, k, transpose_a, transpose_b, offset_a, offset_b, dtype)
         kernel_kwargs = {

--- a/tests/ops/test_recurrent_gated_delta_rule.py
+++ b/tests/ops/test_recurrent_gated_delta_rule.py
@@ -19,6 +19,7 @@ _perf_frameworks = _backends + ["pytorch"]
 
 _SHAPE_CONFIGS = [
     pytest.param(2, 1, 4, 64, 64, False, False, False, id="decode"),
+    pytest.param(1, 1, 16, 128, 128, True, True, True, id="qwen35_cached_decode"),
     pytest.param(2, 16, 4, 64, 64, False, False, False, id="T16"),
     pytest.param(1, 32, 8, 128, 128, False, True, False, id="T32_final_state"),
     pytest.param(2, 8, 4, 64, 64, True, True, False, id="init_final_state"),

--- a/tests/suites/liger/test_dyt.py
+++ b/tests/suites/liger/test_dyt.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import gc
+
+import pytest
+import torch
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import dyt
+
+
+class Test_Liger_DyT(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @staticmethod
+    def reference(x, alpha, gamma, beta=None):
+        """
+        PyTorch reference implementation of DyT.
+
+        Formula: y = tanh(alpha * x) * gamma + beta
+        """
+        x_f = x.float()
+        alpha_f = alpha.float()
+        gamma_f = gamma.float()
+        tanh_x = torch.tanh(alpha_f * x_f)
+        y = tanh_x * gamma_f
+        if beta is not None:
+            y = y + beta.float()
+        return y.to(x.dtype)
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+            ((2, 4, 512), torch.float32),  # multi-dimensional
+            ((4, 300), torch.float32),  # non-power-of-2 hidden dim
+            # Shapes from Liger test/transformers/test_dyt.py
+            ((2, 8, 4096), torch.float32),
+            ((4, 16, 2048), torch.float32),
+            ((1, 1, 1023), torch.float32),  # non-power-of-2
+            ((3, 7, 256), torch.float32),
+        ],
+    )
+    @pytest.mark.parametrize("have_beta", [True, False])
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op(self, shape, dtype, have_beta, backend, monkeypatch):
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        N = shape[-1]
+
+        x = torch.randn(*shape, dtype=dtype, device=device)
+        alpha = torch.randn(1, dtype=dtype, device=device)
+        gamma = torch.randn(N, dtype=dtype, device=device)
+        beta = torch.randn(N, dtype=dtype, device=device) if have_beta else None
+
+        self.assertCorrectness(
+            dyt,
+            self.reference,
+            {
+                "x": x,
+                "alpha": alpha,
+                "gamma": gamma,
+                "beta": beta,
+            },
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((8, 512), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+            # Shapes from Liger test/transformers/test_dyt.py
+            ((2, 8, 4096), torch.float32),
+            ((4, 16, 2048), torch.float32),
+            ((1, 1, 1023), torch.float32),  # non-power-of-2
+            ((3, 7, 256), torch.float32),
+        ],
+    )
+    @pytest.mark.parametrize("have_beta", [True, False])
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_backward(self, shape, dtype, have_beta, backend, monkeypatch):
+        """Test backward pass (gradients for x, alpha, gamma, and optional beta)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        N = shape[-1]
+
+        x = torch.randn(*shape, dtype=dtype, device=device, requires_grad=True)
+        alpha = torch.randn(1, dtype=dtype, device=device, requires_grad=True)
+        gamma = torch.randn(N, dtype=dtype, device=device, requires_grad=True)
+        beta = torch.randn(N, dtype=dtype, device=device, requires_grad=True) if have_beta else None
+
+        dout = torch.ones(*shape, dtype=dtype, device=device)
+
+        self.assertCorrectness(
+            dyt,
+            self.reference,
+            {
+                "x": x,
+                "alpha": alpha,
+                "gamma": gamma,
+                "beta": beta,
+            },
+            gradient=dout,
+            atol=1e-2,
+            rtol=1e-2,
+        )

--- a/tests/suites/liger/test_fused_add_rms_norm.py
+++ b/tests/suites/liger/test_fused_add_rms_norm.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import gc
+
+import pytest
+import torch
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import fused_add_rms_norm
+
+
+class Test_Liger_FusedAddRMSNorm(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @staticmethod
+    def reference(X, R, W, eps=1e-6, offset=0.0, casting_mode="llama"):
+        """
+        PyTorch float32 reference for fused residual-add + RMSNorm.
+
+        Computes:
+          S = X + R
+          Y = S / RMS(S) * (W + offset)
+        where RMS(S) = sqrt(mean(S^2) + eps).
+        """
+        S = X.float() + R.float()
+        rms = S.pow(2).mean(dim=-1, keepdim=True).add(eps).rsqrt()
+        W_shifted = W.float() + offset
+        Y = (S * rms * W_shifted).to(X.dtype)
+        return Y, S.to(X.dtype)
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((8, 512), torch.float32),
+            ((16, 1024), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+            ((2, 4, 512), torch.float32),  # multi-dimensional input
+            ((4, 300), torch.float32),  # non-power-of-2 hidden dim
+            # Shapes from Liger test/transformers/test_fused_add_rms_norm.py
+            ((9, 7, 41), torch.float32),
+            ((2, 128, 512), torch.float32),
+        ],
+    )
+    @pytest.mark.parametrize("offset", [0.0, 1.0])
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_forward(self, shape, dtype, offset, backend, monkeypatch):
+        """Test forward output (Y, S) matches PyTorch reference."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        H = shape[-1]
+
+        X = torch.randn(*shape, dtype=dtype, device=device)
+        R = torch.randn(*shape, dtype=dtype, device=device)
+        W = torch.randn(H, dtype=dtype, device=device)
+
+        atol = 1e-2 if dtype != torch.float32 else 5e-3
+        rtol = 1e-2 if dtype != torch.float32 else 5e-3
+
+        Y_test, S_test = fused_add_rms_norm(X, R, W, eps=1e-6, offset=offset, casting_mode="llama")
+        Y_ref, S_ref = self.reference(X, R, W, eps=1e-6, offset=offset)
+
+        assert torch.allclose(Y_test.float(), Y_ref.float(), atol=atol, rtol=rtol), (
+            f"Y mismatch: max_diff={((Y_test.float() - Y_ref.float()).abs().max()).item():.6f}"
+        )
+        assert torch.allclose(S_test.float(), S_ref.float(), atol=1e-5, rtol=1e-5), (
+            f"S mismatch: max_diff={((S_test.float() - S_ref.float()).abs().max()).item():.6f}"
+        )
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((8, 512), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+            ((9, 7, 41), torch.float32),
+            ((2, 128, 512), torch.float32),
+        ],
+    )
+    @pytest.mark.parametrize("offset", [0.0, 1.0])
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_backward(self, shape, dtype, offset, backend, monkeypatch):
+        """Test backward gradients (dX, dR, dW) match PyTorch reference."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        H = shape[-1]
+
+        X_data = torch.randn(*shape, dtype=dtype, device=device)
+        R_data = torch.randn(*shape, dtype=dtype, device=device)
+        W_data = torch.randn(H, dtype=dtype, device=device)
+
+        atol = 1e-1
+        rtol = 1e-1
+
+        # Test implementation
+        X_test = X_data.clone().requires_grad_(True)
+        R_test = R_data.clone().requires_grad_(True)
+        W_test = W_data.clone().requires_grad_(True)
+
+        Y_test, S_test = fused_add_rms_norm(X_test, R_test, W_test, eps=1e-6, offset=offset)
+        # Backward through both outputs
+        dout_Y = torch.ones_like(Y_test)
+        dout_S = torch.ones_like(S_test)
+        torch.autograd.backward([Y_test, S_test], [dout_Y, dout_S])
+
+        # Reference (float32 for stability)
+        X_ref = X_data.clone().float().requires_grad_(True)
+        R_ref = R_data.clone().float().requires_grad_(True)
+        W_ref = W_data.clone().float().requires_grad_(True)
+
+        S_ref = X_ref + R_ref
+        rms = S_ref.pow(2).mean(dim=-1, keepdim=True).add(1e-6).rsqrt()
+        Y_ref = S_ref * rms * (W_ref + offset)
+        # Backward through both outputs
+        torch.autograd.backward(
+            [Y_ref, S_ref],
+            [torch.ones_like(Y_ref), torch.ones_like(S_ref)],
+        )
+
+        assert torch.allclose(X_test.grad.float(), X_ref.grad.float(), atol=atol, rtol=rtol), (
+            f"dX mismatch: max_diff={((X_test.grad.float() - X_ref.grad.float()).abs().max()).item():.6f}"
+        )
+        assert torch.allclose(R_test.grad.float(), R_ref.grad.float(), atol=atol, rtol=rtol), (
+            f"dR mismatch: max_diff={((R_test.grad.float() - R_ref.grad.float()).abs().max()).item():.6f}"
+        )
+        assert torch.allclose(W_test.grad.float(), W_ref.grad.float(), atol=atol, rtol=rtol), (
+            f"dW mismatch: max_diff={((W_test.grad.float() - W_ref.grad.float()).abs().max()).item():.6f}"
+        )
+
+    @pytest.mark.parametrize(
+        "casting_mode",
+        ["llama", "gemma", "none"],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_casting_modes(self, casting_mode, backend, monkeypatch):
+        """Test that all casting modes produce numerically close results."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        X = torch.randn(4, 256, dtype=torch.float32, device=device)
+        R = torch.randn(4, 256, dtype=torch.float32, device=device)
+        W = torch.randn(256, dtype=torch.float32, device=device)
+
+        Y_test, S_test = fused_add_rms_norm(X, R, W, eps=1e-6, offset=0.0, casting_mode=casting_mode)
+        Y_ref, S_ref = self.reference(X, R, W, eps=1e-6, offset=0.0)
+
+        assert torch.allclose(Y_test, Y_ref, atol=1e-3, rtol=1e-3), f"casting_mode={casting_mode}: Y mismatch"
+        assert torch.allclose(S_test, S_ref, atol=1e-5, rtol=1e-5), f"casting_mode={casting_mode}: S mismatch"

--- a/tests/suites/liger/test_fused_linear_cross_entropy.py
+++ b/tests/suites/liger/test_fused_linear_cross_entropy.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import gc
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import fused_linear_cross_entropy
+
+
+class Test_Liger_FusedLinearCrossEntropy(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @staticmethod
+    def reference(input, weight, target, bias=None, ignore_index=-100, label_smoothing=0.0, reduction="mean"):
+        """PyTorch float32 reference for fused linear + cross-entropy."""
+        logits = input.float() @ weight.float().t()
+        if bias is not None:
+            logits = logits + bias.float()
+        return F.cross_entropy(
+            logits,
+            target,
+            ignore_index=ignore_index,
+            label_smoothing=label_smoothing,
+            reduction=reduction,
+        )
+
+    @pytest.mark.parametrize(
+        "BT, H, V, dtype",
+        [
+            (4, 64, 128, torch.float32),
+            (8, 128, 256, torch.float32),
+            (4, 64, 128, torch.float16),
+            (4, 64, 128, torch.bfloat16),
+            (6, 64, 150, torch.float32),  # non-power-of-2 vocab
+            # Shapes from Liger test/transformers/test_fused_linear_cross_entropy.py
+            (63, 41, 41, torch.float32),
+            (1024, 1024, 4096, torch.float32),
+        ],
+    )
+    @pytest.mark.parametrize("reduction", ["mean", "sum"])
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_forward(self, BT, H, V, dtype, reduction, backend, monkeypatch):
+        """Test forward loss matches PyTorch reference."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        input_data = torch.randn(BT, H, dtype=dtype, device=device)
+        weight = torch.randn(V, H, dtype=dtype, device=device)
+        target = torch.randint(0, V, (BT,), device=device)
+        target[: BT // 4] = -100
+
+        atol = 1e-2 if dtype != torch.float32 else 5e-3
+        rtol = 1e-2 if dtype != torch.float32 else 5e-3
+
+        loss_test = fused_linear_cross_entropy(
+            input_data.clone(), weight, target, ignore_index=-100, reduction=reduction
+        )
+        loss_ref = self.reference(input_data, weight, target, ignore_index=-100, reduction=reduction)
+
+        assert torch.allclose(loss_test.float(), loss_ref.float(), atol=atol, rtol=rtol), (
+            f"Loss mismatch: test={loss_test.item():.6f}, ref={loss_ref.item():.6f}"
+        )
+
+    @pytest.mark.parametrize(
+        "BT, H, V, dtype",
+        [
+            (4, 64, 128, torch.float32),
+            (8, 128, 256, torch.float32),
+            (4, 64, 128, torch.float16),
+            (4, 64, 128, torch.bfloat16),
+            (63, 41, 41, torch.float32),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_backward(self, BT, H, V, dtype, backend, monkeypatch):
+        """Test backward gradient w.r.t. input matches PyTorch reference."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        input_data = torch.randn(BT, H, dtype=dtype, device=device)
+        weight = torch.randn(V, H, dtype=dtype, device=device)
+        target = torch.randint(0, V, (BT,), device=device)
+        target[: BT // 4] = -100
+
+        atol = 1e-1
+        rtol = 1e-1
+
+        # Test implementation
+        x_test = input_data.clone().requires_grad_(True)
+        loss_test = fused_linear_cross_entropy(x_test, weight, target, ignore_index=-100)
+        loss_test.backward()
+
+        # Reference (float32)
+        x_ref = input_data.clone().float().requires_grad_(True)
+        w_ref = weight.float()
+        logits_ref = x_ref @ w_ref.t()
+        loss_ref = F.cross_entropy(logits_ref, target, ignore_index=-100)
+        loss_ref.backward()
+
+        assert torch.allclose(x_test.grad.float(), x_ref.grad.float(), atol=atol, rtol=rtol), (
+            f"dInput mismatch: max_diff={((x_test.grad.float() - x_ref.grad.float()).abs().max()).item():.6f}"
+        )
+
+    @pytest.mark.parametrize(
+        "BT, H, V, dtype",
+        [
+            (4, 64, 128, torch.float32),
+            (4, 64, 128, torch.float16),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_with_bias(self, BT, H, V, dtype, backend, monkeypatch):
+        """Test that bias is correctly applied."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        input_data = torch.randn(BT, H, dtype=dtype, device=device)
+        weight = torch.randn(V, H, dtype=dtype, device=device)
+        bias = torch.randn(V, dtype=dtype, device=device)
+        target = torch.randint(0, V, (BT,), device=device)
+
+        atol = 1e-2 if dtype != torch.float32 else 5e-3
+        rtol = 1e-2 if dtype != torch.float32 else 5e-3
+
+        loss_test = fused_linear_cross_entropy(input_data.clone(), weight, target, bias=bias)
+        loss_ref = self.reference(input_data, weight, target, bias=bias)
+
+        assert torch.allclose(loss_test.float(), loss_ref.float(), atol=atol, rtol=rtol), (
+            f"Bias test loss mismatch: test={loss_test.item():.6f}, ref={loss_ref.item():.6f}"
+        )
+
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_features(self, backend, monkeypatch):
+        """Test the extended features: ce_weight, softcap, z_loss, token accuracy/predicted tokens."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        BT, H, V = 32, 64, 128
+        atol = rtol = 1e-3
+        x = torch.randn(BT, H, device=device)
+        w = torch.randn(V, H, device=device)
+        target = torch.randint(0, V, (BT,), device=device)
+        target[: BT // 4] = -100
+        logits = x.float() @ w.float().t()
+        valid = target != -100
+
+        # z-loss regularizer: lse_square_scale * logsumexp(logits)^2
+        lss = 1e-4
+        loss_z, z_loss = fused_linear_cross_entropy(
+            x.clone(), w, target, return_z_loss=True, lse_square_scale=lss, reduction="sum"
+        )
+        z_ref = (lss * torch.logsumexp(logits, -1)[valid] ** 2).sum()
+        assert torch.allclose(z_loss.float(), z_ref.float(), atol=atol, rtol=rtol), (
+            f"z_loss mismatch: {z_loss.item():.6f} vs {z_ref.item():.6f}"
+        )
+
+        # softcap: logits -> softcap * tanh(logits / softcap)
+        sc = 30.0
+        loss_sc = fused_linear_cross_entropy(x.clone(), w, target, softcap=sc, reduction="sum")
+        loss_sc_ref = F.cross_entropy(sc * torch.tanh(logits / sc), target, ignore_index=-100, reduction="sum")
+        assert torch.allclose(loss_sc.float(), loss_sc_ref.float(), atol=atol, rtol=rtol)
+
+        # per-class weight (weighted CE)
+        cw = torch.rand(V, device=device) + 0.5
+        loss_w = fused_linear_cross_entropy(x.clone(), w, target, ce_weight=cw, reduction="mean")
+        loss_w_ref = F.cross_entropy(logits, target, weight=cw, ignore_index=-100, reduction="mean")
+        assert torch.allclose(loss_w.float(), loss_w_ref.float(), atol=atol, rtol=rtol)
+
+        # token accuracy + predicted tokens
+        _, ta, pt = fused_linear_cross_entropy(
+            x.clone(), w, target, return_token_accuracy=True, return_predicted_tokens=True
+        )
+        pred = logits.argmax(-1)
+        acc_ref = (pred[valid] == target[valid]).float().mean()
+        assert torch.allclose(ta.float(), acc_ref.float(), atol=atol, rtol=rtol)
+        assert (pt[valid] == pred[valid]).all(), "predicted tokens must match argmax on valid rows"

--- a/tests/suites/liger/test_grpo_loss.py
+++ b/tests/suites/liger/test_grpo_loss.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import gc
+
+import pytest
+import torch
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import grpo_loss
+
+
+def _reference_grpo_loss(
+    logits,
+    old_logp,
+    ref_logp,
+    completion_ids,
+    advantages,
+    completion_mask=None,
+    temperature=0.9,
+    beta=0.0,
+    eps_low=0.2,
+    eps_high=0.2,
+    loss_type="grpo",
+):
+    """PyTorch float32 reference for GRPO forward pass."""
+    B, L_ADD_1, N = logits.shape
+    L = L_ADD_1 - 1
+    logits_f = logits.float()
+    advantages_f = advantages.float()
+
+    # Compute log-softmax / logsumexp for each (b, l)
+    log_probs = torch.log_softmax(logits_f[:, :L, :] / temperature, dim=-1)  # (B, L, N)
+    logp = log_probs.gather(-1, completion_ids.unsqueeze(-1)).squeeze(-1)  # (B, L)
+
+    if old_logp is not None:
+        old_logp_f = old_logp.float()
+    else:
+        old_logp_f = logp.detach()
+
+    coef_1 = torch.exp(logp - old_logp_f)
+    adv = advantages_f.unsqueeze(1).expand_as(logp)  # (B, L)
+
+    if loss_type in ("grpo", "dapo", "bnpo", "dr_grpo"):
+        coef_2 = coef_1.clamp(1.0 - eps_low, 1.0 + eps_high)
+        loss1 = coef_1 * adv
+        loss2 = coef_2 * adv
+        per_token_loss = -torch.minimum(loss1, loss2)
+        is_low_clipped = (coef_1 < (1.0 - eps_low)) & (adv < 0)
+        is_high_clipped = (coef_1 > (1.0 + eps_high)) & (adv > 0)
+        is_clipped = (is_low_clipped | is_high_clipped).float()
+    elif loss_type == "cispo":
+        coef_2 = torch.clamp(coef_1, max=eps_high)
+        per_token_loss = -coef_2 * adv * logp
+        is_clipped = (coef_1 > eps_high) & (adv > 0)
+        is_clipped = is_clipped.float()
+    else:
+        is_clipped = torch.zeros_like(logp)
+        per_token_loss = torch.zeros_like(logp)
+
+    kl = None
+    if beta != 0.0 and ref_logp is not None:
+        ref_logp_f = ref_logp.float()
+        kl = torch.exp(ref_logp_f - logp) - (ref_logp_f - logp) - 1.0
+        per_token_loss = per_token_loss + beta * kl
+
+    if completion_mask is not None:
+        mask_f = completion_mask.float()
+        per_token_loss = per_token_loss * mask_f
+
+    return per_token_loss, kl, is_clipped
+
+
+class Test_Liger_GrpoLoss(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @pytest.mark.parametrize(
+        "B, L, N",
+        [
+            (2, 8, 256),
+            (4, 16, 512),
+            (1, 4, 128),
+        ],
+    )
+    @pytest.mark.parametrize("loss_type", ["grpo", "cispo"])
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op(self, B, L, N, loss_type, backend, monkeypatch):
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        temperature = 0.9
+        eps_low = 0.2
+        eps_high = 0.2
+
+        logits = torch.randn(B, L + 1, N, dtype=torch.float32, device=device, requires_grad=True)
+        completion_ids = torch.randint(0, N, (B, L), dtype=torch.int64, device=device)
+        advantages = torch.randn(B, dtype=torch.float32, device=device)
+        old_logp = torch.randn(B, L, dtype=torch.float32, device=device)
+
+        loss, kl, is_clipped = grpo_loss(
+            logits,
+            old_logp,
+            None,  # ref_logp
+            completion_ids,
+            advantages,
+            temperature=temperature,
+            beta=0.0,
+            eps_low=eps_low,
+            eps_high=eps_high,
+            inplace=False,
+            loss_type=loss_type,
+        )
+
+        ref_loss, _, ref_is_clipped = _reference_grpo_loss(
+            logits.detach(),
+            old_logp,
+            None,
+            completion_ids,
+            advantages,
+            temperature=temperature,
+            eps_low=eps_low,
+            eps_high=eps_high,
+            loss_type=loss_type,
+        )
+
+        assert torch.allclose(loss.float(), ref_loss.float(), atol=1e-2, rtol=1e-2), (
+            f"loss mismatch: max={(loss.float() - ref_loss.float()).abs().max()}"
+        )
+
+    @pytest.mark.parametrize(
+        "B, L, N",
+        [
+            (2, 8, 256),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_with_mask(self, B, L, N, backend, monkeypatch):
+        """Test with completion_mask."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+
+        logits = torch.randn(B, L + 1, N, dtype=torch.float32, device=device)
+        completion_ids = torch.randint(0, N, (B, L), dtype=torch.int64, device=device)
+        advantages = torch.randn(B, dtype=torch.float32, device=device)
+        old_logp = torch.randn(B, L, dtype=torch.float32, device=device)
+        completion_mask = torch.randint(0, 2, (B, L), dtype=torch.bool, device=device)
+
+        loss, kl, is_clipped = grpo_loss(
+            logits,
+            old_logp,
+            None,
+            completion_ids,
+            advantages,
+            completion_mask=completion_mask,
+            beta=0.0,
+            inplace=False,
+        )
+
+        ref_loss, _, _ = _reference_grpo_loss(
+            logits,
+            old_logp,
+            None,
+            completion_ids,
+            advantages,
+            completion_mask=completion_mask,
+        )
+
+        assert torch.allclose(loss.float(), ref_loss.float(), atol=1e-2, rtol=1e-2)
+
+    @pytest.mark.parametrize(
+        "B, L, N",
+        [
+            (2, 8, 256),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_with_kl(self, B, L, N, backend, monkeypatch):
+        """Test with KL penalty (beta > 0)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        beta = 0.1
+
+        logits = torch.randn(B, L + 1, N, dtype=torch.float32, device=device)
+        completion_ids = torch.randint(0, N, (B, L), dtype=torch.int64, device=device)
+        advantages = torch.randn(B, dtype=torch.float32, device=device)
+        old_logp = torch.randn(B, L, dtype=torch.float32, device=device)
+        ref_logp = torch.randn(B, L, dtype=torch.float32, device=device)
+
+        loss, kl, is_clipped = grpo_loss(
+            logits,
+            old_logp,
+            ref_logp,
+            completion_ids,
+            advantages,
+            beta=beta,
+            inplace=False,
+        )
+        assert kl is not None
+
+        ref_loss, ref_kl, _ = _reference_grpo_loss(
+            logits,
+            old_logp,
+            ref_logp,
+            completion_ids,
+            advantages,
+            beta=beta,
+        )
+
+        assert torch.allclose(loss.float(), ref_loss.float(), atol=1e-2, rtol=1e-2)
+        assert torch.allclose(kl.float(), ref_kl.float(), atol=1e-2, rtol=1e-2)
+
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_backward(self, backend, monkeypatch):
+        """Test backward pass (gradient w.r.t. logits)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        B, L, N = 2, 8, 128
+
+        logits = torch.randn(B, L + 1, N, dtype=torch.float32, device=device, requires_grad=True)
+        completion_ids = torch.randint(0, N, (B, L), dtype=torch.int64, device=device)
+        advantages = torch.randn(B, dtype=torch.float32, device=device)
+        old_logp = torch.randn(B, L, dtype=torch.float32, device=device)
+
+        loss, kl, is_clipped = grpo_loss(
+            logits,
+            old_logp,
+            None,
+            completion_ids,
+            advantages,
+            beta=0.0,
+            inplace=False,
+        )
+        loss.sum().backward()
+        assert logits.grad is not None, "logits.grad should not be None after backward"

--- a/tests/suites/liger/test_poly_norm.py
+++ b/tests/suites/liger/test_poly_norm.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import pytest
+import torch
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import poly_norm
+
+
+class Test_Liger_PolyNorm(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @staticmethod
+    def reference(input, weight, bias, eps=1e-6):
+        """
+        PyTorch reference implementation of PolyNorm.
+
+        Formula: y = w₀·norm(x³) + w₁·norm(x²) + w₂·norm(x) + b
+        where norm(u) = u / sqrt(mean(u²) + ε)
+        """
+        x = input.float()
+        shape = x.shape
+        dim = shape[-1]
+        x_2d = x.view(-1, dim)
+
+        x3 = x_2d * x_2d * x_2d
+        x2 = x_2d * x_2d
+
+        rstd_3 = torch.rsqrt((x3 * x3).mean(dim=-1, keepdim=True) + eps)
+        rstd_2 = torch.rsqrt((x2 * x2).mean(dim=-1, keepdim=True) + eps)
+        rstd_1 = torch.rsqrt((x_2d * x_2d).mean(dim=-1, keepdim=True) + eps)
+
+        w0, w1, w2 = weight[0].float(), weight[1].float(), weight[2].float()
+        b = bias[0].float()
+
+        y = w0 * x3 * rstd_3 + w1 * x2 * rstd_2 + w2 * x_2d * rstd_1 + b
+        return y.view(*shape).to(input.dtype)
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((8, 512), torch.float32),
+            ((16, 1024), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+            ((2, 4, 512), torch.float32),
+            ((4, 300), torch.float32),  # non-power-of-2 hidden dim
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op(self, shape, dtype, backend, monkeypatch):
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        eps = 1e-6
+
+        x = torch.randn(*shape, dtype=dtype, device=device)
+        weight = torch.randn(3, dtype=dtype, device=device)
+        bias = torch.randn(1, dtype=dtype, device=device)
+
+        self.assertCorrectness(
+            poly_norm,
+            self.reference,
+            {
+                "input": x,
+                "weight": weight,
+                "bias": bias,
+                "eps": eps,
+            },
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((8, 512), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_backward(self, shape, dtype, backend, monkeypatch):
+        """Test backward pass (gradient computation)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        eps = 1e-6
+
+        x = torch.randn(*shape, dtype=dtype, device=device, requires_grad=True)
+        weight = torch.randn(3, dtype=dtype, device=device, requires_grad=True)
+        bias = torch.randn(1, dtype=dtype, device=device, requires_grad=True)
+
+        dout = torch.ones(*shape, dtype=dtype, device=device)
+
+        self.assertCorrectness(
+            poly_norm,
+            self.reference,
+            {
+                "input": x,
+                "weight": weight,
+                "bias": bias,
+                "eps": eps,
+            },
+            gradient=dout,
+            atol=1e-2,
+            rtol=1e-2,
+        )

--- a/tests/suites/liger/test_rms_norm.py
+++ b/tests/suites/liger/test_rms_norm.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import gc
+
+import pytest
+import torch
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import rms_norm
+
+
+def _reference_rms_norm(X, W, eps, offset=0.0):
+    """PyTorch float32 reference for RMS normalization."""
+    X_f = X.float()
+    rms = torch.sqrt(torch.mean(X_f**2, dim=-1, keepdim=True) + eps)
+    Y = X_f / rms
+    if W is not None:
+        Y = Y * (W.float() + offset)
+    return Y.to(X.dtype)
+
+
+class Test_Liger_RMSNorm(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((8, 512), torch.float32),
+            ((16, 1024), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+            ((2, 4, 512), torch.float32),  # multi-dimensional
+            ((4, 300), torch.float32),  # non-power-of-2 hidden dim
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op(self, shape, dtype, backend, monkeypatch):
+        """Test RMS norm forward with affine weight (W)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        H = shape[-1]
+        eps = 1e-6
+
+        X = torch.randn(*shape, dtype=dtype, device=device)
+        W = torch.ones(H, dtype=dtype, device=device)
+
+        def fw():
+            return rms_norm(X.clone(), W, eps)
+
+        def ref():
+            return _reference_rms_norm(X, W, eps)
+
+        self.assertCorrectness(fw, ref, kwargs={}, atol=1e-2, rtol=1e-2)
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((8, 512), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_no_affine(self, shape, dtype, backend, monkeypatch):
+        """Test RMS norm forward without affine weight (W=None)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        eps = 1e-6
+
+        X = torch.randn(*shape, dtype=dtype, device=device)
+
+        def fw():
+            return rms_norm(X.clone(), None, eps)
+
+        def ref():
+            return _reference_rms_norm(X, None, eps)
+
+        self.assertCorrectness(fw, ref, kwargs={}, atol=1e-2, rtol=1e-2)
+
+    @pytest.mark.parametrize("casting_mode", ["llama", "gemma", "none"])
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((4, 256), torch.bfloat16),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_casting_modes(self, shape, dtype, casting_mode, backend, monkeypatch):
+        """All three casting modes must compile and produce near-reference output.
+
+        Regression guard: NONE mode in the CuTile fwd kernel previously referenced
+        an undefined `x_sq` variable and would crash at compile time if exercised.
+        """
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        H = shape[-1]
+        eps = 1e-6
+
+        X = torch.randn(*shape, dtype=dtype, device=device)
+        W = torch.ones(H, dtype=dtype, device=device)
+
+        def fw():
+            return rms_norm(X.clone(), W, eps, casting_mode=casting_mode)
+
+        def ref():
+            return _reference_rms_norm(X, W, eps)
+
+        self.assertCorrectness(fw, ref, kwargs={}, atol=1e-2, rtol=1e-2)
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+        ],
+    )
+    @pytest.mark.parametrize("offset", [0.0, 1.0])
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_with_offset(self, shape, dtype, offset, backend, monkeypatch):
+        """Test RMS norm with non-zero offset (Gemma-style W+1 shift)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        H = shape[-1]
+        eps = 1e-6
+
+        X = torch.randn(*shape, dtype=dtype, device=device)
+        W = torch.ones(H, dtype=dtype, device=device)
+
+        def fw():
+            return rms_norm(X.clone(), W, eps, offset=offset)
+
+        def ref():
+            return _reference_rms_norm(X, W, eps, offset=offset)
+
+        self.assertCorrectness(fw, ref, kwargs={}, atol=1e-2, rtol=1e-2)
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((8, 512), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_backward(self, shape, dtype, backend, monkeypatch):
+        """Test backward pass (gradients for X and W)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        H = shape[-1]
+        eps = 1e-6
+
+        X = torch.randn(*shape, dtype=dtype, device=device, requires_grad=True)
+        W = torch.ones(H, dtype=dtype, device=device, requires_grad=True)
+        dout = torch.ones(*shape, dtype=dtype, device=device)
+
+        self.assertCorrectness(
+            rms_norm,
+            _reference_rms_norm,
+            {"X": X, "W": W, "eps": eps},
+            gradient=dout,
+            atol=1e-2,
+            rtol=1e-1,
+        )

--- a/tests/suites/liger/test_softmax.py
+++ b/tests/suites/liger/test_softmax.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import gc
+
+import pytest
+import torch
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import softmax
+
+
+def _reference_softmax(x):
+    """PyTorch float32 reference for softmax on the last dimension."""
+    return torch.nn.functional.softmax(x.float(), dim=-1).to(x.dtype)
+
+
+class Test_Liger_Softmax(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((2, 8), torch.float32),
+            ((4, 16), torch.float32),
+            ((1, 1023), torch.float32),  # non-power-of-2 n_cols, single block
+            ((3, 7, 256), torch.float32),  # 3D input
+            ((2, 8), torch.float16),
+            ((2, 8), torch.bfloat16),
+            ((1, 4096), torch.float32),  # multi-block dispatch
+            ((1, 2, 4096), torch.float32),  # 3D multi-block dispatch
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op(self, shape, dtype, backend, monkeypatch):
+        """Test softmax forward pass."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        x = torch.randn(*shape, dtype=dtype, device=device)
+
+        def fw():
+            return softmax(x.clone())
+
+        def ref():
+            return _reference_softmax(x)
+
+        self.assertCorrectness(fw, ref, kwargs={}, atol=1e-2, rtol=1e-2)
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((2, 8), torch.float32),
+            ((4, 16), torch.float32),
+            ((2, 8), torch.float16),
+            ((2, 8), torch.bfloat16),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_backward(self, shape, dtype, backend, monkeypatch):
+        """Test backward pass (gradient flows through softmax)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        x = torch.randn(*shape, dtype=dtype, device=device, requires_grad=True)
+
+        y = softmax(x)
+        y.sum().backward()
+
+        assert x.grad is not None

--- a/tests/suites/liger/test_swiglu.py
+++ b/tests/suites/liger/test_swiglu.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import gc
+
+import pytest
+import torch
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import swiglu
+
+
+def _reference_swiglu(a, b):
+    """PyTorch float32 reference: silu(a) * b."""
+    a_f = a.float()
+    b_f = b.float()
+    silu_a = a_f * torch.sigmoid(a_f)
+    return (silu_a * b_f).to(a.dtype)
+
+
+class Test_Liger_SwiGLU(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            # functional test shapes from Liger test_swiglu.py
+            ((2, 8, 8), torch.float32),
+            ((9, 7, 41), torch.float32),
+            # transformer shapes from Liger test/transformers/test_swiglu.py
+            ((2, 256, 256), torch.float32),
+            ((6, 42, 123), torch.float32),
+            # standard shapes
+            ((4, 256), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+            # non-power-of-2
+            ((4, 300), torch.float32),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_forward(self, shape, dtype, backend, monkeypatch):
+        """Test forward output matches PyTorch reference."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        a = torch.randn(*shape, dtype=dtype, device=device)
+        b = torch.randn(*shape, dtype=dtype, device=device)
+
+        atol = 1e-2 if dtype != torch.float32 else 5e-3
+        rtol = 1e-2 if dtype != torch.float32 else 5e-3
+
+        c_test = swiglu(a.clone(), b.clone())
+        c_ref = _reference_swiglu(a, b)
+
+        assert torch.allclose(c_test.float(), c_ref.float(), atol=atol, rtol=rtol), (
+            f"Forward mismatch: max_diff={((c_test.float() - c_ref.float()).abs().max()).item():.6f}"
+        )
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((2, 8, 8), torch.float32),
+            ((9, 7, 41), torch.float32),
+            ((2, 256, 256), torch.float32),
+            ((6, 42, 123), torch.float32),
+            ((4, 256), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_backward(self, shape, dtype, backend, monkeypatch):
+        """Test backward gradients (da, db) match PyTorch reference."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        a_data = torch.randn(*shape, dtype=dtype, device=device)
+        b_data = torch.randn(*shape, dtype=dtype, device=device)
+
+        atol = 1e-1
+        rtol = 1e-1
+
+        # Test implementation
+        a_test = a_data.clone().requires_grad_(True)
+        b_test = b_data.clone().requires_grad_(True)
+        c_test = swiglu(a_test, b_test)
+        c_test.backward(torch.ones_like(c_test))
+
+        # Reference (float32)
+        a_ref = a_data.clone().float().requires_grad_(True)
+        b_ref = b_data.clone().float().requires_grad_(True)
+        c_ref = _reference_swiglu(a_ref, b_ref.to(a_ref.dtype))
+        c_ref.backward(torch.ones_like(c_ref))
+
+        assert torch.allclose(a_test.grad.float(), a_ref.grad.float(), atol=atol, rtol=rtol), (
+            f"da mismatch: max_diff={((a_test.grad.float() - a_ref.grad.float()).abs().max()).item():.6f}"
+        )
+        assert torch.allclose(b_test.grad.float(), b_ref.grad.float(), atol=atol, rtol=rtol), (
+            f"db mismatch: max_diff={((b_test.grad.float() - b_ref.grad.float()).abs().max()).item():.6f}"
+        )

--- a/tests/suites/liger/test_tvd.py
+++ b/tests/suites/liger/test_tvd.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import gc
+
+import pytest
+import torch
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import tvd
+
+
+class _TorchTVDReference:
+    """PyTorch float32 reference for TVD."""
+
+    def __init__(self, reduction="batchmean", ignore_index=-100):
+        self.reduction = reduction
+        self.ignore_index = ignore_index
+
+    def __call__(self, p, q, shift_labels=None):
+        p_f = p.float()
+        q_f = q.float()
+        tvd_val = torch.abs(p_f - q_f) / 2.0
+        n_non_ignore = p_f.size(0)
+
+        if shift_labels is not None:
+            tvd_val = torch.where(
+                shift_labels.unsqueeze(1) != self.ignore_index,
+                tvd_val,
+                torch.zeros_like(tvd_val),
+            )
+            n_non_ignore = (shift_labels != self.ignore_index).sum().item()
+            if n_non_ignore == 0:
+                return torch.tensor(0.0, device=p.device)
+
+        if self.reduction == "mean":
+            return torch.sum(tvd_val) / (n_non_ignore * p_f.size(1))
+        elif self.reduction == "sum":
+            return torch.sum(tvd_val)
+        elif self.reduction == "none":
+            return tvd_val.to(p.dtype)
+        else:  # batchmean
+            return torch.sum(tvd_val) / n_non_ignore
+
+
+class Test_Liger_TVD(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @pytest.mark.parametrize(
+        "B, T, V",
+        [
+            # Shapes from Liger test/transformers/test_tvd.py
+            (1, 4096, 32000),
+            (41, 401, 1271),
+            (3, 423, 32000),
+        ],
+    )
+    @pytest.mark.parametrize("reduction", ["batchmean", "sum", "mean", "none"])
+    @pytest.mark.parametrize(
+        "dtype, atol, rtol",
+        [
+            (torch.float32, 1e-5, 1e-5),
+            (torch.bfloat16, 1e-3, 1e-3),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op(self, B, T, V, reduction, dtype, atol, rtol, backend, monkeypatch):
+        """Test TVD forward correctness."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        torch.manual_seed(0)
+
+        BT = B * T
+        p = torch.randn(BT, V, device=device, dtype=dtype)
+        q = torch.randn(BT, V, device=device).softmax(dim=-1).to(dtype)
+
+        ref_fn = _TorchTVDReference(reduction=reduction)
+        out_ref = ref_fn(p, q)
+
+        out_test = tvd(p, q, reduction=reduction)
+
+        if reduction == "none":
+            assert torch.allclose(out_test.float(), out_ref.float(), atol=atol, rtol=rtol), (
+                f"Forward mismatch: max_diff={((out_test.float() - out_ref.float()).abs().max()).item():.6f}"
+            )
+        else:
+            assert torch.allclose(out_test.float(), out_ref.float(), atol=atol, rtol=rtol), (
+                f"Forward mismatch: test={out_test.item():.6f} ref={out_ref.item():.6f}"
+            )
+
+    @pytest.mark.parametrize(
+        "B, T, V",
+        [
+            (1, 4096, 32000),
+            (41, 401, 1271),
+            (3, 423, 32000),
+        ],
+    )
+    @pytest.mark.parametrize("reduction", ["batchmean", "sum", "mean"])
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_backward(self, B, T, V, reduction, backend, monkeypatch):
+        """Test TVD backward pass (gradient w.r.t. p)."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        torch.manual_seed(0)
+        BT = B * T
+
+        p_data = torch.randn(BT, V, device=device, dtype=torch.float32)
+        q_data = torch.randn(BT, V, device=device).softmax(dim=-1)
+
+        # Reference
+        p_ref = p_data.clone().requires_grad_(True)
+        ref_fn = _TorchTVDReference(reduction=reduction)
+        out_ref = ref_fn(p_ref, q_data)
+        out_ref.backward()
+
+        # Test
+        p_test = p_data.clone().requires_grad_(True)
+        out_test = tvd(p_test, q_data, reduction=reduction)
+        out_test.backward()
+
+        assert p_test.grad is not None
+        assert torch.allclose(p_test.grad.float(), p_ref.grad.float(), atol=1e-5, rtol=1e-5), (
+            f"Backward mismatch: max_diff={((p_test.grad - p_ref.grad).abs().max()).item():.6f}"
+        )
+
+    @pytest.mark.parametrize(
+        "B, T, V",
+        [
+            (1, 4096, 32000),
+            (41, 401, 1271),
+            (3, 423, 32000),
+        ],
+    )
+    @pytest.mark.parametrize("reduction", ["batchmean", "sum", "mean", "none"])
+    @pytest.mark.parametrize("ignore_index", [-100, 0, 1])
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op_with_ignore_index(self, B, T, V, reduction, ignore_index, backend, monkeypatch):
+        """Test TVD with shift_labels and ignore_index."""
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        torch.manual_seed(0)
+        BT = B * T
+
+        p = torch.randn(BT, V, device=device, dtype=torch.float32)
+        q = torch.randn(BT, V, device=device).softmax(dim=-1)
+
+        labels = torch.randint(0, V, (BT,), device=device, dtype=torch.long)
+        # Assign some positions to ignore_index
+        n_ignore = max(1, BT // 4)
+        idx = torch.randperm(BT)[:n_ignore]
+        labels[idx] = ignore_index
+
+        ref_fn = _TorchTVDReference(reduction=reduction, ignore_index=ignore_index)
+        out_ref = ref_fn(p, q, shift_labels=labels)
+
+        out_test = tvd(p, q, shift_labels=labels, reduction=reduction, ignore_index=ignore_index)
+
+        atol, rtol = 1e-5, 1e-5
+        if reduction == "none":
+            assert torch.allclose(out_test.float(), out_ref.float(), atol=atol, rtol=rtol), (
+                f"With-ignore forward mismatch: max_diff="
+                f"{((out_test.float() - out_ref.float()).abs().max()).item():.6f}"
+            )
+        else:
+            assert torch.allclose(out_test.float(), out_ref.float(), atol=atol, rtol=rtol), (
+                f"With-ignore forward mismatch: test={out_test.item():.6f} ref={out_ref.item():.6f}"
+            )


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->

Update codes.

This PR contains **15** new commit(s).

### Commits included:

```
ff1cfdb fix(ops.chunked_gdr, qwen3.5_1d_conv): stabilize long-context generation
e28d967 fix(flashinfer): honor num_sms occupancy limit
9ec2591 chore(transformers): bump cuda-tile pin to >=1.5.0 and regenerate uv.lock
b092cdc fix(tilecpp/matmul): mask partial output tile stores
e11cb2a fix(tilecpp/flash_decode): mask query-group boundary loads/stores
26a17eb perf(cutile): add sm100+ small-tile (128x128) entry to static-persistent matmul autotune table
050acdc perf(cutile/gdn): Neumann-by-squaring solve_tril + occupancy=2 for intra_chunk_prepare
21207f5 chore: drop stale cutile setup comment
bd792f1 Change matmul dtype in Tile C++ to TF32 (mirroring cuTile Python)
5b3f315 [liger][cutile] Modify some cuTile kernels
4641ce5 fix(bmm/cutile): bump autotune compile timeout 10s -> 15s
afdb10a [cuTile] Improve pre-SM90 MLA autotuning
3fbd78c cutile-rs: per-suite kernel crates + NVFP4 dtype codes
f01f1d4 perf(flashinfer/cutile): fix DecodePaged + MLADecodePaged + MoE regression
58f8cf7 perf(flashinfer/cutile): restore two-loop causal split in prefill-ragged body
```

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: ["ops", "benchmark"]
```

## Checklist
- [ ] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

