### PR TITLE
[TEST · DO NOT MERGE] Re-check tilecpp l2norm chunk_gated_delta_rule failure

### DIFF
--- a/tests/ops/test_chunk_gated_delta_rule.py
+++ b/tests/ops/test_chunk_gated_delta_rule.py
@@ -173,8 +173,11 @@ class Test_ChunkGatedDeltaRule(common.PyTestCase):
         if dtype == torch.float32:
             pytest.skip("Skipping fp32 tests due to known failures; under investigation")
 
-        if backend == "tilecpp" and use_l2:
-            pytest.skip("Skipping tilecpp l2norm case due to known failure; under investigation")
+        # [TEST PR] tilecpp+use_l2 skip intentionally removed to re-check whether the
+        # tilecpp l2norm case still fails on current TileGym CI. Do NOT merge.
+        # Original skip (added in Ocean 02c4638d, Jul 1 2026):
+        #     if backend == "tilecpp" and use_l2:
+        #         pytest.skip("Skipping tilecpp l2norm case due to known failure; under investigation")
 
         self.setUp()
 


### PR DESCRIPTION
**Test-only PR — do not merge.**

## Purpose
Removes the `if backend == "tilecpp" and use_l2: pytest.skip(...)` guard in `test_op` (added in Ocean `02c4638d`, Jul 1 2026, to skip the then-failing tilecpp l2norm case). This re-runs `test_op[tilecpp-l2norm-bf16]` on current TileGym CI to confirm whether the tilecpp l2norm case **still fails**.

## Expected
If tilecpp l2norm is still broken, `test-ops` will fail on `test_op[tilecpp-l2norm-bf16]` (expected: intra-kernel launch `CUDA_ERROR_INVALID_VALUE`). Result to be reported to the tilecpp team alongside the correlated-keys regression.

Only the skip is removed; no kernel/test-logic changes.

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: ["ops", "benchmark"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)