### PR TITLE
perf(flashinfer/cutile): route small-per-expert MoE bf16 ragged_bmm to swap_ab & other updates

### DIFF
--- a/src/tilegym/ops/__init__.py
+++ b/src/tilegym/ops/__init__.py
@@ -38,6 +38,25 @@ except (ImportError, RuntimeError):
 if is_backend_available("tilecpp"):
     from . import tilecpp
 
+# Import cutile-rs (Rust FFI) backend if available
+if is_backend_available("cutile-rs"):
+    try:
+        from . import cutile_rs
+    except (ImportError, RuntimeError):
+        import warnings
+
+        warnings.warn(
+            "cutile-rs backend import failed, cutile-rs operations will not be available",
+            stacklevel=2,
+        )
+        cutile_rs = None  # type: ignore
+        # Backend isn't usable if its ops failed to import — keep the selector in sync.
+        from tilegym.backend.selector import _AVAILABLE_BACKENDS
+
+        _AVAILABLE_BACKENDS.discard("cutile-rs")
+else:
+    cutile_rs = None  # type: ignore
+
 # Re-export key interfaces
 from .attn_interface import attention_sink_interface
 from .attn_interface import fmha_interface

--- a/src/tilegym/ops/tilecpp/matmul.py
+++ b/src/tilegym/ops/tilecpp/matmul.py
@@ -82,8 +82,17 @@ def _matmul_autotune_configs():
             Config(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=64, num_ctas=1, occupancy=1),
             Config(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=32, num_ctas=1, occupancy=2),
         ]
+    elif gpu_capability[0] < 9:
+        # Pre-SM90: num_ctas=1 (CGA unsupported); sweep TILE_K in [32, 64, 128]
+        configs = [
+            Config(TILE_SIZE_M=tile_m, TILE_SIZE_N=tile_n, TILE_SIZE_K=tile_k, num_ctas=1, occupancy=occupancy)
+            for tile_m in [64, 128]
+            for tile_n in [64, 128]
+            for tile_k in [32, 64, 128]
+            for occupancy in [1, 2]
+        ]
     else:
-        # sm100 (Blackwell)
+        # sm100+ (Blackwell)
         configs = [
             Config(TILE_SIZE_M=128, TILE_SIZE_N=128, TILE_SIZE_K=32, num_ctas=1, occupancy=1),
             Config(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, num_ctas=2, occupancy=1),
@@ -94,7 +103,6 @@ def _matmul_autotune_configs():
 
 
 def _persistent_matmul_autotune_configs():
-    """Autotune search space for static_persistent_matmul_kernel."""
     gpu_capability = torch.cuda.get_device_capability()
 
     if gpu_capability in [(12, 0), (12, 1)]:
@@ -111,17 +119,22 @@ def _persistent_matmul_autotune_configs():
     elif gpu_capability[0] < 9:
         # sm80 (A100)
         configs = [
+            Config(TILE_SIZE_M=64, TILE_SIZE_N=64, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=2),
+            Config(TILE_SIZE_M=64, TILE_SIZE_N=128, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=2),
+            Config(TILE_SIZE_M=128, TILE_SIZE_N=64, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=2),
             Config(TILE_SIZE_M=128, TILE_SIZE_N=128, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=1),
-            Config(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=1),
+            Config(TILE_SIZE_M=128, TILE_SIZE_N=128, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=1, occupancy=2),
         ]
     else:
+        # sm100+ (Blackwell)
         configs = [
             Config(TILE_SIZE_M=128, TILE_SIZE_N=512, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=4, occupancy=1),
             Config(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=2, occupancy=1),
             Config(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=1),
             Config(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=128, GROUP_SIZE_M=8, num_ctas=2, occupancy=1),
-            Config(TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=4, occupancy=1),
-            Config(TILE_SIZE_M=512, TILE_SIZE_N=256, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=4, occupancy=1),
+            # Small-tile candidate for small/rectangular GEMMs, where the entries above cap
+            # the persistent grid at 16-32 tile-jobs and strand most SMs.
+            Config(TILE_SIZE_M=128, TILE_SIZE_N=128, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=1),
         ]
     return configs
 

--- a/src/tilegym/ops/tilecpp/persistent_matmul.cuh
+++ b/src/tilegym/ops/tilecpp/persistent_matmul.cuh
@@ -16,6 +16,8 @@
 #include <cuda_fp16.h>
 #include <cuda_bf16.h>
 #include <cuda_fp8.h>
+#include <cuda_tf32.h>
+#include <type_traits>
 
 template<typename T,
          int M, int N, int K,
@@ -48,6 +50,7 @@ __tile_global__ void static_persistent_matmul_kernel(
     constexpr auto zero_pad = ct::view_padding::zero;
 
     using AccTile = ct::tile<float, ct::shape<TILE_SIZE_M, TILE_SIZE_N>>;
+    using MmaType = std::conditional_t<std::is_same_v<T, float>, __nv_tf32, T>;
 
     if constexpr (!TRANSPOSE_A && !TRANSPOSE_B) {
         auto pA = ct::partition_view{ct::tensor_span{A, ct::extents<uint32_t, M, K>{}}, ct::shape<TILE_SIZE_M, TILE_SIZE_K>{}};
@@ -63,8 +66,8 @@ __tile_global__ void static_persistent_matmul_kernel(
 
             AccTile acc = ct::zeros<AccTile>();
             for (auto k : ct::irange(0, k_tiles)) {
-                auto a = pA.template load_masked<zero_pad>(bid_m, k);
-                auto b = pB.template load_masked<zero_pad>(k, bid_n);
+                auto a = ct::element_cast<MmaType>(pA.template load_masked<zero_pad>(bid_m, k));
+                auto b = ct::element_cast<MmaType>(pB.template load_masked<zero_pad>(k, bid_n));
                 acc = ct::mma(a, b, acc);
             }
             auto result = ct::element_cast<T>(acc);
@@ -89,8 +92,8 @@ __tile_global__ void static_persistent_matmul_kernel(
             AccTile acc = ct::zeros<AccTile>();
             for (auto k : ct::irange(0, k_tiles)) {
                 auto a_raw = pA.template load_masked<zero_pad>(k, bid_m);
-                auto b     = pB.template load_masked<zero_pad>(k, bid_n);
-                auto a     = ct::transpose(a_raw);
+                auto a     = ct::element_cast<MmaType>(ct::transpose(a_raw));
+                auto b     = ct::element_cast<MmaType>(pB.template load_masked<zero_pad>(k, bid_n));
                 acc = ct::mma(a, b, acc);
             }
             auto result = ct::element_cast<T>(acc);
@@ -114,9 +117,9 @@ __tile_global__ void static_persistent_matmul_kernel(
 
             AccTile acc = ct::zeros<AccTile>();
             for (auto k : ct::irange(0, k_tiles)) {
-                auto a     = pA.template load_masked<zero_pad>(bid_m, k);
+                auto a     = ct::element_cast<MmaType>(pA.template load_masked<zero_pad>(bid_m, k));
                 auto b_raw = pB.template load_masked<zero_pad>(bid_n, k);
-                auto b     = ct::transpose(b_raw);
+                auto b     = ct::element_cast<MmaType>(ct::transpose(b_raw));
                 acc = ct::mma(a, b, acc);
             }
             auto result = ct::element_cast<T>(acc);
@@ -142,8 +145,8 @@ __tile_global__ void static_persistent_matmul_kernel(
             for (auto k : ct::irange(0, k_tiles)) {
                 auto a_raw = pA.template load_masked<zero_pad>(k, bid_m);
                 auto b_raw = pB.template load_masked<zero_pad>(bid_n, k);
-                auto a     = ct::transpose(a_raw);
-                auto b     = ct::transpose(b_raw);
+                auto a     = ct::element_cast<MmaType>(ct::transpose(a_raw));
+                auto b     = ct::element_cast<MmaType>(ct::transpose(b_raw));
                 acc = ct::mma(a, b, acc);
             }
             auto result = ct::element_cast<T>(acc);

--- a/src/tilegym/suites/flashinfer/cutile/gemm/ragged_bmm.py
+++ b/src/tilegym/suites/flashinfer/cutile/gemm/ragged_bmm.py
@@ -627,9 +627,17 @@ def ragged_bmm(
     # Check if autotune is enabled
     enable_autotune = is_autotune_enabled()
 
-    # Decide whether to use swap_ab based on M vs N ratio
-    # swap_ab is beneficial when M is small relative to N
-    use_swap_ab = max_m <= 128 and N >= 256
+    # Decide whether to use swap_ab based on M vs N ratio.
+    # swap_ab (small BLOCK_M) is beneficial when the per-batch M is small relative
+    # to N. Use the per-batch average M (total_m / Q) rather than the host `max_m`
+    # hint: `max_m` is only a grid/cache-key upper bound and callers may pass a
+    # coarse over-estimate (e.g. the fused-MoE path passes total tokens_in_chunk,
+    # not the per-expert max), which would wrongly route small-per-expert MoE
+    # GEMMs to the large-M standard kernel (BLOCK_M=128) instead of swap_ab
+    # (BLOCK_M<=64). The grid bound stays exact via the device-side max_m_device,
+    # so this only affects config selection, never correctness.
+    avg_m = total_m // Q if Q > 0 else max_m
+    use_swap_ab = avg_m <= 128 and N >= 256
 
     if enable_autotune:
         if use_swap_ab:

--- a/src/tilegym/suites/liger/__init__.py
+++ b/src/tilegym/suites/liger/__init__.py
@@ -34,6 +34,7 @@ from .ops import llama4_rope
 from .ops import multi_token_attention
 from .ops import poly_norm
 from .ops import qwen2vl_mrope
+from .ops import relu_squared
 from .ops import rms_norm
 from .ops import rope
 from .ops import softmax
@@ -62,6 +63,7 @@ __all__ = [
     "fused_linear_cross_entropy",
     "grpo_loss",
     "poly_norm",
+    "relu_squared",
     "rms_norm",
     "softmax",
     "swiglu",

--- a/src/tilegym/suites/liger/cutile/__init__.py
+++ b/src/tilegym/suites/liger/cutile/__init__.py
@@ -20,6 +20,7 @@ from . import llama4_rope  # noqa: F401
 from . import multi_token_attention  # noqa: F401
 from . import poly_norm  # noqa: F401
 from . import qwen2vl_mrope  # noqa: F401
+from . import relu_squared  # noqa: F401
 from . import rms_norm  # noqa: F401
 from . import rope  # noqa: F401
 from . import softmax  # noqa: F401
@@ -41,6 +42,7 @@ from .llama4_rope import Llama4RopeCuTileFunction  # noqa: F401
 from .multi_token_attention import MultiTokenAttentionCuTileFunction  # noqa: F401
 from .poly_norm import PolyNormCuTileFunction  # noqa: F401
 from .qwen2vl_mrope import Qwen2VLMRopeCuTileFunction  # noqa: F401
+from .relu_squared import ReLUSquaredCuTileFunction  # noqa: F401
 from .rms_norm import RMSNormCuTileFunction  # noqa: F401
 from .rope import RopeCuTileFunction  # noqa: F401
 from .softmax import SoftmaxCuTileFunction  # noqa: F401
@@ -79,6 +81,7 @@ __all__ = [
     "FusedLinearCrossEntropyCuTileFunction",
     "GrpoLossCuTileFunction",
     "PolyNormCuTileFunction",
+    "ReLUSquaredCuTileFunction",
     "RMSNormCuTileFunction",
     "SwiGLUCuTileFunction",
     "SoftmaxCuTileFunction",
@@ -88,6 +91,7 @@ __all__ = [
     "fused_linear_cross_entropy",
     "grpo_loss",
     "poly_norm",
+    "relu_squared",
     "rms_norm",
     "softmax",
     "swiglu",

--- a/src/tilegym/suites/liger/cutile/relu_squared.py
+++ b/src/tilegym/suites/liger/cutile/relu_squared.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+ReLU-squared activation kernel (CuTile backend).
+
+Formula: y = relu(x)^2 = max(x, 0)^2
+
+Row-parallel: grid = (n_rows, 1, 1). Each block handles one row, looping over
+column chunks of BLOCK_SIZE.
+
+PERF NOTES
+==========
+- Pure element-wise, memory-bandwidth-bound. No exp/reduction → no occupancy=1
+  or exp2 tricks needed (unlike swiglu). Backward writes a fresh DX (not in-place),
+  so there is no scatter-in-loop hang hazard.
+- Two kernel variants per direction:
+    *_aligned: check_bounds=False — used when n_cols % BLOCK_SIZE == 0 (all power-of-2
+               n_cols up to MAX_FUSED_SIZE). Faster: no per-lane bounds masking.
+    *_ct:      check_bounds=True  — fallback for non-aligned n_cols.
+- Compute in float32, cast to the output dtype on scatter.
+"""
+
+import cuda.tile as ct
+import torch
+
+from tilegym.backend import register_impl
+
+from .utils import next_power_of_2
+
+MAX_FUSED_SIZE = 4096  # tile cap; relu is register-light so a large tile is safe
+
+
+@ct.kernel
+def _relu_squared_fwd_ct_aligned(
+    X,  # (n_rows, n_cols) input
+    Y,  # (n_rows, n_cols) output
+    n_cols: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+):
+    """ReLU-squared forward — aligned fast path (check_bounds=False)."""
+    row_idx = ct.bid(0)
+    n_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+
+        x = ct.astype(ct.gather(X, (row_idx, col_idx), check_bounds=False, padding_value=0.0), ct.float32)
+        relu_x = ct.maximum(x, 0.0)
+        y = relu_x * relu_x
+        ct.scatter(Y, (row_idx, col_idx), ct.astype(y, Y.dtype), check_bounds=False)
+
+
+@ct.kernel
+def _relu_squared_fwd_ct(
+    X,  # (n_rows, n_cols) input
+    Y,  # (n_rows, n_cols) output
+    n_cols: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+):
+    """ReLU-squared forward — general path (check_bounds=True) for arbitrary n_cols."""
+    row_idx = ct.bid(0)
+    n_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+
+        x = ct.astype(ct.gather(X, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+        relu_x = ct.maximum(x, 0.0)
+        y = relu_x * relu_x
+        ct.scatter(Y, (row_idx, col_idx), ct.astype(y, Y.dtype), check_bounds=True)
+
+
+@ct.kernel
+def _relu_squared_bwd_ct_aligned(
+    DY,  # (n_rows, n_cols) upstream gradient
+    X,  # (n_rows, n_cols) saved input
+    DX,  # (n_rows, n_cols) output gradient
+    n_cols: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+):
+    """ReLU-squared backward — aligned fast path (check_bounds=False).
+
+    d/dx[relu(x)^2] = 2 * relu(x)  →  dx = dy * 2 * max(x, 0)
+    """
+    row_idx = ct.bid(0)
+    n_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+
+        dy = ct.astype(ct.gather(DY, (row_idx, col_idx), check_bounds=False, padding_value=0.0), ct.float32)
+        x = ct.astype(ct.gather(X, (row_idx, col_idx), check_bounds=False, padding_value=0.0), ct.float32)
+        relu_x = ct.maximum(x, 0.0)
+        dx = dy * 2.0 * relu_x
+        ct.scatter(DX, (row_idx, col_idx), ct.astype(dx, DX.dtype), check_bounds=False)
+
+
+@ct.kernel
+def _relu_squared_bwd_ct(
+    DY,  # (n_rows, n_cols) upstream gradient
+    X,  # (n_rows, n_cols) saved input
+    DX,  # (n_rows, n_cols) output gradient
+    n_cols: ct.Constant[int],
+    BLOCK_SIZE: ct.Constant[int],
+):
+    """ReLU-squared backward — general path (check_bounds=True) for arbitrary n_cols."""
+    row_idx = ct.bid(0)
+    n_chunks = (n_cols + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    for ci in range(n_chunks):
+        col_idx = ct.add(ct.arange(BLOCK_SIZE, dtype=ct.int32), ci * BLOCK_SIZE)
+
+        dy = ct.astype(ct.gather(DY, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+        x = ct.astype(ct.gather(X, (row_idx, col_idx), check_bounds=True, padding_value=0.0), ct.float32)
+        relu_x = ct.maximum(x, 0.0)
+        dx = dy * 2.0 * relu_x
+        ct.scatter(DX, (row_idx, col_idx), ct.astype(dx, DX.dtype), check_bounds=True)
+
+
+def _calculate_block_size(n_cols):
+    # Cap the tile at MAX_FUSED_SIZE (or next_pow2(n_cols) if smaller).
+    block = max(min(next_power_of_2(n_cols), MAX_FUSED_SIZE), 128)
+    # Largest power-of-2 tile <= block that evenly divides n_cols → enables the
+    # check_bounds=False aligned fast path (dispatch selects it when n_cols % block == 0).
+    aligned = block
+    while aligned > 128 and n_cols % aligned != 0:
+        aligned //= 2
+    # Prefer the aligned block only when it stays large (>= half the cap); otherwise keep the
+    # full block and let the masked (check_bounds=True) kernel cover the remainder in fewer chunks.
+    if n_cols % aligned == 0 and aligned >= block // 2:
+        return aligned
+    return block
+
+
+class ReLUSquaredCuTileFunction(torch.autograd.Function):
+    """CuTile autograd wrapper for ReLU-squared: y = relu(x)^2."""
+
+    @staticmethod
+    def forward(ctx, x):
+        ori_shape = x.shape
+        n_cols = ori_shape[-1]
+        x = x.contiguous().view(-1, n_cols)
+        n_rows = x.shape[0]
+
+        y = torch.empty_like(x)
+        BLOCK_SIZE = _calculate_block_size(n_cols)
+        fwd_kernel = _relu_squared_fwd_ct_aligned if n_cols % BLOCK_SIZE == 0 else _relu_squared_fwd_ct
+
+        ct.launch(
+            torch.cuda.current_stream(),
+            (n_rows, 1, 1),
+            fwd_kernel,
+            (x, y, int(n_cols), int(BLOCK_SIZE)),
+        )
+        ctx.save_for_backward(x)
+        ctx.ori_shape = ori_shape
+        return y.view(*ori_shape)
+
+    @staticmethod
+    def backward(ctx, dy):
+        (x,) = ctx.saved_tensors
+        ori_shape = ctx.ori_shape
+        n_cols = ori_shape[-1]
+        dy = dy.contiguous().view(-1, n_cols)
+        n_rows = dy.shape[0]
+
+        dx = torch.empty_like(dy)
+        BLOCK_SIZE = _calculate_block_size(n_cols)
+        bwd_kernel = _relu_squared_bwd_ct_aligned if n_cols % BLOCK_SIZE == 0 else _relu_squared_bwd_ct
+
+        ct.launch(
+            torch.cuda.current_stream(),
+            (n_rows, 1, 1),
+            bwd_kernel,
+            (dy, x, dx, int(n_cols), int(BLOCK_SIZE)),
+        )
+        return dx.view(*ori_shape)
+
+
+@register_impl("liger.relu_squared", backend="cutile")
+def relu_squared(input: torch.Tensor) -> torch.Tensor:
+    """
+    ReLU-squared activation: y = relu(x)^2 = max(x, 0)^2.
+
+    Args:
+        input: Input tensor of shape (*, N).
+
+    Returns:
+        Output tensor of same shape as input.
+    """
+    return ReLUSquaredCuTileFunction.apply(input)

--- a/src/tilegym/suites/liger/ops.py
+++ b/src/tilegym/suites/liger/ops.py
@@ -770,3 +770,21 @@ def multi_token_attention(
         Output tensor of same shape as scores.
     """
     raise NotImplementedError(f"multi_token_attention is not implemented for {get_current_backend()}")
+
+
+@dispatch(
+    "liger.relu_squared",
+)
+def relu_squared(input: torch.Tensor) -> torch.Tensor:
+    """
+    ReLU-squared activation: y = relu(x)^2 = max(x, 0)^2.
+
+    Reference: https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/relu_squared.py
+
+    Args:
+        input: Input tensor of shape (*, N).
+
+    Returns:
+        Output tensor of same shape as input.
+    """
+    raise NotImplementedError(f"relu_squared is not implemented for {get_current_backend()}")

--- a/tests/suites/liger/test_relu_squared.py
+++ b/tests/suites/liger/test_relu_squared.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import gc
+
+import pytest
+import torch
+
+import tilegym
+from tests import common
+from tilegym.suites.liger.ops import relu_squared
+
+
+def _reference_relu_squared(x):
+    return torch.square(torch.relu(x))
+
+
+class Test_Liger_ReLUSquared(common.PyTestCase):
+    _backends = ["cutile"]
+
+    @staticmethod
+    def reference(input):
+        """
+        PyTorch reference implementation of ReLU-squared.
+
+        Formula: y = relu(x)^2 = max(x, 0)^2
+        """
+        x_f = input.float()
+        relu_x = torch.relu(x_f)
+        y = relu_x * relu_x
+        return y.to(input.dtype)
+
+    @pytest.mark.parametrize(
+        "shape, dtype",
+        [
+            ((4, 256), torch.float32),
+            ((4, 256), torch.float16),
+            ((4, 256), torch.bfloat16),
+            ((2, 4, 512), torch.float32),  # multi-dimensional
+            ((4, 300), torch.float32),  # non-power-of-2 hidden dim
+            ((2, 8, 4096), torch.float32),
+            ((4, 16, 2048), torch.float32),
+            ((1, 1, 1023), torch.float32),  # non-power-of-2
+            ((3, 7, 256), torch.float32),
+        ],
+    )
+    @pytest.mark.parametrize("backend", _backends)
+    def test_op(self, shape, dtype, backend, monkeypatch):
+        self.setUp()
+        if tilegym.is_backend_available(backend):
+            tilegym.set_backend(backend)
+        else:
+            pytest.skip(f"Backend {backend} is not available")
+
+        device = torch.device("cuda")
+        input = torch.randn(*shape, dtype=dtype, device=device)
+
+        self.assertCorrectness(
+            relu_squared,
+            self.reference,
+            {"input": input},
+            atol=1e-2,
+            rtol=1e-2,
+        )


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->

Update codes.

This PR contains **4** new commit(s).

### Commits included:

```
0aaa833 fix(ops): register cutile-rs backend ops on import
b77cc89 static_persistent_matmul_kernel changes for Tile C++ performance
e825ebe feat(liger/relu_squared): add cuTile kernel
84da78c perf(flashinfer/cutile): route small-per-expert MoE bf16 ragged_bmm to swap_ab
```

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: ["ops", "benchmark"]
```

## Checklist
- [ ] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

