### PR TITLE
Bump version from 1.3.0 to 1.4.0

### DIFF
--- a/modeling/transformers/uv.lock
+++ b/modeling/transformers/uv.lock
@@ -4085,7 +4085,7 @@ wheels = [
 
 [[package]]
 name = "tilegym"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "../../" }
 dependencies = [
     { name = "cuda-bindings" },

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def parse_requirements(filename: str) -> list[str]:
 
 setuptools.setup(
     name="tilegym",
-    version="1.3.0",
+    version="1.4.0",
     author="NVIDIA Corporation",
     description="TileGym",
     long_description=README,

--- a/src/tilegym/__init__.py
+++ b/src/tilegym/__init__.py
@@ -72,7 +72,7 @@ __all__ = [
 ]
 
 # Version info
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 import contextlib
 from enum import Enum


### PR DESCRIPTION
Bump the TileGym package version from 1.3.0 to 1.4.0.

## CI Configuration

```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: []
```
