### PR TITLE
fix: warnings is imported repeatedly inside exception handlers

### DIFF
--- a/src/tilegym/ops/__init__.py
+++ b/src/tilegym/ops/__init__.py
@@ -4,6 +4,7 @@
 
 """TileGym ops module - contains all operation interfaces and backend implementations"""
 
+import warnings
 from tilegym.backend import is_backend_available
 
 # Backend implementations
@@ -16,7 +17,6 @@ if is_backend_available("cutile"):
     try:
         from . import cutile
     except (ImportError, RuntimeError):
-        import warnings
 
         warnings.warn("Cutile backend import failed, cutile operations will not be available")
         cutile = None  # type: ignore
@@ -29,7 +29,6 @@ from . import moe_interface
 try:
     from . import triton
 except (ImportError, RuntimeError):
-    import warnings
 
     warnings.warn("Triton backend import failed, triton operations will not be available")
     triton = None  # type: ignore


### PR DESCRIPTION
This PR addresses the following issue in `src/tilegym/ops/__init__.py`: warnings is imported repeatedly inside exception handlers.

## Changes
- `src/tilegym/ops/__init__.py`: warnings is imported repeatedly inside exception handlers.

## Details
```diff
--- a/src/tilegym/ops/__init__.py
+++ b/src/tilegym/ops/__init__.py
@@ -1,31 +1,28 @@
-"""TileGym ops module - contains all operation interfaces and backend implementations"""
-
-from tilegym.backend import is_backend_available
-
-# Backend implementations
-# Import interface modules
-from . import activation
-from . import attn_interface
-
-# Make cutile optional - only import if backend is fully available
-if is_backend_available("cutile"):
-    try:
-        from . import cutile
-    except (ImportError, RuntimeError):
-        import warnings
-
-        warnings.warn("Cutile backend import failed, cutile operations will not be available")
-        cutile = None  # type: ignore
-else:
-    cutile = None  # type: ignore
-
-from . import moe_interface
-
-# Make triton optional - only import if the library is available
-try:
-    from . import triton
-except (ImportError, RuntimeError):
-    import warnings
-
-    warnings.warn("Triton backend import failed, triton operations will not be available")
-    triton = None  # type: ignore
+"""TileGym ops module - contains all operation interfaces and backend implementations"""
+
+import warnings
+from tilegym.backend import is_backend_available
+
+# Backend implementations
+# Import interface modules
+from . import activation
+from . import attn_interface
+
+# Make cutile optional - only import if backend is fully available
+if is_backend_available("cutile"):
+    try:
+        from . import cutile
+    except (ImportError, RuntimeError):
+        warnings.warn("Cutile backend import failed, cutile operations will not be available")
+        cutile = None  # type: ignore
+else:
+    cutile = None  # type: ignore
+
+from . import moe_interface
+
+# Make triton optional - only import if the library is available
+try:
+    from . import triton
+except (ImportError, RuntimeError):
+    warnings.warn("Triton backend import failed, triton operations will not be available")
+    triton = None  # type: ignore
```

## Tests
- `tests/test_ops_warnings_import.py`

```diff
--- /dev/null
+++ b/tests/test_ops_warnings_import.py
@@ -0,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+import ast
+import inspect
+from pathlib import Path
+
+import tilegym.ops
+
+
+def test_warnings_imported_once_at_module_level():
+    """Verify warnings is imported once at module level, not inside except handlers."""
+    source_path = Path(inspect.getfile(tilegym.ops))
+    tree = ast.parse(source_path.read_text())
+
+    def add_parents(node, parent=None):
+        node.parent = parent
+        for child in ast.iter_child_nodes(node):
+            add_parents(child, node)
+
+    add_parents(tree)
+
+    warnings_imports = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        and any(alias.name == "warnings" for alias in node.names)
+    ]
+
+    assert len(warnings_imports) == 1
+    assert isinstance(warnings_imports[0].parent, ast.Module)
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).