### PR TITLE
feat(dispatcher): add has_backend_impl and expose op name on dispatch wrapper & other updates

### DIFF
--- a/src/tilegym/backend/__init__.py
+++ b/src/tilegym/backend/__init__.py
@@ -9,6 +9,7 @@ Backend management for TileGym project
 from .dispatcher import dispatch
 from .dispatcher import get_available_backends_for_op
 from .dispatcher import get_registry_info
+from .dispatcher import has_backend_impl
 from .dispatcher import print_registry_info
 from .dispatcher import register_impl
 from .selector import assert_backend_available
@@ -56,6 +57,7 @@ __all__ = [
     "dispatch",
     "register_impl",
     "get_available_backends_for_op",
+    "has_backend_impl",
     "get_registry_info",
     "print_registry_info",
     # Cutile utilities

--- a/src/tilegym/backend/dispatcher.py
+++ b/src/tilegym/backend/dispatcher.py
@@ -131,6 +131,11 @@ def dispatch(name: str, fallback_backend: str = "pytorch"):
 
         _REGISTRY[name]["default"] = default_impl
 
+        # Expose the op name on the dispatched callable so tooling (e.g. test
+        # collection) can map a public op back to its registry entry and query
+        # which backends implement it.
+        wrapper._tilegym_op_name = name
+
         return wrapper
 
     return decorator
@@ -150,6 +155,24 @@ def get_available_backends_for_op(name: str) -> list:
         return ["default"]
 
     return list(_REGISTRY[name].keys())
+
+
+def has_backend_impl(name: str, backend: str) -> bool:
+    """
+    Check whether a specific backend implementation is registered for an op.
+
+    Unlike a plain membership test, this ignores the synthetic ``"default"``
+    entry (the NotImplementedError stub), so it answers "is there a real
+    ``backend`` kernel for this op?".
+
+    Args:
+        name: Operation name (registry key, e.g. ``"softmax"``)
+        backend: Backend name (e.g. ``"cutile"``, ``"triton"``)
+
+    Returns:
+        True if a real implementation for ``backend`` is registered.
+    """
+    return name in _REGISTRY and backend in _REGISTRY[name]
 
 
 def get_registry_info() -> Dict[str, Dict[str, str]]:

--- a/src/tilegym/ops/cutile/softmax.py
+++ b/src/tilegym/ops/cutile/softmax.py
@@ -6,6 +6,7 @@ import math
 
 import cuda.tile as ct
 import torch
+from cuda.tile import RoundingMode as RMd
 
 from tilegym.backend import register_impl
 from tilegym.experimental import experimental_kernel
@@ -39,13 +40,13 @@ def _softmax_kernel(
         row_minus_max = row - row_max
 
         # Compute exponential
-        numerator = ct.exp(row_minus_max)
+        numerator = ct.exp(row_minus_max, rounding_mode=RMd.APPROX)
 
         # Compute sum for normalization
         denominator = ct.sum(numerator, 0, keepdims=True)
 
         # Final softmax computation
-        softmax_output = numerator / denominator
+        softmax_output = ct.truediv(numerator, denominator, rounding_mode=RMd.APPROX, flush_to_zero=True)
         softmax_output = ct.astype(softmax_output, input.dtype)
         ct.scatter(output, (row_idx, offsets), softmax_output, check_bounds=True)
 
@@ -69,10 +70,11 @@ def _softmax_kernel_multi_wave_full_row_reg_cached_ldg(
     row = ct.astype(row, ct.float32)
 
     row_max = ct.max(row, 0, keepdims=True)
-    numerator = ct.exp(row - row_max)
+    numerator = ct.exp(row - row_max, rounding_mode=RMd.APPROX)
     denominator = ct.sum(numerator, 0, keepdims=True)
 
-    softmax_output = ct.astype(numerator / denominator, input.dtype)
+    softmax_output = ct.truediv(numerator, denominator, rounding_mode=RMd.APPROX, flush_to_zero=True)
+    softmax_output = ct.astype(softmax_output, input.dtype)
     ct.scatter(output, (row_idx, offsets), softmax_output, check_bounds=check_bound)
 
 
@@ -101,13 +103,13 @@ def _softmax_kernel_tma(
         row_minus_max = row - row_max
 
         # Compute exponential
-        numerator = ct.exp(row_minus_max)
+        numerator = ct.exp(row_minus_max, rounding_mode=RMd.APPROX)
 
         # Compute sum for normalization
         denominator = ct.sum(numerator, 1, keepdims=True)
 
         # Final softmax computation
-        softmax_output = numerator / denominator
+        softmax_output = ct.truediv(numerator, denominator, rounding_mode=RMd.APPROX, flush_to_zero=True)
 
         # Convert back to original dtype and store
         softmax_output = ct.astype(softmax_output, input.dtype)
@@ -150,9 +152,12 @@ def _softmax_kernel_chunked(
             chunk = ct.gather(input, (row_idx, col_indices), check_bounds=True, padding_value=-math.inf)
             chunk = ct.astype(chunk, ct.float32)
             row_minus_max = chunk - row_max
-            numerator = ct.exp(row_minus_max)
+            numerator = ct.exp(row_minus_max, rounding_mode=RMd.APPROX)
             exponentials_sum = ct.sum(numerator, 0, keepdims=True)
             denominator = denominator + exponentials_sum
+
+        # Reciprocal once per row, multiplied inside the pass-3 chunk loop.
+        inv_denominator = ct.truediv(1.0, denominator, rounding_mode=RMd.APPROX, flush_to_zero=True)
 
         # Pass 3: Compute final softmax
         for chunk_idx in range(num_chunks):
@@ -162,8 +167,8 @@ def _softmax_kernel_chunked(
             chunk = ct.gather(input, (row_idx, col_indices), check_bounds=True, padding_value=-math.inf)
             chunk = ct.astype(chunk, ct.float32)
             row_minus_max = chunk - row_max
-            numerator = ct.exp(row_minus_max)
-            softmax_output = numerator / denominator
+            numerator = ct.exp(row_minus_max, rounding_mode=RMd.APPROX)
+            softmax_output = numerator * inv_denominator
             softmax_output = ct.astype(softmax_output, input.dtype)
             # Use scatter with bounds checking to avoid writing padded zeros
             ct.scatter(output, (row_idx, col_indices), softmax_output, check_bounds=True)

--- a/src/tilegym/ops/cutile/splitk_reduce.py
+++ b/src/tilegym/ops/cutile/splitk_reduce.py
@@ -45,6 +45,7 @@ def _splitk_reduce_kernel(
         order=(0, 1, 2, 3),
         allow_tma=True,
         latency=2,
+        padding_mode=ct.PaddingMode.ZERO,
     )
     out_splitk = ct.reshape(out_splitk, (NUM_KV_SPLITS_POW2, TILE_D))
 

--- a/src/tilegym/ops/tilecpp/attention.cuh
+++ b/src/tilegym/ops/tilecpp/attention.cuh
@@ -251,7 +251,11 @@ __tile_global__ void prefill_fmha_fwd_kernel(
     // Convert back to input type and store output
     auto acc_T = ct::element_cast<T>(acc);
     auto acc_4d = ct::reshape(acc_T, ct::shape<1, 1, BLOCK_M, BLOCK_D>{});
-    Out_view.store(acc_4d, batch_idx, head_idx, pid_x, 0);
+    if constexpr (EVEN_Q) {
+        Out_view.store(acc_4d, batch_idx, head_idx, pid_x, 0);
+    } else {
+        Out_view.store_masked(acc_4d, batch_idx, head_idx, pid_x, 0);
+    }
 
     if constexpr (HAS_BACKWARD) {
         auto L_span = ct::tensor_span{L_ptr, ct::extents<uint32_t, B, H, S_QO>{}};
@@ -260,7 +264,11 @@ __tile_global__ void prefill_fmha_fwd_kernel(
         auto lse_2d = m_i + ct::log2(l_i);                                 // (TILE_M, 1)
         auto lse_1d = ct::reshape(lse_2d, ct::shape<BLOCK_M>{});
         auto lse_3d = ct::reshape(lse_1d, ct::shape<1, 1, BLOCK_M>{});
-        L_view.store(lse_3d, batch_idx, head_idx, pid_x);
+        if constexpr (EVEN_Q) {
+            L_view.store(lse_3d, batch_idx, head_idx, pid_x);
+        } else {
+            L_view.store_masked(lse_3d, batch_idx, head_idx, pid_x);
+        }
     }
 }
 

--- a/src/tilegym/ops/tilecpp/chunk_gated_delta_rule.cuh
+++ b/src/tilegym/ops/tilecpp/chunk_gated_delta_rule.cuh
@@ -74,6 +74,8 @@ __tile__ inline TileType cgdr_solve_tril(TileType A) {
 // Grid: (B * NUM_HEADS, num_chunks, 1).
 // ============================================================================
 template<typename T,
+         typename BetaT,
+         typename GT,
          int CHUNK_SIZE,
          int BLOCK_K,
          bool USE_QK_L2NORM,
@@ -83,8 +85,8 @@ __tile_global__ void chunk_gated_delta_rule_intra_kernel(
     const T* __restrict__ Q,           // (B, T, H, K)
     const T* __restrict__ K,           // (B, T, H, K)
     const T* __restrict__ V,           // (B, T, H, V)
-    const T* __restrict__ Beta,        // (B, T, H)
-    const T* __restrict__ G,           // (B, T, H)
+    const BetaT* __restrict__ Beta,    // (B, T, H)
+    const GT* __restrict__ G,          // (B, T, H)
     float* __restrict__ Q_out,         // (B, H, num_chunks, CHUNK_SIZE, K)
     float* __restrict__ K_out,         // (B, H, num_chunks, CHUNK_SIZE, K)
     float* __restrict__ V_corr,        // (B, H, num_chunks, CHUNK_SIZE, V)
@@ -249,12 +251,12 @@ __tile_global__ void chunk_gated_delta_rule_intra_kernel(
     // --- v_corrected = attn @ (v * beta[:, None]) : iterate V tiles ---
     int num_v_tiles = (V_dim + BLOCK_K - 1) / BLOCK_K;
     for (auto vt : ct::irange(0, num_v_tiles)) {
-        auto v_4d = pV.load(b, pid_chunk, h, vt);
+        auto v_4d = pV.load_masked(b, pid_chunk, h, vt);
         auto v    = ct::element_cast<float>(ct::reshape<ct::shape<CHUNK_SIZE, BLOCK_K>>(v_4d));
         auto vb   = v * beta_col;
         auto vc   = ct::matmul(attn, vb);
-        pVcorr.store(ct::reshape<ct::shape<1, 1, 1, CHUNK_SIZE, BLOCK_K>>(vc),
-                     b, h, pid_chunk, 0, vt);
+        pVcorr.store_masked(ct::reshape<ct::shape<1, 1, 1, CHUNK_SIZE, BLOCK_K>>(vc),
+                            b, h, pid_chunk, 0, vt);
     }
 }
 

--- a/src/tilegym/ops/tilecpp/chunk_gated_delta_rule.py
+++ b/src/tilegym/ops/tilecpp/chunk_gated_delta_rule.py
@@ -19,6 +19,7 @@ import torch
 
 from tilegym.backend import register_impl
 from tilegym.ops.tilecpp.utils._cuda_utils import TileCppKernel
+from tilegym.ops.tilecpp.utils._cuda_utils import get_cpp_type
 from tilegym.ops.tilecpp.utils._dump_types import dump_kernel_types
 
 _intra_kernel = TileCppKernel(
@@ -64,7 +65,11 @@ def _launch_intra(
 
     occupancy = 1
     bool_to_str = lambda b: "true" if b else "false"
+    beta_cpp_type = get_cpp_type(Beta.dtype)
+    g_cpp_type = get_cpp_type(G.dtype)
     template_params = [
+        beta_cpp_type,
+        g_cpp_type,
         chunk_size,
         block_k,
         bool_to_str(use_qk_l2norm),
@@ -74,7 +79,7 @@ def _launch_intra(
         dtype=dtype,
         template_params=template_params,
         signature=(
-            "const {T}*, const {T}*, const {T}*, const {T}*, const {T}*, "
+            f"const {{T}}*, const {{T}}*, const {{T}}*, const {beta_cpp_type}*, const {g_cpp_type}*, "
             "float*, float*, float*, float*, float*, "
             "float, int, int, int, int, int, int"
         ),

--- a/src/tilegym/ops/tilecpp/layer_norm_legacy.cuh
+++ b/src/tilegym/ops/tilecpp/layer_norm_legacy.cuh
@@ -22,12 +22,12 @@
  *
  * Each program handles one row. Uses loop over blocks if N > BLOCK_SIZE.
  */
-template<typename T, int N, int BLOCK_SIZE>
+template<typename T, typename WT, typename BT, int N, int BLOCK_SIZE>
 __tile_global__ void layer_norm_fwd_fused_kernel(
     T* __restrict__ X,
     T* __restrict__ Y,
-    T* __restrict__ W,
-    T* __restrict__ B,
+    const WT* __restrict__ W,
+    const BT* __restrict__ B,
     float* __restrict__ Mean,
     float* __restrict__ Rstd,
     float eps,
@@ -88,8 +88,8 @@ __tile_global__ void layer_norm_fwd_fused_kernel(
         auto cols = ct::full<i32xN>(off) + ct::iota<i32xN>();
         auto mask = cols < ct::full<i32xN>(N);
 
-        auto w_t = ct::load_masked(W + cols, mask, T(0));
-        auto b_t = ct::load_masked(B + cols, mask, T(0));
+        auto w_t = ct::load_masked(W + cols, mask, WT(0));
+        auto b_t = ct::load_masked(B + cols, mask, BT(0));
         auto w = ct::element_cast<float>(w_t) + weight_shift;
         auto b = ct::element_cast<float>(b_t);
 

--- a/src/tilegym/ops/tilecpp/layer_norm_legacy.py
+++ b/src/tilegym/ops/tilecpp/layer_norm_legacy.py
@@ -14,6 +14,7 @@ import torch
 
 from tilegym.backend import register_impl
 from tilegym.ops.tilecpp.utils._cuda_utils import TileCppKernel
+from tilegym.ops.tilecpp.utils._cuda_utils import get_cpp_type
 from tilegym.ops.tilecpp.utils._dump_types import dump_kernel_types
 
 
@@ -44,11 +45,13 @@ def _launch_layer_norm_fwd(
     """Launch the layer_norm_fwd_fused_kernel CUDA kernel."""
     dump_kernel_types("layer_norm_fwd_fused_kernel", x, y, weight, bias)
     dtype = x.dtype
+    w_cpp_type = get_cpp_type(weight.dtype)
+    b_cpp_type = get_cpp_type(bias.dtype)
 
     kernel, _, _ = _layer_norm_fwd_kernel.get_kernel(
         dtype=dtype,
-        template_params=[N, BLOCK_SIZE],
-        signature="{T}*, {T}*, {T}*, {T}*, float*, float*, float, float",
+        template_params=[w_cpp_type, b_cpp_type, N, BLOCK_SIZE],
+        signature=f"{{T}}*, {{T}}*, const {w_cpp_type}*, const {b_cpp_type}*, float*, float*, float, float",
     )
 
     _layer_norm_fwd_kernel.launch(
@@ -72,6 +75,8 @@ class LayerNorm(torch.autograd.Function):
     def forward(ctx, x, normalized_shape, weight, bias, eps, weight_shift=0.0):
         # allocate output
         y = torch.empty_like(x)
+        weight = weight.contiguous()
+        bias = bias.contiguous()
         # reshape input data into 2D tensor
         x_arg = x.reshape(-1, x.shape[-1])
         M, N = x_arg.shape

--- a/src/tilegym/ops/tilecpp/persistent_layer_norm.cuh
+++ b/src/tilegym/ops/tilecpp/persistent_layer_norm.cuh
@@ -25,6 +25,8 @@
 #include <cuda_bf16.h>
 
 template<typename T,
+         typename WT,
+         typename BT,
          int BLOCK_N,
          int BLOCK_D,
          bool IS_SWISH,
@@ -38,8 +40,8 @@ template<typename T,
 __tile_global__ void persistent_layer_norm_fwd_kernel(
     const T* __restrict__ X,       // (N, D)
     T* __restrict__ Y,             // (N, D)
-    const T* __restrict__ W,       // (D,)
-    const T* __restrict__ B,       // (D,)
+    const WT* __restrict__ W,      // (D,)
+    const BT* __restrict__ B,      // (D,)
     float* __restrict__ Mean,      // (N,)
     float* __restrict__ Rstd       // (N,)
 ) {

--- a/src/tilegym/ops/tilecpp/persistent_layer_norm.py
+++ b/src/tilegym/ops/tilecpp/persistent_layer_norm.py
@@ -19,6 +19,7 @@ from tilegym.ops.tilecpp.autotuner import TileCppAutotuner
 from tilegym.ops.tilecpp.autotuner import autotune
 from tilegym.ops.tilecpp.autotuner import is_autotuning_enabled
 from tilegym.ops.tilecpp.utils._cuda_utils import TileCppKernel
+from tilegym.ops.tilecpp.utils._cuda_utils import get_cpp_type
 from tilegym.ops.tilecpp.utils._dump_types import dump_kernel_types
 
 _fwd_kernel = TileCppKernel(
@@ -64,6 +65,8 @@ def _get_default_persistent_layer_norm_configs():
 
 def _launch_fwd(x, y, weight, bias, mean, rstd, eps, compute_mean_and_rstd, block_n, block_d):
     dtype = x.dtype
+    w_cpp_type = get_cpp_type(weight.dtype)
+    b_cpp_type = get_cpp_type(bias.dtype)
     dump_kernel_types("persistent_layer_norm_fwd_kernel", x, weight, bias)
 
     N, D = x.shape
@@ -92,8 +95,8 @@ def _launch_fwd(x, y, weight, bias, mean, rstd, eps, compute_mean_and_rstd, bloc
 
     kernel, _, _ = _fwd_kernel.get_kernel(
         dtype=dtype,
-        template_params=template_params,
-        signature=("const {T}*, {T}*, const {T}*, const {T}*, float*, float*"),
+        template_params=[w_cpp_type, b_cpp_type] + list(template_params),
+        signature=f"const {{T}}*, {{T}}*, const {w_cpp_type}*, const {b_cpp_type}*, float*, float*",
     )
 
     _fwd_kernel.launch(
@@ -176,6 +179,8 @@ def _persistent_layer_norm_fwd(x, weight, bias, eps, mean=None, rstd=None):
     N, D = x.shape
     assert weight.dim() == 1 and bias.dim() == 1
     assert weight.numel() == D and bias.numel() == D
+    weight = weight.contiguous()
+    bias = bias.contiguous()
 
     y = torch.empty_like(x)
     if (mean is None) != (rstd is None):

--- a/src/tilegym/ops/tilecpp/recurrent_gated_delta_rule.cuh
+++ b/src/tilegym/ops/tilecpp/recurrent_gated_delta_rule.cuh
@@ -10,7 +10,7 @@
  * Tensor layouts:
  *   Q, K:         (B, T, H, K_HEAD_DIM)   - input dtype T
  *   V, Output:    (B, T, H, V_HEAD_DIM)   - input dtype T
- *   G, Beta:      (B, T, H)               - input dtype T (loaded as scalar)
+ *   G, Beta:      (B, T, H)               - float32 (loaded as scalar)
  *   InitState:    (B, H, K_HEAD_DIM, V_HEAD_DIM)  - float32
  *   FinalState:   (B, H, K_HEAD_DIM, V_HEAD_DIM)  - float32
  */
@@ -26,7 +26,7 @@
  * Forward kernel.
  *
  * Template params:
- *   T:                   element type for Q/K/V/G/Beta/Output
+ *   T:                   element type for Q/K/V/Output
  *   BLOCK_K, BLOCK_V:    power-of-2 tile sizes (>= K_HEAD_DIM, BLOCK_V <= V_HEAD_DIM)
  *   HAS_INITIAL_STATE:   seed the recurrent state from InitState if true
  *   OUTPUT_FINAL_STATE:  write state back to FinalState if true
@@ -36,6 +36,8 @@
  * same cubin can serve every shape (avoids recompile per shape).
  */
 template<typename T,
+         typename GT,
+         typename BetaT,
          int BLOCK_K,
          int BLOCK_V,
          bool HAS_INITIAL_STATE,
@@ -45,8 +47,8 @@ __tile_global__ void recurrent_gated_delta_rule_fwd_kernel(
     const T* __restrict__ Q,               // (B, T, H, K_HEAD_DIM)
     const T* __restrict__ K,               // (B, T, H, K_HEAD_DIM)
     const T* __restrict__ V,               // (B, T, H, V_HEAD_DIM)
-    const T* __restrict__ G,               // (B, T, H)
-    const T* __restrict__ Beta,            // (B, T, H)
+    const GT* __restrict__ G,              // (B, T, H)
+    const BetaT* __restrict__ Beta,        // (B, T, H)
     T* __restrict__ Output,                // (B, T, H, V_HEAD_DIM)
     const float* __restrict__ InitState,   // (B, H, K_HEAD_DIM, V_HEAD_DIM) or nullptr
     float* __restrict__ FinalState,        // (B, H, K_HEAD_DIM, V_HEAD_DIM) or nullptr

--- a/src/tilegym/ops/tilecpp/recurrent_gated_delta_rule.py
+++ b/src/tilegym/ops/tilecpp/recurrent_gated_delta_rule.py
@@ -15,6 +15,7 @@ import torch
 
 from tilegym.backend import register_impl
 from tilegym.ops.tilecpp.utils._cuda_utils import TileCppKernel
+from tilegym.ops.tilecpp.utils._cuda_utils import get_cpp_type
 from tilegym.ops.tilecpp.utils._dump_types import dump_kernel_types
 
 _fwd_kernel = TileCppKernel(
@@ -50,6 +51,8 @@ def _launch_fwd(
     use_qk_l2norm,
 ):
     dtype = query.dtype
+    g_cpp_type = get_cpp_type(g.dtype)
+    beta_cpp_type = get_cpp_type(beta.dtype)
     dump_kernel_types("recurrent_gated_delta_rule_fwd_kernel", query, key, value)
 
     B, T, H, K_HEAD_DIM = query.shape
@@ -80,8 +83,8 @@ def _launch_fwd(
 
     kernel, _, _ = _fwd_kernel.get_kernel(
         dtype=dtype,
-        template_params=template_params,
-        signature="const {T}*, const {T}*, const {T}*, const {T}*, const {T}*, {T}*, const float*, float*, float, int, int, int, int, int",
+        template_params=[g_cpp_type, beta_cpp_type] + list(template_params),
+        signature=f"const {{T}}*, const {{T}}*, const {{T}}*, const {g_cpp_type}*, const {beta_cpp_type}*, {{T}}*, const float*, float*, float, int, int, int, int, int",
     )
 
     grid = (B * H, (V_HEAD_DIM + BLOCK_V - 1) // BLOCK_V, 1)

--- a/src/tilegym/ops/tilecpp/rms_norm.cuh
+++ b/src/tilegym/ops/tilecpp/rms_norm.cuh
@@ -36,10 +36,10 @@
  *   N: Number of columns (hidden size)
  *   eps: Small epsilon for numerical stability
  */
-template<typename T, int BLOCK_SIZE, int N, float EPS>
+template<typename T, typename WT, int BLOCK_SIZE, int N, float EPS>
 __tile_global__ void rms_norm_kernel(
     const T* __restrict__ X,
-    const T* __restrict__ W,
+    const WT* __restrict__ W,
     T* __restrict__ Y,
     float* __restrict__ rstd_ptr,
     int stride
@@ -48,6 +48,7 @@ __tile_global__ void rms_norm_kernel(
 
     using TxBS = ct::tile<T, ct::shape<BLOCK_SIZE>>;
     using f32xBS = ct::tile<float, ct::shape<BLOCK_SIZE>>;
+    using WxBS   = ct::tile<WT,    ct::shape<BLOCK_SIZE>>;
     using i32xBS = ct::tile<int, ct::shape<BLOCK_SIZE>>;
 
     // Each program handles one row
@@ -60,6 +61,7 @@ __tile_global__ void rms_norm_kernel(
     auto rstd_aligned = ct::assume_aligned<16>(rstd_ptr);
 
     auto zero_pad = ct::zeros<TxBS>();
+    auto zero_pad_w = ct::zeros<WxBS>();
 
     constexpr bool EVEN_N = (N % BLOCK_SIZE) == 0;
     constexpr int num_blocks = (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
@@ -92,7 +94,7 @@ __tile_global__ void rms_norm_kernel(
     for (auto j_idx : ct::irange(0, num_blocks)) {
         int j = j_idx * BLOCK_SIZE;
         auto cols = ct::iota<i32xBS>() + j;
-        TxBS wj_raw;
+        WxBS wj_raw;
         TxBS xj_raw;
         if constexpr (EVEN_N) {
             [[ using cutile : hint(1000, latency=1) ]]
@@ -102,7 +104,7 @@ __tile_global__ void rms_norm_kernel(
         } else {
             auto mask = cols < N;
             [[ using cutile : hint(1000, latency=1) ]]
-            wj_raw = ct::load_masked(W_aligned + cols, mask, zero_pad);
+            wj_raw = ct::load_masked(W_aligned + cols, mask, zero_pad_w);
             [[ using cutile : hint(1000, latency=1) ]]
             xj_raw = ct::load_masked(X_row + cols, mask, zero_pad);
         }
@@ -127,11 +129,11 @@ __tile_global__ void rms_norm_kernel(
  * Template Parameters:
  *   T, M, N, BLOCK_SIZE (= N).
  */
-template<typename T, int M, int N, int BLOCK_SIZE>
+template<typename T, typename WT, int M, int N, int BLOCK_SIZE>
 [[ using cutile : hint(1000, num_cta_in_cga=1) ]]
 __tile_global__ void rms_norm_kernel_pv(
     const T* __restrict__ X,
-    const T* __restrict__ W,
+    const WT* __restrict__ W,
     T* __restrict__ Y,
     float* __restrict__ rstd_ptr,
     float eps
@@ -158,7 +160,7 @@ __tile_global__ void rms_norm_kernel_pv(
         ct::tensor_span{W, ct::extents<uint32_t, N>{}},
         ct::shape<BLOCK_SIZE>{});
 
-    TxBS_1d w_loaded;
+    ct::tile<WT, ct::shape<BLOCK_SIZE>> w_loaded;
     [[ using cutile : hint(1000, latency=1) ]]
     w_loaded = W_view.load(0);
     auto w = ct::element_cast<float>(w_loaded);
@@ -209,6 +211,7 @@ __tile_global__ void rms_norm_kernel_pv(
  *   NUM_SMS: persistent grid size (== grid x-dim)
  */
 template<typename T,
+         typename WT,
          int TILE_SIZE_M, int TILE_SIZE_N,
          int occupancy,
          int M,
@@ -220,7 +223,7 @@ template<typename T,
 __tile_global__ void rms_norm_static_persistent_kernel(
     const T* __restrict__ X,
     T* __restrict__ Y,
-    const T* __restrict__ W,
+    const WT* __restrict__ W,
     float* __restrict__ Rstd
 ) {
     namespace ct = cuda::tiles;
@@ -308,12 +311,12 @@ __tile_global__ void rms_norm_static_persistent_kernel(
  *   stride: Row stride of X (typically N)
  *   N: Number of columns
  */
-template<typename T, int BLOCK_SIZE>
+template<typename T, typename WT, int BLOCK_SIZE>
 __tile_global__ void rms_norm_backward_dx_kernel(
     T* __restrict__ DX,
     const T* __restrict__ DY,
     const T* __restrict__ X,
-    const T* __restrict__ W,
+    const WT* __restrict__ W,
     const float* __restrict__ Rstd,
     float* __restrict__ temp_buffer,
     int stride,
@@ -323,6 +326,7 @@ __tile_global__ void rms_norm_backward_dx_kernel(
 
     using TxBS = ct::tile<T, ct::shape<BLOCK_SIZE>>;
     using f32xBS = ct::tile<float, ct::shape<BLOCK_SIZE>>;
+    using WxBS   = ct::tile<WT,    ct::shape<BLOCK_SIZE>>;
     using i32xBS = ct::tile<int, ct::shape<BLOCK_SIZE>>;
 
     int row = ct::bid().x;
@@ -335,6 +339,7 @@ __tile_global__ void rms_norm_backward_dx_kernel(
     auto Rstd_aligned = ct::assume_aligned<16>(Rstd);
 
     auto zero_pad = ct::zeros<TxBS>();
+    auto zero_pad_w = ct::zeros<WxBS>();
 
     // Load rstd for this row (scalar)
     float inv_std = Rstd_aligned[row];
@@ -350,7 +355,7 @@ __tile_global__ void rms_norm_backward_dx_kernel(
 
         auto x_raw = ct::load_masked(X_row + cols, mask, zero_pad);
         auto dy_raw = ct::load_masked(DY_row + cols, mask, zero_pad);
-        auto w_raw = ct::load_masked(W_aligned + cols, mask, zero_pad);
+        auto w_raw = ct::load_masked(W_aligned + cols, mask, zero_pad_w);
 
         // Upcast to float32 before any multiply so dy*x is computed in fp32.
         // Doing the multiply in native fp16/bf16 would lose precision.
@@ -377,7 +382,7 @@ __tile_global__ void rms_norm_backward_dx_kernel(
 
         auto x_raw = ct::load_masked(X_row + cols, mask, zero_pad);
         auto dy_raw = ct::load_masked(DY_row + cols, mask, zero_pad);
-        auto w_raw = ct::load_masked(W_aligned + cols, mask, zero_pad);
+        auto w_raw = ct::load_masked(W_aligned + cols, mask, zero_pad_w);
 
         auto x = ct::element_cast<float>(x_raw);
         auto dy = ct::element_cast<float>(dy_raw);

--- a/src/tilegym/ops/tilecpp/rms_norm.py
+++ b/src/tilegym/ops/tilecpp/rms_norm.py
@@ -16,6 +16,7 @@ import torch.nn as nn
 
 from tilegym.backend import register_impl
 from tilegym.ops.tilecpp.utils._cuda_utils import TileCppKernel
+from tilegym.ops.tilecpp.utils._cuda_utils import get_cpp_type
 from tilegym.ops.tilecpp.utils._cuda_utils import get_dtype_info
 from tilegym.ops.tilecpp.utils._dump_types import dump_kernel_types
 
@@ -88,14 +89,15 @@ def _launch_rms_norm_kernel(
 ):
     dump_kernel_types("rms_norm_kernel", x, weight, y, rstd)
     dtype = x.dtype
+    w_cpp_type = get_cpp_type(weight.dtype)
 
     eps_tp = f"{eps}f"
 
-    # Signature: const T*, const T*, T*, float*, int
+    # Signature: const T*, const WT*, T*, float*, int
     kernel, _, _ = _rms_norm_kernel.get_kernel(
         dtype=dtype,
-        template_params=[block_size, N, eps_tp],
-        signature="const {T}*, const {T}*, {T}*, float*, int",
+        template_params=[w_cpp_type, block_size, N, eps_tp],
+        signature=f"const {{T}}*, const {w_cpp_type}*, {{T}}*, float*, int",
     )
 
     grid = M
@@ -129,12 +131,13 @@ def _launch_rms_norm_kernel_pv(
     """
     dump_kernel_types("rms_norm_kernel_pv", x, weight, y, rstd)
     dtype = x.dtype
+    w_cpp_type = get_cpp_type(weight.dtype)
 
     # Template params: M, N, BLOCK_SIZE
     kernel, _, _ = _rms_norm_kernel_pv.get_kernel(
         dtype=dtype,
-        template_params=[M, N, block_size],
-        signature="const {T}*, const {T}*, {T}*, float*, float",
+        template_params=[w_cpp_type, M, N, block_size],
+        signature=f"const {{T}}*, const {w_cpp_type}*, {{T}}*, float*, float",
     )
 
     # One block per row
@@ -173,6 +176,7 @@ def _launch_rms_norm_static_persistent_kernel(
     """
     dump_kernel_types("rms_norm_static_persistent_kernel", x, y, weight, rstd)
     dtype = x.dtype
+    w_cpp_type = get_cpp_type(weight.dtype)
 
     NUM_SMS = _get_num_sm()
     grid_size = min(NUM_SMS, _ceildiv(M, tile_size_m) * _ceildiv(N, tile_size_n))
@@ -184,8 +188,8 @@ def _launch_rms_norm_static_persistent_kernel(
 
     kernel, _, _ = _rms_norm_static_persistent_kernel.get_kernel(
         dtype=dtype,
-        template_params=[tile_size_m, tile_size_n, occupancy, M, N, NUM_SMS, eps_tp, offset_tp],
-        signature="const {T}*, {T}*, const {T}*, float*",
+        template_params=[w_cpp_type, tile_size_m, tile_size_n, occupancy, M, N, NUM_SMS, eps_tp, offset_tp],
+        signature=f"const {{T}}*, {{T}}*, const {w_cpp_type}*, float*",
     )
 
     _rms_norm_static_persistent_kernel.launch(
@@ -215,12 +219,13 @@ def _launch_rms_norm_backward_dx_kernel(
     """Launch the rms_norm_backward_dx_kernel CUDA kernel."""
     dump_kernel_types("rms_norm_backward_dx_kernel", dx, dy, x, weight)
     dtype = x.dtype
+    w_cpp_type = get_cpp_type(weight.dtype)
 
-    # Signature: T*, const T*, const T*, const T*, const float*, float*, int, int
+    # Signature: T*, const T*, const T*, const WT*, const float*, float*, int, int
     kernel, _, _ = _rms_norm_backward_dx_kernel.get_kernel(
         dtype=dtype,
-        template_params=[block_size],
-        signature="{T}*, const {T}*, const {T}*, const {T}*, const float*, float*, int, int",
+        template_params=[w_cpp_type, block_size],
+        signature=f"{{T}}*, const {{T}}*, const {{T}}*, const {w_cpp_type}*, const float*, float*, int, int",
     )
 
     # One block per row
@@ -338,7 +343,7 @@ class RMSNorm(torch.autograd.Function):
         if bias is not None:
             raise NotImplementedError("Bias is not supported in TileCpp RMSNorm")
 
-        # Ensure inputs are contiguous
+        # Ensure inputs are contiguous.
         x = x.contiguous()
         weight = weight.contiguous()
 

--- a/src/tilegym/ops/tilecpp/rope.cuh
+++ b/src/tilegym/ops/tilecpp/rope.cuh
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cuda_tile.h>
+#include <type_traits>
 #include <cuda_fp16.h>
 #include <cuda_bf16.h>
 
@@ -39,16 +40,18 @@
  *
  * Each program handles one (batch, seq) position, processing all heads in parallel.
  */
-template<typename T, int BATCH, int Q_HEADS, int K_HEADS,
+template<typename T, typename CT, typename ST, int BATCH, int Q_HEADS, int K_HEADS,
          int BLOCK_QH, int BLOCK_KH, int BLOCK_HD,
          int HALF_ROPE_DIM, int HEAD_DIM, int COS_BS, int SEQ_LEN>
 __tile_global__ void rope_kernel(
     T* __restrict__ q,    // [batch, n_q_heads, seq_len, head_dim]
     T* __restrict__ k,    // [batch, n_kv_heads, seq_len, head_dim]
-    T* __restrict__ cos,  // [cos_batch, seq_len, 2, half_rope_dim]
-    T* __restrict__ sin   // [cos_batch, seq_len, 2, half_rope_dim]
+    const CT* __restrict__ cos,  // [cos_batch, seq_len, 2, half_rope_dim]
+    const ST* __restrict__ sin   // [cos_batch, seq_len, 2, half_rope_dim]
 ) {
     namespace ct = cuda::tiles;
+    using AuxT  = std::conditional_t<(sizeof(ST) > sizeof(CT)), ST, CT>;
+    using CompT = std::conditional_t<(sizeof(AuxT) > sizeof(T)), AuxT, T>;
 
     q = ct::assume_aligned<16>(q);
     k = ct::assume_aligned<16>(k);
@@ -65,12 +68,12 @@ __tile_global__ void rope_kernel(
     auto pCos = ct::partition_view(ct::tensor_span{cos, ct::extents{COS_BS, SEQ_LEN, 2, HALF_ROPE_DIM}},
                                    ct::shape<1, 1, 1, BLOCK_HD>{});
     auto cos_loaded = pCos.load(cos_batch_idx, row_idx, 0, 0);
-    auto cos_row = ct::reshape<ct::shape<1, BLOCK_HD>>(cos_loaded);
+    auto cos_row = ct::element_cast<CompT>(ct::reshape<ct::shape<1, BLOCK_HD>>(cos_loaded));
 
     auto pSin = ct::partition_view(ct::tensor_span{sin, ct::extents{COS_BS, SEQ_LEN, 2, HALF_ROPE_DIM}},
                                    ct::shape<1, 1, 1, BLOCK_HD>{});
     auto sin_loaded = pSin.load(cos_batch_idx, row_idx, 0, 0);
-    auto sin_row = ct::reshape<ct::shape<1, BLOCK_HD>>(sin_loaded);
+    auto sin_row = ct::element_cast<CompT>(ct::reshape<ct::shape<1, BLOCK_HD>>(sin_loaded));
 
     // Process Q tensor - 4D view over head_dim. Tile indices 0 and 1 along the
     // head_dim axis cover [0:2*BLOCK_HD) == [0:rope_dim); any elements at
@@ -78,10 +81,10 @@ __tile_global__ void rope_kernel(
     auto pQ = ct::partition_view(ct::tensor_span{q, ct::extents{BATCH, Q_HEADS, SEQ_LEN, HEAD_DIM}},
                                  ct::shape<1, BLOCK_QH, 1, BLOCK_HD>{});
     auto q_tile_1_loaded = pQ.load(batch_idx, 0, row_idx, 0);
-    auto q_tile_1 = ct::reshape<ct::shape<BLOCK_QH, BLOCK_HD>>(q_tile_1_loaded);
+    auto q_tile_1 = ct::element_cast<CompT>(ct::reshape<ct::shape<BLOCK_QH, BLOCK_HD>>(q_tile_1_loaded));
 
     auto q_tile_2_loaded = pQ.load(batch_idx, 0, row_idx, 1);
-    auto q_tile_2 = ct::reshape<ct::shape<BLOCK_QH, BLOCK_HD>>(q_tile_2_loaded);
+    auto q_tile_2 = ct::element_cast<CompT>(ct::reshape<ct::shape<BLOCK_QH, BLOCK_HD>>(q_tile_2_loaded));
 
     auto cos_bcast_q = ct::broadcast<ct::shape<BLOCK_QH, BLOCK_HD>>(cos_row);
     auto sin_bcast_q = ct::broadcast<ct::shape<BLOCK_QH, BLOCK_HD>>(sin_row);
@@ -90,8 +93,8 @@ __tile_global__ void rope_kernel(
     auto new_q_tile_1 = q_tile_1 * cos_bcast_q - q_tile_2 * sin_bcast_q;
     auto new_q_tile_2 = q_tile_2 * cos_bcast_q + q_tile_1 * sin_bcast_q;
 
-    auto new_q_tile_1_reshaped = ct::reshape<ct::shape<1, BLOCK_QH, 1, BLOCK_HD>>(new_q_tile_1);
-    auto new_q_tile_2_reshaped = ct::reshape<ct::shape<1, BLOCK_QH, 1, BLOCK_HD>>(new_q_tile_2);
+    auto new_q_tile_1_reshaped = ct::reshape<ct::shape<1, BLOCK_QH, 1, BLOCK_HD>>(ct::element_cast<T>(new_q_tile_1));
+    auto new_q_tile_2_reshaped = ct::reshape<ct::shape<1, BLOCK_QH, 1, BLOCK_HD>>(ct::element_cast<T>(new_q_tile_2));
 
     pQ.store(new_q_tile_1_reshaped, batch_idx, 0, row_idx, 0);
     pQ.store(new_q_tile_2_reshaped, batch_idx, 0, row_idx, 1);
@@ -100,10 +103,10 @@ __tile_global__ void rope_kernel(
     auto pK = ct::partition_view(ct::tensor_span{k, ct::extents{BATCH, K_HEADS, SEQ_LEN, HEAD_DIM}},
                                  ct::shape<1, BLOCK_KH, 1, BLOCK_HD>{});
     auto k_tile_1_loaded = pK.load(batch_idx, 0, row_idx, 0);
-    auto k_tile_1 = ct::reshape<ct::shape<BLOCK_KH, BLOCK_HD>>(k_tile_1_loaded);
+    auto k_tile_1 = ct::element_cast<CompT>(ct::reshape<ct::shape<BLOCK_KH, BLOCK_HD>>(k_tile_1_loaded));
 
     auto k_tile_2_loaded = pK.load(batch_idx, 0, row_idx, 1);
-    auto k_tile_2 = ct::reshape<ct::shape<BLOCK_KH, BLOCK_HD>>(k_tile_2_loaded);
+    auto k_tile_2 = ct::element_cast<CompT>(ct::reshape<ct::shape<BLOCK_KH, BLOCK_HD>>(k_tile_2_loaded));
 
     auto cos_bcast_k = ct::broadcast<ct::shape<BLOCK_KH, BLOCK_HD>>(cos_row);
     auto sin_bcast_k = ct::broadcast<ct::shape<BLOCK_KH, BLOCK_HD>>(sin_row);
@@ -111,8 +114,8 @@ __tile_global__ void rope_kernel(
     auto new_k_tile_1 = k_tile_1 * cos_bcast_k - k_tile_2 * sin_bcast_k;
     auto new_k_tile_2 = k_tile_2 * cos_bcast_k + k_tile_1 * sin_bcast_k;
 
-    auto new_k_tile_1_reshaped = ct::reshape<ct::shape<1, BLOCK_KH, 1, BLOCK_HD>>(new_k_tile_1);
-    auto new_k_tile_2_reshaped = ct::reshape<ct::shape<1, BLOCK_KH, 1, BLOCK_HD>>(new_k_tile_2);
+    auto new_k_tile_1_reshaped = ct::reshape<ct::shape<1, BLOCK_KH, 1, BLOCK_HD>>(ct::element_cast<T>(new_k_tile_1));
+    auto new_k_tile_2_reshaped = ct::reshape<ct::shape<1, BLOCK_KH, 1, BLOCK_HD>>(ct::element_cast<T>(new_k_tile_2));
 
     pK.store(new_k_tile_1_reshaped, batch_idx, 0, row_idx, 0);
     pK.store(new_k_tile_2_reshaped, batch_idx, 0, row_idx, 1);
@@ -122,16 +125,18 @@ __tile_global__ void rope_kernel(
 /**
  * RoPE backward kernel - processes all heads at once using 2D tiles.
  */
-template<typename T, int BATCH, int Q_HEADS, int K_HEADS,
+template<typename T, typename CT, typename ST, int BATCH, int Q_HEADS, int K_HEADS,
          int BLOCK_QH, int BLOCK_KH, int BLOCK_HD,
          int HALF_ROPE_DIM, int HEAD_DIM, int COS_BS, int SEQ_LEN>
 __tile_global__ void rope_backward_kernel(
     T* __restrict__ dq,   // [batch, n_q_heads, seq_len, head_dim]
     T* __restrict__ dk,   // [batch, n_kv_heads, seq_len, head_dim]
-    T* __restrict__ cos,  // [cos_batch, seq_len, 2, half_rope_dim]
-    T* __restrict__ sin   // [cos_batch, seq_len, 2, half_rope_dim]
+    const CT* __restrict__ cos,  // [cos_batch, seq_len, 2, half_rope_dim]
+    const ST* __restrict__ sin   // [cos_batch, seq_len, 2, half_rope_dim]
 ) {
     namespace ct = cuda::tiles;
+    using AuxT  = std::conditional_t<(sizeof(ST) > sizeof(CT)), ST, CT>;
+    using CompT = std::conditional_t<(sizeof(AuxT) > sizeof(T)), AuxT, T>;
 
     dq = ct::assume_aligned<16>(dq);
     dk = ct::assume_aligned<16>(dk);
@@ -146,21 +151,21 @@ __tile_global__ void rope_backward_kernel(
     auto pCos = ct::partition_view(ct::tensor_span{cos, ct::extents{COS_BS, SEQ_LEN, 2, HALF_ROPE_DIM}},
                                    ct::shape<1, 1, 1, BLOCK_HD>{});
     auto cos_loaded = pCos.load(cos_batch_idx, row_idx, 0, 0);
-    auto cos_row = ct::reshape<ct::shape<1, BLOCK_HD>>(cos_loaded);
+    auto cos_row = ct::element_cast<CompT>(ct::reshape<ct::shape<1, BLOCK_HD>>(cos_loaded));
 
     auto pSin = ct::partition_view(ct::tensor_span{sin, ct::extents{COS_BS, SEQ_LEN, 2, HALF_ROPE_DIM}},
                                    ct::shape<1, 1, 1, BLOCK_HD>{});
     auto sin_loaded = pSin.load(cos_batch_idx, row_idx, 0, 0);
-    auto sin_row = ct::reshape<ct::shape<1, BLOCK_HD>>(sin_loaded);
+    auto sin_row = ct::element_cast<CompT>(ct::reshape<ct::shape<1, BLOCK_HD>>(sin_loaded));
 
     // Process dQ tensor
     auto pDQ = ct::partition_view(ct::tensor_span{dq, ct::extents{BATCH, Q_HEADS, SEQ_LEN, HEAD_DIM}},
                                   ct::shape<1, BLOCK_QH, 1, BLOCK_HD>{});
     auto dq_tile_1_loaded = pDQ.load(batch_idx, 0, row_idx, 0);
-    auto dq_tile_1 = ct::reshape<ct::shape<BLOCK_QH, BLOCK_HD>>(dq_tile_1_loaded);
+    auto dq_tile_1 = ct::element_cast<CompT>(ct::reshape<ct::shape<BLOCK_QH, BLOCK_HD>>(dq_tile_1_loaded));
 
     auto dq_tile_2_loaded = pDQ.load(batch_idx, 0, row_idx, 1);
-    auto dq_tile_2 = ct::reshape<ct::shape<BLOCK_QH, BLOCK_HD>>(dq_tile_2_loaded);
+    auto dq_tile_2 = ct::element_cast<CompT>(ct::reshape<ct::shape<BLOCK_QH, BLOCK_HD>>(dq_tile_2_loaded));
 
     auto cos_bcast_q = ct::broadcast<ct::shape<BLOCK_QH, BLOCK_HD>>(cos_row);
     auto sin_bcast_q = ct::broadcast<ct::shape<BLOCK_QH, BLOCK_HD>>(sin_row);
@@ -169,8 +174,8 @@ __tile_global__ void rope_backward_kernel(
     auto new_dq_tile_1 = dq_tile_1 * cos_bcast_q + dq_tile_2 * sin_bcast_q;
     auto new_dq_tile_2 = dq_tile_2 * cos_bcast_q - dq_tile_1 * sin_bcast_q;
 
-    auto new_dq_tile_1_reshaped = ct::reshape<ct::shape<1, BLOCK_QH, 1, BLOCK_HD>>(new_dq_tile_1);
-    auto new_dq_tile_2_reshaped = ct::reshape<ct::shape<1, BLOCK_QH, 1, BLOCK_HD>>(new_dq_tile_2);
+    auto new_dq_tile_1_reshaped = ct::reshape<ct::shape<1, BLOCK_QH, 1, BLOCK_HD>>(ct::element_cast<T>(new_dq_tile_1));
+    auto new_dq_tile_2_reshaped = ct::reshape<ct::shape<1, BLOCK_QH, 1, BLOCK_HD>>(ct::element_cast<T>(new_dq_tile_2));
 
     pDQ.store(new_dq_tile_1_reshaped, batch_idx, 0, row_idx, 0);
     pDQ.store(new_dq_tile_2_reshaped, batch_idx, 0, row_idx, 1);
@@ -179,10 +184,10 @@ __tile_global__ void rope_backward_kernel(
     auto pDK = ct::partition_view(ct::tensor_span{dk, ct::extents{BATCH, K_HEADS, SEQ_LEN, HEAD_DIM}},
                                   ct::shape<1, BLOCK_KH, 1, BLOCK_HD>{});
     auto dk_tile_1_loaded = pDK.load(batch_idx, 0, row_idx, 0);
-    auto dk_tile_1 = ct::reshape<ct::shape<BLOCK_KH, BLOCK_HD>>(dk_tile_1_loaded);
+    auto dk_tile_1 = ct::element_cast<CompT>(ct::reshape<ct::shape<BLOCK_KH, BLOCK_HD>>(dk_tile_1_loaded));
 
     auto dk_tile_2_loaded = pDK.load(batch_idx, 0, row_idx, 1);
-    auto dk_tile_2 = ct::reshape<ct::shape<BLOCK_KH, BLOCK_HD>>(dk_tile_2_loaded);
+    auto dk_tile_2 = ct::element_cast<CompT>(ct::reshape<ct::shape<BLOCK_KH, BLOCK_HD>>(dk_tile_2_loaded));
 
     auto cos_bcast_k = ct::broadcast<ct::shape<BLOCK_KH, BLOCK_HD>>(cos_row);
     auto sin_bcast_k = ct::broadcast<ct::shape<BLOCK_KH, BLOCK_HD>>(sin_row);
@@ -190,8 +195,8 @@ __tile_global__ void rope_backward_kernel(
     auto new_dk_tile_1 = dk_tile_1 * cos_bcast_k + dk_tile_2 * sin_bcast_k;
     auto new_dk_tile_2 = dk_tile_2 * cos_bcast_k - dk_tile_1 * sin_bcast_k;
 
-    auto new_dk_tile_1_reshaped = ct::reshape<ct::shape<1, BLOCK_KH, 1, BLOCK_HD>>(new_dk_tile_1);
-    auto new_dk_tile_2_reshaped = ct::reshape<ct::shape<1, BLOCK_KH, 1, BLOCK_HD>>(new_dk_tile_2);
+    auto new_dk_tile_1_reshaped = ct::reshape<ct::shape<1, BLOCK_KH, 1, BLOCK_HD>>(ct::element_cast<T>(new_dk_tile_1));
+    auto new_dk_tile_2_reshaped = ct::reshape<ct::shape<1, BLOCK_KH, 1, BLOCK_HD>>(ct::element_cast<T>(new_dk_tile_2));
 
     pDK.store(new_dk_tile_1_reshaped, batch_idx, 0, row_idx, 0);
     pDK.store(new_dk_tile_2_reshaped, batch_idx, 0, row_idx, 1);

--- a/src/tilegym/ops/tilecpp/rope.py
+++ b/src/tilegym/ops/tilecpp/rope.py
@@ -15,6 +15,7 @@ import torch
 
 from tilegym.backend import register_impl
 from tilegym.ops.tilecpp.utils._cuda_utils import TileCppKernel
+from tilegym.ops.tilecpp.utils._cuda_utils import get_cpp_type
 from tilegym.ops.tilecpp.utils._dump_types import dump_kernel_types
 
 
@@ -102,9 +103,13 @@ def rope_forward(q, k, cos, sin, rope_dim=None):
     dtype = q.dtype
     dump_kernel_types("rope_kernel", q, k, cos, sin)
 
-    # Template params: T, BATCH, Q_HEADS, K_HEADS, BLOCK_QH, BLOCK_KH, BLOCK_HD,
+    # Template params: T, CT, BATCH, Q_HEADS, K_HEADS, BLOCK_QH, BLOCK_KH, BLOCK_HD,
     #                  HALF_ROPE_DIM, HEAD_DIM, COS_BS, SEQ_LEN
+    cos_cpp_type = get_cpp_type(cos.dtype)
+    sin_cpp_type = get_cpp_type(sin.dtype)
     template_params = [
+        cos_cpp_type,
+        sin_cpp_type,
         batch_size,
         n_q_head,
         n_kv_head,
@@ -120,7 +125,7 @@ def rope_forward(q, k, cos, sin, rope_dim=None):
     kernel, _, _ = _rope_forward_kernel.get_kernel(
         dtype=dtype,
         template_params=template_params,
-        signature="{T}*, {T}*, {T}*, {T}*",
+        signature=f"{{T}}*, {{T}}*, const {cos_cpp_type}*, const {sin_cpp_type}*",
     )
 
     _rope_forward_kernel.launch(
@@ -186,7 +191,11 @@ def rope_backward(dq, dk, cos, sin, rope_dim=None):
     dtype = dq.dtype
     dump_kernel_types("rope_backward_kernel", dq, dk, cos, sin)
 
+    cos_cpp_type = get_cpp_type(cos.dtype)
+    sin_cpp_type = get_cpp_type(sin.dtype)
     template_params = [
+        cos_cpp_type,
+        sin_cpp_type,
         batch_size,
         n_q_head,
         n_kv_head,
@@ -202,7 +211,7 @@ def rope_backward(dq, dk, cos, sin, rope_dim=None):
     kernel, _, _ = _rope_backward_kernel.get_kernel(
         dtype=dtype,
         template_params=template_params,
-        signature="{T}*, {T}*, {T}*, {T}*",
+        signature=f"{{T}}*, {{T}}*, const {cos_cpp_type}*, const {sin_cpp_type}*",
     )
 
     _rope_backward_kernel.launch(

--- a/src/tilegym/suites/flashinfer/cutile/fmha_decode_bsr.py
+++ b/src/tilegym/suites/flashinfer/cutile/fmha_decode_bsr.py
@@ -32,29 +32,34 @@ INV_LOG_2 = 1.0 / math.log(2)
 # TRANS_QK to datacenter Blackwell only, mirroring the sm120/121 exclusion
 # idiom already used in ops/cutile/{matmul,bmm,attention}.py.
 _SM120_LIKE = [(12, 0), (12, 1)]
+# H100 opts into both optimisations below explicitly, rather than through the
+# >= sm100 test.
+_SM90 = (9, 0)
 
 
 def _supports_trans_qk() -> bool:
-    """True only on Blackwell parts with the wide MMA that TRANS_QK targets.
+    """True on H100 and on Blackwell parts with the wide MMA that TRANS_QK targets.
 
     Excludes A100 (sm80, no benefit) and sm120/sm121 (no wide MMA -> regression).
     """
     cap = torch.cuda.get_device_capability("cuda")
-    return cap[0] >= 10 and cap not in _SM120_LIKE
+    return cap == _SM90 or (cap[0] >= 10 and cap not in _SM120_LIKE)
 
 
 def _supports_gather_page_load() -> bool:
-    """True only on datacenter Blackwell (sm100/sm103), where the gather-TMA that
-    backs ct.load_advanced_indexing is a large win for multi-page KV loads.
+    """True on H100 and datacenter Blackwell (sm100/sm103), where the gather-TMA
+    that backs ct.load_advanced_indexing is a large win for multi-page KV loads.
 
     On sm100 the gathered multi-page load is 10-74% FASTER than per-page TMA loads
     (measured, DecodePaged). On sm120/sm121 (consumer Blackwell, no efficient
     gather-TMA) it REGRESSES 29-83% and the penalty scales with NUM_PAGES, so those
-    parts (and A100) fall back to per-page TMA loads. Same datacenter-Blackwell
-    predicate as _supports_trans_qk.
+    parts (and A100) fall back to per-page TMA loads.
+
+    On sm90 the gather only pays off together with TRANS_QK, which is enabled
+    there as well.
     """
     cap = torch.cuda.get_device_capability("cuda")
-    return cap[0] >= 10 and cap not in _SM120_LIKE
+    return cap == _SM90 or (cap[0] >= 10 and cap not in _SM120_LIKE)
 
 
 ConstInt = ct.Constant[int]

--- a/src/tilegym/suites/flashinfer/cutile/gemm/ragged_bmm.py
+++ b/src/tilegym/suites/flashinfer/cutile/gemm/ragged_bmm.py
@@ -13,9 +13,9 @@ from tilegym.backend import register_impl
 from tilegym.kernel_utils import get_kernel_configs
 from tilegym.ops.cutile.utils import cached_replace_hints
 
-# Module-level tune caches for standard and swap_ab ragged BMM
-_ragged_bmm_standard_tune_cache: dict = {}
-_ragged_bmm_swap_ab_tune_cache: dict = {}
+# Module-level tune cache for ragged BMM: shape key -> (config, tuned kernel).
+# The tuned kernel is whichever of the standard / swap_ab variants measured faster.
+_ragged_bmm_tune_cache: dict = {}
 
 
 @ct.kernel
@@ -425,11 +425,17 @@ def _get_default_kernel_configs():
         }
 
 
-def _ragged_bmm_autotune_standard(
-    stream, a, b, c, m_indptr, Q, max_m, max_m_device, N, total_m, transpose_a, transpose_b
-):
+def _ragged_bmm_autotune(stream, a, b, c, m_indptr, Q, max_m, max_m_device, N, total_m, transpose_a, transpose_b):
     """
-    Autotuned launch for standard ragged BMM kernel.
+    Autotuned launch for ragged BMM.
+
+    Tunes the standard and the swap_ab kernel over their respective config spaces
+    and launches whichever measured faster. The two variants only differ in the
+    accumulator layout, so they are interchangeable for any shape; which one wins
+    is not predictable from the shape alone (it depends on the per-arch config
+    space and is non-monotonic in the per-batch M), so it is measured rather than
+    guessed. Both variants read their grid bound from max_m_device, so the choice
+    never affects correctness.
     """
     NUM_SMS = torch.cuda.get_device_properties(a.device).multi_processor_count
 
@@ -473,87 +479,28 @@ def _ragged_bmm_autotune_standard(
         return {"num_ctas": cfg.num_ctas, "occupancy": cfg.occupancy}
 
     cache_key = (Q, max_m, N, total_m, transpose_a_int, transpose_b_int, a.dtype, str(a.device))
-    if cache_key not in _ragged_bmm_standard_tune_cache:
-        result = exhaustive_search(
-            list(_ragged_bmm_autotune_configs_standard()),
-            stream,
-            grid_fn,
-            _ragged_bmm_kernel,
-            args_fn,
-            hints_fn,
-        )
-        best_cfg = result.best.config
-        _ragged_bmm_standard_tune_cache[cache_key] = (
+    if cache_key not in _ragged_bmm_tune_cache:
+        best = None
+        for kernel, configs in (
+            (_ragged_bmm_kernel, list(_ragged_bmm_autotune_configs_standard())),
+            (_ragged_bmm_swap_ab_kernel, list(_ragged_bmm_autotune_configs_swap_ab())),
+        ):
+            try:
+                result = exhaustive_search(configs, stream, grid_fn, kernel, args_fn, hints_fn)
+            except Exception:
+                # A whole config space can fail to build on a given arch (e.g. smem
+                # limits); fall back to whichever variant did tune successfully.
+                continue
+            if best is None or result.best.mean_us < best[0]:
+                best = (result.best.mean_us, kernel, result.best.config)
+        if best is None:
+            raise RuntimeError("ragged_bmm autotune found no working configuration")
+        _, best_kernel, best_cfg = best
+        _ragged_bmm_tune_cache[cache_key] = (
             best_cfg,
-            _ragged_bmm_kernel.replace_hints(**hints_fn(best_cfg)),
+            best_kernel.replace_hints(**hints_fn(best_cfg)),
         )
-    best_cfg, tuned_kernel = _ragged_bmm_standard_tune_cache[cache_key]
-    ct.launch(stream, grid_fn(best_cfg), tuned_kernel, args_fn(best_cfg))
-
-
-def _ragged_bmm_autotune_swap_ab(
-    stream, a, b, c, m_indptr, Q, max_m, max_m_device, N, total_m, transpose_a, transpose_b
-):
-    """
-    Autotuned launch for swap_ab ragged BMM kernel.
-    """
-    NUM_SMS = torch.cuda.get_device_properties(a.device).multi_processor_count
-
-    transpose_a_int = 1 if transpose_a else 0
-    transpose_b_int = 1 if transpose_b else 0
-
-    def args_fn(cfg):
-        BM = cfg.BLOCK_M
-        BN = cfg.BLOCK_N
-        BK = cfg.BLOCK_K
-        GSM = cfg.GROUP_SIZE_M
-
-        return (
-            a,
-            b,
-            c,
-            m_indptr,
-            Q,
-            max_m,
-            max_m_device,
-            N,
-            transpose_a_int,
-            transpose_b_int,
-            BM,
-            BN,
-            BK,
-            GSM,
-        )
-
-    def grid_fn(cfg):
-        BM = cfg.BLOCK_M
-        BN = cfg.BLOCK_N
-        num_pid_m = ct.cdiv(max_m, BM)
-        num_pid_n = ct.cdiv(N, BN)
-        tiles_per_batch = num_pid_m * num_pid_n
-        total_tiles = tiles_per_batch * Q
-        num_programs = min(NUM_SMS // cfg.num_ctas, total_tiles) * cfg.occupancy
-        return (num_programs, 1, 1)
-
-    def hints_fn(cfg):
-        return {"num_ctas": cfg.num_ctas, "occupancy": cfg.occupancy}
-
-    swap_cache_key = (Q, max_m, N, total_m, transpose_a_int, transpose_b_int, a.dtype, str(a.device))
-    if swap_cache_key not in _ragged_bmm_swap_ab_tune_cache:
-        result = exhaustive_search(
-            list(_ragged_bmm_autotune_configs_swap_ab()),
-            stream,
-            grid_fn,
-            _ragged_bmm_swap_ab_kernel,
-            args_fn,
-            hints_fn,
-        )
-        best_cfg = result.best.config
-        _ragged_bmm_swap_ab_tune_cache[swap_cache_key] = (
-            best_cfg,
-            _ragged_bmm_swap_ab_kernel.replace_hints(**hints_fn(best_cfg)),
-        )
-    best_cfg, tuned_kernel = _ragged_bmm_swap_ab_tune_cache[swap_cache_key]
+    best_cfg, tuned_kernel = _ragged_bmm_tune_cache[cache_key]
     ct.launch(stream, grid_fn(best_cfg), tuned_kernel, args_fn(best_cfg))
 
 
@@ -627,49 +574,25 @@ def ragged_bmm(
     # Check if autotune is enabled
     enable_autotune = is_autotune_enabled()
 
-    # Decide whether to use swap_ab based on M vs N ratio.
-    # swap_ab (small BLOCK_M) is beneficial when the per-batch M is small relative
-    # to N. Use the per-batch average M (total_m / Q) rather than the host `max_m`
-    # hint: `max_m` is only a grid/cache-key upper bound and callers may pass a
-    # coarse over-estimate (e.g. the fused-MoE path passes total tokens_in_chunk,
-    # not the per-expert max), which would wrongly route small-per-expert MoE
-    # GEMMs to the large-M standard kernel (BLOCK_M=128) instead of swap_ab
-    # (BLOCK_M<=64). The grid bound stays exact via the device-side max_m_device,
-    # so this only affects config selection, never correctness.
-    avg_m = total_m // Q if Q > 0 else max_m
-    use_swap_ab = avg_m <= 128 and N >= 256
-
     if enable_autotune:
-        if use_swap_ab:
-            _ragged_bmm_autotune_swap_ab(
-                torch.cuda.current_stream(),
-                a,
-                b,
-                c,
-                m_indptr,
-                Q,
-                max_m,
-                max_m_device,
-                N,
-                total_m,
-                transpose_a,
-                transpose_b,
-            )
-        else:
-            _ragged_bmm_autotune_standard(
-                torch.cuda.current_stream(),
-                a,
-                b,
-                c,
-                m_indptr,
-                Q,
-                max_m,
-                max_m_device,
-                N,
-                total_m,
-                transpose_a,
-                transpose_b,
-            )
+        # The standard and swap_ab kernels are both tuned and the faster one wins.
+        # There is no host-side shape heuristic here on purpose: a threshold on the
+        # per-batch M mis-routes MoE GEMMs, because which variant is faster is not
+        # monotonic in M and differs per arch (measured on sm90 / sm103 / sm120).
+        _ragged_bmm_autotune(
+            torch.cuda.current_stream(),
+            a,
+            b,
+            c,
+            m_indptr,
+            Q,
+            max_m,
+            max_m_device,
+            N,
+            total_m,
+            transpose_a,
+            transpose_b,
+        )
     else:
         # Use fixed default configs
         default_configs = _get_default_kernel_configs()

--- a/tests/ops/test_chunk_gated_delta_rule.py
+++ b/tests/ops/test_chunk_gated_delta_rule.py
@@ -176,9 +176,6 @@ class Test_ChunkGatedDeltaRule(common.PyTestCase):
         if dtype == torch.float32:
             pytest.skip("Skipping fp32 tests due to known failures; under investigation")
 
-        if backend == "tilecpp" and use_l2:
-            pytest.skip("Skipping tilecpp l2norm case due to known failure; under investigation")
-
         self.setUp()
 
         from tilegym.ops import chunk_gated_delta_rule
@@ -284,8 +281,6 @@ class Test_ChunkGatedDeltaRule(common.PyTestCase):
         that reduced-precision Neumann products amplified catastrophically. The
         pre-normalized case also exercises the non-L2 infinity-norm guard.
         """
-        if backend == "tilecpp":
-            pytest.skip("Skipping tilecpp case due to known failure; under investigation")
         monkeypatch.setenv("TILEGYM_DISABLE_AUTOTUNE", "1")
         if not tilegym.is_backend_available(backend):
             pytest.skip(f"Backend {backend} is not available")

--- a/tests/suites/flashinfer/test_flashinfer_gemm_alpha_beta.py
+++ b/tests/suites/flashinfer/test_flashinfer_gemm_alpha_beta.py
@@ -45,7 +45,11 @@ class Test_FlashInfer_Matmul_Alpha_Beta(common.PyTestCase):
     @pytest.mark.parametrize("m, n, k", [(4096, 4096, 4096), (8192, 8192, 8192)])
     @pytest.mark.parametrize(
         "dtype, out_dtype",
-        [(torch.float16, torch.float16), (torch.bfloat16, torch.bfloat16), (torch.float8_e4m3fn, torch.bfloat16)],
+        [
+            (torch.float16, torch.float16),
+            (torch.bfloat16, torch.bfloat16),
+            (torch.float8_e4m3fn, torch.bfloat16),
+        ],
     )
     @pytest.mark.parametrize("trans_a, trans_b", [(False, True)])
     @pytest.mark.parametrize("alpha, beta", [(1.0, 0.0), (1.5, 2.0)])


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->

Update codes.

This PR contains **9** new commit(s).

### Commits included:

```
74110fc style(tests): reformat gemm_alpha_beta parametrize list
12ed859 flashinfer/cutile decode: keep TRANS_QK and gather page load enabled on sm90
cb20f76 fix(tilecpp): read auxiliary inputs at the caller's dtype
39ba3c3 fix(tilecpp): mask the FMHA forward tail store
801a3b8 fix(cutile): MLA split-KV NaN on sm_80 for non-power-of-2 seqlen
b106b36 cuTile ragged_bmm: tune both kernel variants instead of guessing swap_ab from the shape
3e2fe2f fix(tilecpp): chunk_gated_delta_rule V-tile bounds and G/Beta dtype
0511a0f perf(cutile softmax): per-op approx exp/div in all forward kernels
d5cd6da feat(dispatcher): add has_backend_impl and expose op name on dispatch wrapper
```

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: ["ops"]
```

## Checklist
- [ ] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

## TODO
Failed tests of tilecpp will be fixed in the next PR.