### PR TITLE
ci: sync request-nvskills-ci workflow with latest template

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -6,11 +6,14 @@ name: Request NVSkills CI
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
   push:
 
 jobs:
   request:
     if: >
+      github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/nvskills-ci')) ||
@@ -20,6 +23,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      statuses: read
     uses: NVIDIA/skills/.github/workflows/team-request.yml@main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary

Sync `.github/workflows/request-nvskills-ci.yml` with the [upstream template](https://github.com/NVIDIA/skills/blob/main/.github/workflows/request-nvskills-ci.yml) announced in NVCARPS on 2026-08-07.

Adds:
- `pull_request` trigger (opened/reopened/synchronize/ready_for_review)
- Corresponding `pull_request` branch in the job's `if` condition
- `statuses: read` permission — required by the updated wrapper; missing it causes `/nvskills-ci` to fail with `startup_failure` before any job is created

## Why merge separately (not via a skill PR)

`issue_comment` events always resolve the workflow file from the default branch, not the PR branch. So `/nvskills-ci` on any open PR keeps using the old workflow from `main` until this update lands. This PR unblocks all in-flight skill PRs (e.g. #179).

## CI Configuration

```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: []
```
