### PR TITLE
test(tilecpp): skip the two tilecpp cases ToT nvcc cannot build correctly & other updates

### DIFF
--- a/src/tilegym/ops/cutile/layer_norm_legacy.py
+++ b/src/tilegym/ops/cutile/layer_norm_legacy.py
@@ -25,10 +25,15 @@ def _persistent_layer_norm_autotune_configs():
 
     Generates configurations:
     - BLOCK_N: [1, 2, 4, 8, 16, 32] - number of rows per block
+    - num_worker_warps: [4, 8] - CUDA-core warp-group width (Triton ``num_warps``
+      equivalent). Normalization-style kernels with large tiles are the
+      canonical case for tuning this hint, and nww=8 (256 threads) is a large
+      win on the bandwidth-bound small-D shapes.
     - num_ctas: [1] - single CTA for this kernel
     """
     for block_n in [1, 2, 4, 8, 16, 32]:
-        yield SimpleNamespace(BLOCK_N=block_n, num_ctas=1)
+        for num_worker_warps in [4, 8]:
+            yield SimpleNamespace(BLOCK_N=block_n, num_ctas=1, num_worker_warps=num_worker_warps)
 
 
 def _get_default_persistent_layer_norm_configs(BLOCK_D=None):
@@ -44,8 +49,8 @@ def _get_default_persistent_layer_norm_configs(BLOCK_D=None):
             block_n = min(8, p)
         else:
             block_n = 8
-        return {"BLOCK_N": block_n, "num_ctas": 1}
-    return {"BLOCK_N": 8, "num_ctas": 1}
+        return {"BLOCK_N": block_n, "num_ctas": 1, "num_worker_warps": 8}
+    return {"BLOCK_N": 8, "num_ctas": 1, "num_worker_warps": 8}
 
 
 def _persistent_layer_norm_early_config_prune(configs, N, D, BLOCK_D):
@@ -321,12 +326,14 @@ def _persistent_layer_norm_autotune_base(
                 grid_fn,
                 _persistent_layer_norm_fwd_kernel,
                 args_fn,
-                lambda cfg: {"num_ctas": cfg.num_ctas},
+                lambda cfg: {"num_ctas": cfg.num_ctas, "num_worker_warps": cfg.num_worker_warps},
             )
         best_cfg = result.best.config
         _layer_norm_legacy_tune_cache[cache_key] = (
             best_cfg,
-            _persistent_layer_norm_fwd_kernel.replace_hints(num_ctas=best_cfg.num_ctas),
+            _persistent_layer_norm_fwd_kernel.replace_hints(
+                num_ctas=best_cfg.num_ctas, num_worker_warps=best_cfg.num_worker_warps
+            ),
         )
     best_cfg, tuned_kernel = _layer_norm_legacy_tune_cache[cache_key]
     ct.launch(stream, grid_fn(best_cfg), tuned_kernel, args_fn(best_cfg))
@@ -404,10 +411,13 @@ def _cutile_persistent_layer_norm_fwd(
         grid_size = min(NUM_SMS, num_row_blocks)
         grid = (grid_size, 1, 1)
 
+        default_kernel = _persistent_layer_norm_fwd_kernel.replace_hints(
+            num_ctas=configs["num_ctas"], num_worker_warps=configs["num_worker_warps"]
+        )
         ct.launch(
             torch.cuda.current_stream(),
             grid,
-            _persistent_layer_norm_fwd_kernel,
+            default_kernel,
             (
                 x,
                 y,

--- a/src/tilegym/ops/tilecpp/bmm.py
+++ b/src/tilegym/ops/tilecpp/bmm.py
@@ -21,7 +21,6 @@ from tilegym.backend import register_impl
 from tilegym.ops.tilecpp.autotuner import Config
 from tilegym.ops.tilecpp.autotuner import TileCppAutotuner
 from tilegym.ops.tilecpp.autotuner import autotune
-from tilegym.ops.tilecpp.autotuner import is_autotuning_enabled
 from tilegym.ops.tilecpp.utils._cuda_utils import TileCppKernel
 from tilegym.ops.tilecpp.utils._cuda_utils import get_cpp_type
 from tilegym.ops.tilecpp.utils._cuda_utils import make_kernel_args
@@ -482,23 +481,14 @@ def bmm_static_persistent(a, b, transpose_a=False, transpose_b=False, **kwargs):
     """
     Static persistent batch matrix multiplication.
 
-    Uses static persistent scheduling with GPU-specific default configurations:
-    - B200 (sm_120/121): TILE_M=128, TILE_N=128, TILE_K=64, occupancy=2, num_ctas=1
-    - H100 (sm_90): TILE_M=128, TILE_N=128, TILE_K=64, occupancy=1, num_ctas=1
-    - GB100 (sm_100): TILE_M=256, TILE_N=256, TILE_K=64, occupancy=1, num_ctas=2
+    The tile configuration is always chosen by the autotuner, whose search space
+    is GPU-dependent.
 
     Args:
         a: Input tensor A with shape (Q, M, K) or (Q, K, M) if transposed
         b: Input tensor B with shape (Q, K, N) or (Q, N, K) if transposed
         transpose_a: Whether to transpose A
         transpose_b: Whether to transpose B
-        **kwargs: Optional kernel configuration parameters:
-            - TILE_M: M-dimension tile size (default: GPU-dependent)
-            - TILE_N: N-dimension tile size (default: GPU-dependent)
-            - TILE_K: K-dimension tile size (default: 64)
-            - GROUP_SIZE_M: Number of M-tiles to group (default: 8)
-            - occupancy: Occupancy multiplier (default: GPU-dependent)
-            - num_ctas: Number of CTAs per kernel (default: GPU-dependent)
 
     Returns:
         Output tensor C with shape (Q, M, N)
@@ -523,63 +513,7 @@ def bmm_static_persistent(a, b, transpose_a=False, transpose_b=False, **kwargs):
 
     c = torch.empty((Q, M, N), device=a.device, dtype=a.dtype)
 
-    if is_autotuning_enabled():
-        return _autotune_bmm_static_persistent(a, b, c, Q, M, N, K, transpose_a, transpose_b)
-
-    capability = torch.cuda.get_device_capability()
-    if capability in [(12, 0), (12, 1)]:
-        # B200: Smaller tiles, num_ctas=1, higher occupancy
-        default_config = {
-            "TILE_M": 128,
-            "TILE_N": 128,
-            "TILE_K": 64,
-            "GROUP_SIZE_M": 8,
-            "num_ctas": 1,
-            "occupancy": 2,
-        }
-    elif capability == (9, 0):
-        # H100: Medium tiles
-        default_config = {
-            "TILE_M": 128,
-            "TILE_N": 128,
-            "TILE_K": 64,
-            "GROUP_SIZE_M": 8,
-            "num_ctas": 1,
-            "occupancy": 1,
-        }
-    else:
-        # Other GPUs (e.g., GB100): Larger tiles, num_ctas=2
-        default_config = {
-            "TILE_M": 256,
-            "TILE_N": 256,
-            "TILE_K": 64,
-            "GROUP_SIZE_M": 8,
-            "num_ctas": 2,
-            "occupancy": 1,
-        }
-
-    # Override defaults with any user-provided configs
-    config = {**default_config, **kwargs}
-
-    _launch_bmm_static_persistent_kernel(
-        a,
-        b,
-        c,
-        Q,
-        M,
-        N,
-        K,
-        transpose_a,
-        transpose_b,
-        block_m=config["TILE_M"],
-        block_n=config["TILE_N"],
-        block_k=config["TILE_K"],
-        group_m=config["GROUP_SIZE_M"],
-        occupancy=config["occupancy"],
-        num_ctas=config["num_ctas"],
-    )
-
-    return c
+    return _autotune_bmm_static_persistent(a, b, c, Q, M, N, K, transpose_a, transpose_b)
 
 
 # Register the implementation

--- a/src/tilegym/ops/tilecpp/dropout.cuh
+++ b/src/tilegym/ops/tilecpp/dropout.cuh
@@ -19,20 +19,21 @@
  * Template Parameters:
  *   T: Element type (float, __half, __nv_bfloat16)
  *   BLOCK_SIZE: Number of elements processed per block (must be power of 2)
- *   NUM_BLOCKS: Total number of blocks (N_ELEMENTS / BLOCK_SIZE)
  *
  * Parameters:
  *   x_ptr: Pointer to input tensor
  *   output_ptr: Pointer to output tensor
  *   p: Dropout probability (0.0 to 1.0)
  *   seed: Random seed for deterministic dropout mask
+ *   n_elements: Number of elements in the tensor
  */
-template<typename T, int BLOCK_SIZE, int NUM_BLOCKS>
+template<typename T, int BLOCK_SIZE>
 __tile_global__ void seeded_dropout_kernel(
     const T* __restrict__ x_ptr,
     T* __restrict__ output_ptr,
     float p,
-    uint64_t seed
+    uint64_t seed,
+    int n_elements
 ) {
     namespace ct = cuda::tiles;
 
@@ -43,10 +44,12 @@ __tile_global__ void seeded_dropout_kernel(
     using TxN = ct::tile<T, ct::shape<BLOCK_SIZE>>;
     using f32xN = ct::tile<float, ct::shape<BLOCK_SIZE>>;
     using i32xN = ct::tile<int, ct::shape<BLOCK_SIZE>>;
+    using u32xN = ct::tile<uint32_t, ct::shape<BLOCK_SIZE>>;
 
     int bid = ct::bid().x;
 
-    float scale = 1.0f / (1.0f - p);
+    // p == 1 drops everything; 1/(1-p) would be inf and poison the kept lanes.
+    float scale = (p >= 1.0f) ? 0.0f : 1.0f / (1.0f - p);
     // Python passes seed already mixed into a 32-bit space via _mix_seed; keep
     // the full 32 bits here. A modulo by a Mersenne prime would alias distinct
     // 32-bit seeds and shrink the effective seed space.
@@ -55,21 +58,24 @@ __tile_global__ void seeded_dropout_kernel(
     int tile_start = bid * BLOCK_SIZE;
     auto offsets = ct::iota<i32xN>() + tile_start;
 
-    auto x_ptrs = x_ptr + offsets;
-    auto x_raw = ct::load(x_ptrs);
+    auto mask = offsets < ct::full<i32xN>(n_elements);
+
+    TxN x_raw = ct::load_masked(x_ptr + offsets, mask, T(0));
     auto x = ct::element_cast<float>(x_raw);
 
-    // combined = offsets * 1103515245 + seed
-    auto combined = offsets * 1103515245 + ct::full<i32xN>(seed_i32);
+    // combined = offsets * 1103515245 + seed, computed in uint32 so the
+    // multiply wraps; signed overflow would be undefined behaviour.
+    auto combined = ct::element_cast<uint32_t>(offsets) * 1103515245u
+                  + ct::full<u32xN>(static_cast<uint32_t>(seed_i32));
 
     auto hash_val = combined ^ (combined >> 16);
     hash_val = hash_val ^ (hash_val << 8);
     hash_val = hash_val ^ (hash_val >> 4);
 
     // Convert to float in [0, 1): clear sign bit, cast, normalize
-    auto hash_positive = hash_val & 0x7FFFFFFF;
+    auto hash_positive = hash_val & 0x7FFFFFFFu;
     auto hash_float = ct::element_cast<float>(hash_positive);
-    auto random = hash_float * (1.0f / 2147483647.0f);
+    auto random = hash_float / 2147483647.0f;
 
     // x_keep = random > p
     auto x_keep = random > p;
@@ -79,6 +85,5 @@ __tile_global__ void seeded_dropout_kernel(
 
     // Convert back to T and store using pointer + scatter pattern
     auto output = ct::element_cast<T>(output_f32);
-    auto out_ptrs = output_ptr + offsets;
-    ct::store(out_ptrs, output);
+    ct::store_masked(output_ptr + offsets, output, mask);
 }

--- a/src/tilegym/ops/tilecpp/dropout.py
+++ b/src/tilegym/ops/tilecpp/dropout.py
@@ -49,19 +49,12 @@ def _launch_dropout_kernel(
     dump_kernel_types("seeded_dropout_kernel", x, output)
     dtype = x.dtype
 
-    if n_elements % block_size != 0:
-        raise ValueError(
-            f"dropout requires n_elements ({n_elements}) to be a multiple of block_size ({block_size}); "
-            f"the kernel does unmasked tile loads/stores of BLOCK_SIZE elements per block."
-        )
-
     num_blocks = (n_elements + block_size - 1) // block_size
 
-    # Template params: BLOCK_SIZE, NUM_BLOCKS
     kernel, _, _ = _seeded_dropout_kernel.get_kernel(
         dtype=dtype,
-        template_params=[block_size, num_blocks],
-        signature="const {T}*, {T}*, float, uint64_t",
+        template_params=[block_size],
+        signature="const {T}*, {T}*, float, uint64_t, int",
     )
 
     _seeded_dropout_kernel.launch(
@@ -72,6 +65,7 @@ def _launch_dropout_kernel(
             np.uint64(output.data_ptr()),
             np.float32(p),
             np.uint64(_mix_seed(seed)),
+            np.int32(n_elements),
         ],
     )
 

--- a/src/tilegym/ops/tilecpp/recurrent_gated_delta_rule.cuh
+++ b/src/tilegym/ops/tilecpp/recurrent_gated_delta_rule.cuh
@@ -65,6 +65,10 @@ __tile_global__ void recurrent_gated_delta_rule_fwd_kernel(
     using f32_K   = ct::tile<float, ct::shape<BLOCK_K>>;
     using f32_V   = ct::tile<float, ct::shape<BLOCK_V>>;
 
+    // BLOCK_K/BLOCK_V are rounded up to powers of two, so the trailing tile of
+    // a ragged head dim is partial: pad reads with zero and clip writes.
+    constexpr auto zero_pad = ct::view_padding::zero;
+
     Q          = ct::assume_aligned<16>(Q);
     K          = ct::assume_aligned<16>(K);
     V          = ct::assume_aligned<16>(V);
@@ -105,16 +109,16 @@ __tile_global__ void recurrent_gated_delta_rule_fwd_kernel(
         auto pInit = ct::partition_view(
             ct::tensor_span{InitState, ct::extents{B, NUM_HEADS, K_HEAD_DIM, V_HEAD_DIM}},
             ct::shape<1, 1, BLOCK_K, BLOCK_V>{});
-        auto init_loaded = pInit.load(b, h, 0, pid_v);
+        auto init_loaded = pInit.template load_masked<zero_pad>(b, h, 0, pid_v);
         state = ct::reshape<ct::shape<BLOCK_K, BLOCK_V>>(init_loaded);
     }
 
     for (auto t : ct::irange(0, SEQ_LEN)) {
         // Load q_t, k_t as BLOCK_K tiles.
-        auto q_t_loaded = pQ.load(b, t, h, 0);
+        auto q_t_loaded = pQ.template load_masked<zero_pad>(b, t, h, 0);
         auto q_t = ct::element_cast<float>(ct::reshape<ct::shape<BLOCK_K>>(q_t_loaded));
 
-        auto k_t_loaded = pK.load(b, t, h, 0);
+        auto k_t_loaded = pK.template load_masked<zero_pad>(b, t, h, 0);
         auto k_t = ct::element_cast<float>(ct::reshape<ct::shape<BLOCK_K>>(k_t_loaded));
 
         if constexpr (USE_QK_L2NORM) {
@@ -131,7 +135,7 @@ __tile_global__ void recurrent_gated_delta_rule_fwd_kernel(
         q_t = q_t * scale;
 
         // Load v_t as BLOCK_V tile.
-        auto v_t_loaded = pV.load(b, t, h, pid_v);
+        auto v_t_loaded = pV.template load_masked<zero_pad>(b, t, h, pid_v);
         auto v_t = ct::element_cast<float>(ct::reshape<ct::shape<BLOCK_V>>(v_t_loaded));
 
         auto g_t_tile    = ct::element_cast<float>(pG.load(b, t, h));
@@ -164,7 +168,7 @@ __tile_global__ void recurrent_gated_delta_rule_fwd_kernel(
         // Store output (cast back to T).
         auto out_tile = ct::reshape<ct::shape<1, 1, 1, BLOCK_V>>(
             ct::element_cast<T>(out_t));
-        pO.store(out_tile, b, t, h, pid_v);
+        pO.store_masked(out_tile, b, t, h, pid_v);
     }
 
     // ---- Final state ----
@@ -173,6 +177,6 @@ __tile_global__ void recurrent_gated_delta_rule_fwd_kernel(
             ct::tensor_span{FinalState, ct::extents{B, NUM_HEADS, K_HEAD_DIM, V_HEAD_DIM}},
             ct::shape<1, 1, BLOCK_K, BLOCK_V>{});
         auto state_tile = ct::reshape<ct::shape<1, 1, BLOCK_K, BLOCK_V>>(state);
-        pFinal.store(state_tile, b, h, 0, pid_v);
+        pFinal.store_masked(state_tile, b, h, 0, pid_v);
     }
 }

--- a/src/tilegym/ops/tilecpp/recurrent_gated_delta_rule.py
+++ b/src/tilegym/ops/tilecpp/recurrent_gated_delta_rule.py
@@ -60,16 +60,6 @@ def _launch_fwd(
 
     BLOCK_K = _next_power_of_2(K_HEAD_DIM)
     BLOCK_V = min(64, _next_power_of_2(V_HEAD_DIM))
-    if BLOCK_K != K_HEAD_DIM:
-        raise NotImplementedError(
-            f"tilecpp recurrent_gated_delta_rule requires K head dim to be a power of two "
-            f"(got K={K_HEAD_DIM}); the kernel does unmasked tile loads of size BLOCK_K=next_pow2(K)."
-        )
-    if V_HEAD_DIM % BLOCK_V != 0:
-        raise NotImplementedError(
-            f"tilecpp recurrent_gated_delta_rule requires V head dim ({V_HEAD_DIM}) to be a multiple "
-            f"of BLOCK_V={BLOCK_V}; the kernel does unmasked tile loads of BLOCK_V-wide V tiles."
-        )
 
     # Template params: BLOCK_K, BLOCK_V, HAS_INITIAL_STATE, OUTPUT_FINAL_STATE, USE_QK_L2NORM
     bool_to_str = lambda b: "true" if b else "false"

--- a/src/tilegym/ops/tilecpp/rms_norm.cuh
+++ b/src/tilegym/ops/tilecpp/rms_norm.cuh
@@ -17,7 +17,7 @@
 /**
  * RMSNorm kernel - optimized version.
  *
- * Computes: y = x * rsqrt(mean(x^2) + eps) * weight
+ * Computes: y = x * rsqrt(mean(x^2) + eps) * (offset + weight)
  *
  * Optimizations:
  * - __restrict__ pointers for alias optimization
@@ -36,7 +36,7 @@
  *   N: Number of columns (hidden size)
  *   eps: Small epsilon for numerical stability
  */
-template<typename T, typename WT, int BLOCK_SIZE, int N, float EPS>
+template<typename T, typename WT, int BLOCK_SIZE, int N, float EPS, float OFFSET>
 __tile_global__ void rms_norm_kernel(
     const T* __restrict__ X,
     const WT* __restrict__ W,
@@ -110,7 +110,7 @@ __tile_global__ void rms_norm_kernel(
         }
         auto wj = ct::element_cast<float>(wj_raw);
         auto xj = ct::element_cast<float>(xj_raw);
-        auto yj_f32 = xj * rms * wj;
+        auto yj_f32 = xj * rms * (OFFSET + wj);
         auto yj = ct::element_cast<T>(yj_f32);
         if constexpr (EVEN_N) {
             [[ using cutile : hint(1000, latency=1) ]]
@@ -121,6 +121,77 @@ __tile_global__ void rms_norm_kernel(
             ct::store_masked(Y_row + cols, yj, mask);
         }
     }
+}
+
+
+/**
+ * RMSNorm multi-wave cached kernel.
+ *
+ * Computes: y = x * rsqrt(mean(x^2) + eps) * (offset + weight)
+ *
+ * One block per row and TILE_SIZE >= N, so the whole row is a single tile: it
+ * is loaded once and held in registers across the reduction and the normalize
+ * step, instead of being reloaded the way `rms_norm_kernel` does.
+ *
+ * Grid: (M, 1, 1)
+ *
+ * Template Parameters:
+ *   T: Element type (float, __half, __nv_bfloat16)
+ *   WT: Weight element type
+ *   TILE_SIZE: Row tile size; power of two >= N, so one tile spans the row
+ *   N: Number of columns (hidden size)
+ *   EPS: Small epsilon for numerical stability
+ *
+ * Parameters:
+ *   X: Pointer to input tensor (M, N)
+ *   W: Pointer to weight tensor (N,)
+ *   Y: Pointer to output tensor (M, N)
+ *   rstd_ptr: Pointer to store 1/std per row (M,)
+ *   stride: Row stride (typically N)
+ */
+template<typename T, typename WT, int TILE_SIZE, int N, float EPS, float OFFSET>
+__tile_global__ void rms_norm_multi_wave_cached_kernel(
+    const T* __restrict__ X,
+    const WT* __restrict__ W,
+    T* __restrict__ Y,
+    float* __restrict__ rstd_ptr,
+    int stride
+) {
+    namespace ct = cuda::tiles;
+
+    using TxTS = ct::tile<T, ct::shape<TILE_SIZE>>;
+    using WxTS = ct::tile<WT, ct::shape<TILE_SIZE>>;
+    using i32xTS = ct::tile<int, ct::shape<TILE_SIZE>>;
+
+    // Each program handles one row
+    int row = ct::bid().x;
+
+    auto X_row = X + row * stride;
+    auto Y_row = Y + row * stride;
+    auto W_aligned = ct::assume_aligned<16>(W);
+    auto rstd_aligned = ct::assume_aligned<16>(rstd_ptr);
+
+    auto cols = ct::iota<i32xTS>();
+    auto mask = cols < N;
+
+    // Cache the row in registers: loaded once, reused after the reduction.
+    [[ using cutile : hint(1000, latency=1) ]]
+    auto xj_raw = ct::load_masked(X_row + cols, mask, ct::zeros<TxTS>());
+    auto xj = ct::element_cast<float>(xj_raw);
+
+    float sum_sq = static_cast<float>(ct::sum<0>(xj * xj));
+    float rms = ct::rsqrt(sum_sq / static_cast<float>(N) + EPS);
+
+    rstd_aligned[row] = rms;
+
+    [[ using cutile : hint(1000, latency=1) ]]
+    auto wj_raw = ct::load_masked(W_aligned + cols, mask, ct::zeros<WxTS>());
+    auto wj = ct::element_cast<float>(wj_raw);
+
+    auto yj = ct::element_cast<T>(xj * rms * (OFFSET + wj));
+
+    [[ using cutile : hint(1000, latency=1) ]]
+    ct::store_masked(Y_row + cols, yj, mask);
 }
 
 
@@ -232,7 +303,11 @@ __tile_global__ void rms_norm_static_persistent_kernel(
     using TileMxN = ct::tile<T,     ct::shape<TILE_SIZE_M, TILE_SIZE_N>>;
     using f32_Mx1 = ct::tile<float, ct::shape<TILE_SIZE_M, 1>>;
     using f32_M   = ct::tile<float, ct::shape<TILE_SIZE_M>>;
+    using WxN     = ct::tile<WT,    ct::shape<TILE_SIZE_N>>;
 
+    // TILE_SIZE_N is next_power_of_2(N), so the tile overhangs the row whenever
+    // N is not a power of two. Masked accesses pad with zero, so the overhanging
+    // lanes add nothing to sum(x^2) and are not written past the end of the row.
     X = ct::assume_aligned<16>(X);
     Y = ct::assume_aligned<16>(Y);
     W = ct::assume_aligned<16>(W);
@@ -255,16 +330,16 @@ __tile_global__ void rms_norm_static_persistent_kernel(
                                     ct::shape<TILE_SIZE_M>{});
 
     // Load W once, apply offset in fp32 (y = x_hat * (offset + w)).
-    auto w       = ct::element_cast<float>(pW.load(0));            // (TILE_N,)
+    auto w_raw   = pW.load_masked(0);
+    auto w       = ct::element_cast<float>(w_raw);                 // (TILE_N,)
     auto w_with  = w + ct::full<ct::tile<float, ct::shape<TILE_SIZE_N>>>(OFFSET);
     auto w_bcast = ct::reshape<ct::shape<1, TILE_SIZE_N>>(w_with);
 
     constexpr float inv_N = 1.0f / static_cast<float>(N);
 
     for (auto current_bid : ct::irange(pid, upper_bound, NUM_SMS)) {
-        TileMxN x_tile;
         [[ using cutile : hint(1000, latency=10) ]]
-        x_tile = pX.load(current_bid, 0);
+        auto x_tile = pX.load_masked(current_bid, 0);
         auto x = ct::element_cast<float>(x_tile);
 
         // Row-wise sum(x^2) -> (TILE_M, 1) -> divide by N -> +eps -> rsqrt
@@ -281,7 +356,7 @@ __tile_global__ void rms_norm_static_persistent_kernel(
         auto y_T    = ct::element_cast<T>(y_f32);
 
         [[ using cutile : hint(1000, allow_tma=false, latency=3) ]]
-        pY.store(y_T, current_bid, 0);
+        pY.store_masked(y_T, current_bid, 0);
     }
 }
 

--- a/src/tilegym/ops/tilecpp/rms_norm.py
+++ b/src/tilegym/ops/tilecpp/rms_norm.py
@@ -28,6 +28,11 @@ _rms_norm_kernel = TileCppKernel(
     kernel_name="rms_norm_kernel",
 )
 
+_rms_norm_multi_wave_cached_kernel = TileCppKernel(
+    source_path=Path(__file__).parent / "rms_norm.cuh",
+    kernel_name="rms_norm_multi_wave_cached_kernel",
+)
+
 _rms_norm_kernel_pv = TileCppKernel(
     source_path=Path(__file__).parent / "rms_norm.cuh",
     kernel_name="rms_norm_kernel_pv",
@@ -84,6 +89,7 @@ def _launch_rms_norm_kernel(
     stride: int,
     N: int,
     eps: float,
+    offset: float,
     M: int,
     block_size: int,
 ):
@@ -92,11 +98,12 @@ def _launch_rms_norm_kernel(
     w_cpp_type = get_cpp_type(weight.dtype)
 
     eps_tp = f"{eps}f"
+    offset_tp = f"{offset}f"
 
     # Signature: const T*, const WT*, T*, float*, int
     kernel, _, _ = _rms_norm_kernel.get_kernel(
         dtype=dtype,
-        template_params=[w_cpp_type, block_size, N, eps_tp],
+        template_params=[w_cpp_type, block_size, N, eps_tp, offset_tp],
         signature=f"const {{T}}*, const {w_cpp_type}*, {{T}}*, float*, int",
     )
 
@@ -104,6 +111,49 @@ def _launch_rms_norm_kernel(
 
     _rms_norm_kernel.launch(
         grid=grid,
+        kernel=kernel,
+        args=[
+            np.uint64(x.data_ptr()),
+            np.uint64(weight.data_ptr()),
+            np.uint64(y.data_ptr()),
+            np.uint64(rstd.data_ptr()),
+            np.int32(stride),
+        ],
+    )
+
+
+def _launch_rms_norm_multi_wave_cached_kernel(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    y: torch.Tensor,
+    rstd: torch.Tensor,
+    stride: int,
+    N: int,
+    eps: float,
+    offset: float,
+    M: int,
+    tile_size: int,
+):
+    """
+    Template params: T, WT, TILE_SIZE, N, EPS, OFFSET.
+    Runtime args  : X, W, Y, Rstd, stride.
+    Grid          : M (one block per row; the row is a single cached tile).
+    """
+    dump_kernel_types("rms_norm_multi_wave_cached_kernel", x, weight, y, rstd)
+    dtype = x.dtype
+    w_cpp_type = get_cpp_type(weight.dtype)
+
+    eps_tp = f"{eps}f"
+    offset_tp = f"{offset}f"
+
+    kernel, _, _ = _rms_norm_multi_wave_cached_kernel.get_kernel(
+        dtype=dtype,
+        template_params=[w_cpp_type, tile_size, N, eps_tp, offset_tp],
+        signature=f"const {{T}}*, const {w_cpp_type}*, {{T}}*, float*, int",
+    )
+
+    _rms_norm_multi_wave_cached_kernel.launch(
+        grid=M,
         kernel=kernel,
         args=[
             np.uint64(x.data_ptr()),
@@ -323,6 +373,7 @@ class RMSNorm(torch.autograd.Function):
         eps,
         bias=None,
         mode=None,
+        offset=0.0,
     ):
         """
         CUDA Tile C++ RMSNorm forward pass.
@@ -333,9 +384,9 @@ class RMSNorm(torch.autograd.Function):
             weight: Weight tensor of shape [N]
             eps: Epsilon value for numerical stability
             bias: Bias tensor of shape [N], default is None (not supported)
-            mode: Kernel selection mode (None, "static_persistent", "multi_wave_reload").
-                  ``multi_wave_cached`` is not implemented in the tilecpp backend
-                  and raises NotImplementedError.
+            mode: Kernel selection mode (None, "static_persistent", "multi_wave_reload",
+                  "multi_wave_cached")
+            offset: Offset to add to weight (default 0.0 for Llama, 1.0 for Gemma3)
 
         Returns:
             Normalized and transformed tensor of same shape as input
@@ -380,7 +431,7 @@ class RMSNorm(torch.autograd.Function):
                 M,
                 N,
                 eps,
-                0.0,  # offset: 0.0 for standard RMSNorm
+                offset,
                 TILE_SIZE_M,
                 TILE_SIZE_N,
             )
@@ -402,6 +453,7 @@ class RMSNorm(torch.autograd.Function):
                 x_arg.stride(0),
                 N,
                 eps,
+                offset,
                 M,
                 block_size,
             )
@@ -410,12 +462,34 @@ class RMSNorm(torch.autograd.Function):
             ctx.eps = eps
             ctx.block_size = block_size
         elif mode == "multi_wave_cached":
-            raise NotImplementedError("multi_wave_cached mode is not implemented for the tilecpp backend")
+            # TILE_SIZE >= N, so the row is one tile the kernel keeps in registers.
+            TILE_SIZE = _next_power_of_2(N)
+
+            rstd = torch.empty((M,), dtype=torch.float32, device="cuda")
+
+            _launch_rms_norm_multi_wave_cached_kernel(
+                x_arg,
+                weight,
+                y.reshape(-1, y.shape[-1]),
+                rstd,
+                x_arg.stride(0),
+                N,
+                eps,
+                offset,
+                M,
+                TILE_SIZE,
+            )
+
+            ctx.save_for_backward(x, weight, rstd)
+            ctx.eps = eps
+            ctx.block_size = TILE_SIZE
         else:
             raise ValueError(
                 f"Unknown mode '{mode}'. Supported modes: None, 'static_persistent', "
                 f"'multi_wave_reload', 'multi_wave_cached'"
             )
+
+        ctx.offset = offset
 
         return y
 
@@ -425,17 +499,22 @@ class RMSNorm(torch.autograd.Function):
         Backward pass for CUDA Tile C++ RMSNorm.
         Retrieves saved tensors and delegates to rms_norm_backward().
         """
+        if ctx.offset != 0.0:
+            raise NotImplementedError(
+                f"Backward pass not implemented for TileCpp RMSNorm with non-zero offset ({ctx.offset})"
+            )
+
         x, weight, rstd = ctx.saved_tensors
 
         # Call the standalone backward function
         dx, dw = rms_norm_backward(x, dy, weight, rstd)
 
-        # Return gradients: (x, normalized_shape, weight, eps, bias, mode)
-        return dx, None, dw, None, None, None
+        # Return gradients: (x, normalized_shape, weight, eps, bias, mode, offset)
+        return dx, None, dw, None, None, None, None
 
 
 @register_impl("rms_norm", backend="tilecpp")
-def rms_norm(input, normalized_shape, weight, eps, bias=None, mode=None, **kwargs):
+def rms_norm(input, normalized_shape, weight, eps, bias=None, mode=None, offset=0.0, **kwargs):
     """
     Root mean square normalization implemented using CUDA Tile C++
 
@@ -445,15 +524,15 @@ def rms_norm(input, normalized_shape, weight, eps, bias=None, mode=None, **kwarg
         weight: Tensor of shape (N,)
         eps: Small constant added to variance calculation prior to division
         bias: Bias tensor of shape (N,), default is None (not supported)
-        mode: Kernel selection mode (None, "static_persistent", "multi_wave_reload").
-              ``multi_wave_cached`` is not implemented in the tilecpp backend
-              and raises NotImplementedError.
+        mode: Kernel selection mode (None, "static_persistent", "multi_wave_reload",
+              "multi_wave_cached")
+        offset: Offset to add to weight (default 0.0 for Llama, 1.0 for Gemma3)
         **kwargs: Additional arguments for backend-specific configurations
 
     Returns:
         Normalized tensor with same shape as input
     """
-    return RMSNorm.apply(input, normalized_shape, weight, eps, bias, mode)
+    return RMSNorm.apply(input, normalized_shape, weight, eps, bias, mode, offset)
 
 
 class TileCppRMSNorm(nn.Module):

--- a/src/tilegym/ops/tilecpp/silu_and_mul.cuh
+++ b/src/tilegym/ops/tilecpp/silu_and_mul.cuh
@@ -78,11 +78,78 @@ __tile_global__ void silu_and_mul_kernel(
 
 
 /**
+ * Backward pass for the fused SiLU and multiplication kernel.
+ *
+ *   db = dc * silu(a)
+ *   da = dc * b * (sigmoid(a) + silu(a) * (1 - sigmoid(a)))
+ *
+ * Template Parameters:
+ *   T: Element type (float, __half, __nv_bfloat16)
+ *   BLOCK_SIZE: Tile size (power of 2, >= hidden_size)
+ *
+ * Parameters:
+ *   grad_output: Upstream gradient (M, hidden_size)
+ *   input:       Original forward input (M, 2 * hidden_size)
+ *   grad_input:  OUT gradient w.r.t. input (M, 2 * hidden_size)
+ *   stride:      Input row stride (2 * hidden_size for row-major)
+ *   hidden_size: Size of each half
+ */
+template<typename T, int BLOCK_SIZE>
+__tile_global__ void silu_and_mul_backward_kernel(
+    const T* __restrict__ grad_output,
+    const T* __restrict__ input,
+    T* __restrict__ grad_input,
+    int stride,
+    int hidden_size
+) {
+    namespace ct = cuda::tiles;
+
+    using TxN = ct::tile<T, ct::shape<BLOCK_SIZE>>;
+    using i64xN = ct::tile<int64_t, ct::shape<BLOCK_SIZE>>;
+
+    int64_t pid = ct::bid().x;
+
+    auto grad_output_aligned = ct::assume_aligned<16>(grad_output);
+    auto input_aligned = ct::assume_aligned<16>(input);
+    auto grad_input_aligned = ct::assume_aligned<16>(grad_input);
+
+    auto input_row = input_aligned + pid * stride;
+    auto grad_input_row = grad_input_aligned + pid * stride;
+    auto grad_output_row = grad_output_aligned + pid * (stride / 2);
+
+    auto col_offsets = ct::iota<i64xN>();
+    auto mask = col_offsets < static_cast<int64_t>(hidden_size);
+    auto zero_pad = ct::full<TxN>(static_cast<T>(0));
+
+    auto dc_T = ct::load_masked(grad_output_row + col_offsets, mask, zero_pad);
+    auto dc = ct::element_cast<float>(dc_T);
+
+    auto a_T = ct::load_masked(input_row + col_offsets, mask, zero_pad);
+    auto a = ct::element_cast<float>(a_T);
+
+    auto b_T = ct::load_masked(input_row + hidden_size + col_offsets, mask, zero_pad);
+    auto b = ct::element_cast<float>(b_T);
+
+    auto denom = ct::add(1.0f, ct::exp(-a), ct::round_ties_to_even_t{}, ct::round_subnormals_to_zero_t{});
+    auto sigmoid_a = ct::div(1.0f, denom, ct::round_approximate_t{}, ct::round_subnormals_to_zero_t{});
+    auto silu_a = a * sigmoid_a;
+
+    auto db = dc * silu_a;
+    auto silu_grad = sigmoid_a + silu_a * ct::sub(1.0f, sigmoid_a,
+                                                  ct::round_ties_to_even_t{},
+                                                  ct::round_subnormals_to_zero_t{});
+    auto da = dc * b * silu_grad;
+
+    ct::store_masked(grad_input_row + col_offsets, ct::element_cast<T>(da), mask);
+    ct::store_masked(grad_input_row + hidden_size + col_offsets, ct::element_cast<T>(db), mask);
+}
+
+
+/**
  * Row-wise SiLU and multiplication kernel using tensor_span.
  *
  * Template Parameters:
  *   T: Element type (float, __half, __nv_bfloat16)
- *   M: Number of rows (batch_size)
  *   N: Number of columns (2 * hidden_size)
  *   HIDDEN_SIZE: Hidden size (N / 2) - compile-time constant
  *   TILE_SIZE: Tile size (power of 2, >= HIDDEN_SIZE)
@@ -91,7 +158,7 @@ __tile_global__ void silu_and_mul_kernel(
  *   input: Pointer to input data (M, N) where N = 2 * HIDDEN_SIZE
  *   output: Pointer to output data (M, HIDDEN_SIZE)
  */
-template<typename T, int M, int N, int HIDDEN_SIZE, int TILE_SIZE, int INPUT_STRIDE, int OUTPUT_STRIDE>
+template<typename T, int N, int HIDDEN_SIZE, int TILE_SIZE, int INPUT_STRIDE, int OUTPUT_STRIDE>
 __tile_global__ void silu_and_mul_kernel_row_wise(
     T* __restrict__ input,
     T* __restrict__ output

--- a/src/tilegym/ops/tilecpp/silu_and_mul.py
+++ b/src/tilegym/ops/tilecpp/silu_and_mul.py
@@ -38,6 +38,11 @@ _silu_and_mul_kernel_row_wise = TileCppKernel(
     kernel_name="silu_and_mul_kernel_row_wise",
 )
 
+_silu_and_mul_backward_kernel = TileCppKernel(
+    source_path=Path(__file__).parent / "silu_and_mul.cuh",
+    kernel_name="silu_and_mul_backward_kernel",
+)
+
 
 def ensure_contiguous(fn):
     @functools.wraps(fn)
@@ -123,15 +128,14 @@ def _launch_silu_and_mul_kernel_row_wise(
     dump_kernel_types("silu_and_mul_kernel_row_wise", input_tensor, output_tensor)
     dtype = input_tensor.dtype
 
-    # Template params: M, N, HIDDEN_SIZE, TILE_SIZE, INPUT_STRIDE, OUTPUT_STRIDE
-    M = n_rows
+    # Template params: N, HIDDEN_SIZE, TILE_SIZE, INPUT_STRIDE, OUTPUT_STRIDE
     N = input_tensor.shape[1]  # 2 * hidden_size
     INPUT_STRIDE = input_tensor.stride(0)
     OUTPUT_STRIDE = output_tensor.stride(0)
 
     kernel, _, _ = _silu_and_mul_kernel_row_wise.get_kernel(
         dtype=dtype,
-        template_params=[M, N, hidden_size, tile_size, INPUT_STRIDE, OUTPUT_STRIDE],
+        template_params=[N, hidden_size, tile_size, INPUT_STRIDE, OUTPUT_STRIDE],
         signature="{T}*, {T}*",
     )
 
@@ -149,6 +153,62 @@ def _launch_silu_and_mul_kernel_row_wise(
     )
 
 
+def _launch_silu_and_mul_backward_kernel(
+    grad_output: torch.Tensor,
+    input_tensor: torch.Tensor,
+    grad_input: torch.Tensor,
+    stride: int,
+    hidden_size: int,
+    n_rows: int,
+    block_size: int,
+):
+    """Launch the SiLU and Mul backward kernel."""
+    dump_kernel_types("silu_and_mul_backward_kernel", grad_output, input_tensor, grad_input)
+    dtype = input_tensor.dtype
+
+    kernel, _, _ = _silu_and_mul_backward_kernel.get_kernel(
+        dtype=dtype,
+        template_params=[block_size],
+        signature="const {T}*, const {T}*, {T}*, int, int",
+    )
+
+    _silu_and_mul_backward_kernel.launch(
+        grid=(n_rows,),
+        kernel=kernel,
+        args=[
+            np.uint64(grad_output.data_ptr()),
+            np.uint64(input_tensor.data_ptr()),
+            np.uint64(grad_input.data_ptr()),
+            np.int32(stride),
+            np.int32(hidden_size),
+        ],
+    )
+
+
+def _silu_and_mul_backward(grad_output: torch.Tensor, input: torch.Tensor) -> torch.Tensor:
+    """Gradient w.r.t. the concatenated input, shape (..., 2 * hidden_size)."""
+    original_shape = input.shape
+    hidden_size = original_shape[-1] // 2
+
+    input_flat = input.contiguous().view(-1, original_shape[-1])
+    grad_output_flat = grad_output.contiguous().view(-1, hidden_size)
+    n_rows = input_flat.shape[0]
+
+    grad_input = torch.empty_like(input_flat)
+
+    _launch_silu_and_mul_backward_kernel(
+        grad_output_flat,
+        input_flat,
+        grad_input,
+        stride=input_flat.stride(0),
+        hidden_size=hidden_size,
+        n_rows=n_rows,
+        block_size=calculate_settings(hidden_size),
+    )
+
+    return grad_input.view(*original_shape)
+
+
 # =============================================================================
 # Public Interface
 # =============================================================================
@@ -156,12 +216,14 @@ def _launch_silu_and_mul_kernel_row_wise(
 
 class _SiluAndMul(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, input, out=None, kernel_type="row_wise", **kwargs):
-        return _silu_and_mul_impl(input, out=out, kernel_type=kernel_type, **kwargs)
+    def forward(ctx, input, out=None, kernel_type="row_wise"):
+        ctx.save_for_backward(input)
+        return _silu_and_mul_impl(input, out=out, kernel_type=kernel_type)
 
     @staticmethod
-    def backward(ctx, *grad_outputs):
-        raise NotImplementedError("Backward pass for tilecpp silu_and_mul is not implemented.")
+    def backward(ctx, grad_output):
+        (input,) = ctx.saved_tensors
+        return _silu_and_mul_backward(grad_output, input), None, None
 
 
 @register_impl("silu_and_mul", backend="tilecpp")
@@ -182,12 +244,11 @@ def silu_and_mul(
 
     Returns:
         torch.Tensor: Output tensor of shape (..., hidden_size)
-
-    Note:
-        Backward pass is not implemented and will raise NotImplementedError on autograd.
     """
     if input.requires_grad:
-        return _SiluAndMul.apply(input, out, kernel_type, **kwargs)
+        if out is not None:
+            raise ValueError("out parameter not supported when requires_grad=True")
+        return _SiluAndMul.apply(input, out, kernel_type)
     return _silu_and_mul_impl(input, out=out, kernel_type=kernel_type, **kwargs)
 
 

--- a/src/tilegym/ops/tilecpp/swiglu.cuh
+++ b/src/tilegym/ops/tilecpp/swiglu.cuh
@@ -186,9 +186,7 @@ __tile_global__ void swiglu_forward_kernel_gather(
     c_ptr = ct::assume_aligned<16>(c_ptr);
 
     n_cols     = ct::assume_bounded_below(n_cols,     ct::integral_constant<0>{});
-    n_cols     = ct::assume_divisible(n_cols,         ct::integral_constant<8>{});
     row_stride = ct::assume_bounded_below(row_stride, ct::integral_constant<0>{});
-    row_stride = ct::assume_divisible(row_stride,     ct::integral_constant<16>{});
 
     int row = ct::bid().x;
 

--- a/src/tilegym/ops/tilecpp/swiglu.py
+++ b/src/tilegym/ops/tilecpp/swiglu.py
@@ -208,12 +208,6 @@ def swiglu_forward(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     c = torch.empty_like(a)
     n_rows = a.shape[0]
 
-    if n_cols % 8 != 0:
-        raise NotImplementedError(f"tilecpp swiglu_forward requires n_cols ({n_cols}) to be a multiple of 8.")
-    row_stride = a.stride(0)
-    if row_stride % 16 != 0:
-        raise NotImplementedError(f"tilecpp swiglu_forward requires row stride ({row_stride}) to be a multiple of 16.")
-
     BLOCK_SIZE = next_power_of_2(n_cols)
     _launch_swiglu_forward_gather_kernel(a, b, c, n_rows, n_cols, BLOCK_SIZE)
     return c.view(*ori_shape)

--- a/src/tilegym/suites/flashinfer/cutile/rope_quantize_fp8.py
+++ b/src/tilegym/suites/flashinfer/cutile/rope_quantize_fp8.py
@@ -13,9 +13,19 @@ from cuda.tile.tune import exhaustive_search
 from tilegym.autotune import is_autotune_disabled
 from tilegym.backend import register_impl
 from tilegym.ops.cutile.utils import cached_replace_hints
+from tilegym.ops.cutile.utils import next_power_of_2
 
 ConstInt = ct.Constant[int]
 PAD_ZERO = ct.PaddingMode.ZERO
+
+# Width of the no_rope copy-quantize sub-tile; empirical sweet spot on b200
+_NOPE_BLOCK_CAP = 128
+
+
+def _nope_block(no_rope_dim: int) -> int:
+    # >= 1 so the kernel's ceil-div never divides by zero when there is no nope span.
+    return max(1, min(next_power_of_2(no_rope_dim), _NOPE_BLOCK_CAP))
+
 
 # Module-level tune cache: (num_tokens, num_qo_heads, num_kv_heads, rope_dim, no_rope_dim, q_dtype, out_dtype, device) -> (best_cfg, tuned_kernel)
 _rope_quantize_fp8_tune_cache: dict = {}
@@ -64,6 +74,7 @@ def _cutile_autotune_rope_quantize_fp8(
     rope_dim,
     no_rope_dim,
     total_blocks_y,
+    nope_block,
 ):
     cache_key = (
         num_tokens,
@@ -100,6 +111,7 @@ def _cutile_autotune_rope_quantize_fp8(
                 rope_dim,
                 no_rope_dim,
                 cfg.TOKENS_PER_BLOCK,
+                nope_block,
             ),
             lambda cfg: {"occupancy": cfg.occupancy},
         )
@@ -132,6 +144,7 @@ def _cutile_autotune_rope_quantize_fp8(
             rope_dim,
             no_rope_dim,
             best_cfg.TOKENS_PER_BLOCK,
+            nope_block,
         ),
     )
 
@@ -192,12 +205,13 @@ def _rope_quantize_fp8_kernel(
     ROPE_DIM: ConstInt,
     NO_ROPE_DIM: ConstInt,
     TOKENS_PER_BLOCK: ConstInt,
+    NOPE_BLOCK: ConstInt,
 ):
     pid_x = ct.bid(0)
     pid_y = ct.bid(1)
 
     HALF_DIM: ConstInt = ROPE_DIM // 2
-    no_rope_chunks: ConstInt = (NO_ROPE_DIM + ROPE_DIM - 1) // ROPE_DIM
+    no_rope_chunks: ConstInt = (NO_ROPE_DIM + NOPE_BLOCK - 1) // NOPE_BLOCK
 
     q_rope_end = NUM_QO_HEADS
     k_rope_end = q_rope_end + NUM_KV_HEADS
@@ -245,7 +259,7 @@ def _rope_quantize_fp8_kernel(
         k_tile = ct.load(
             k_nope,
             index=(pid_x, chunk_idx),
-            shape=(TOKENS_PER_BLOCK, ROPE_DIM),
+            shape=(TOKENS_PER_BLOCK, NOPE_BLOCK),
             padding_mode=PAD_ZERO,
         )
         ct.store(
@@ -258,7 +272,7 @@ def _rope_quantize_fp8_kernel(
         q_tile = ct.load(
             q_nope,
             index=(pid_x, head_idx, chunk_idx),
-            shape=(TOKENS_PER_BLOCK, 1, ROPE_DIM),
+            shape=(TOKENS_PER_BLOCK, 1, NOPE_BLOCK),
             padding_mode=PAD_ZERO,
         )
         ct.store(
@@ -319,7 +333,8 @@ def rope_quantize_fp8(
     num_kv_heads = 1 if k_rope.ndim == 2 else k_rope.shape[1]
     no_rope_dim = q_nope.shape[2] if q_nope is not None else 0
 
-    no_rope_chunks = (no_rope_dim + rope_dim - 1) // rope_dim
+    nope_block = _nope_block(no_rope_dim)
+    no_rope_chunks = (no_rope_dim + nope_block - 1) // nope_block
     total_blocks_y = num_qo_heads + num_kv_heads + num_kv_heads * no_rope_chunks + num_qo_heads * no_rope_chunks
 
     assert not is_neox, "is_neox should be False for rope_quantize_fp8"
@@ -349,6 +364,7 @@ def rope_quantize_fp8(
             rope_dim,
             no_rope_dim,
             cfg.TOKENS_PER_BLOCK,
+            nope_block,
         )
         ct.launch(stream, grid, kernel, args)
     else:
@@ -372,5 +388,6 @@ def rope_quantize_fp8(
             rope_dim,
             no_rope_dim,
             total_blocks_y,
+            nope_block,
         )
     return q_rope_out, k_rope_out, q_nope_out, k_nope_out

--- a/src/tilegym/suites/liger/cutile/fused_neighborhood_attention.py
+++ b/src/tilegym/suites/liger/cutile/fused_neighborhood_attention.py
@@ -14,6 +14,7 @@ import torch
 from cuda.tile import RoundingMode as RMd
 from cuda.tile.tune import exhaustive_search
 
+from tilegym.autotune import is_autotune_disabled
 from tilegym.backend import register_impl
 
 ConstInt = ct.Constant[int]
@@ -604,7 +605,7 @@ def _fused_fwd_autotune(
 
     if cache_key not in _fwd_autotune_cache:
         configs = list(_fused_fwd_autotune_configs())
-        if os.environ.get("DISABLE_AUTOTUNE", "0") == "1":
+        if is_autotune_disabled():
             configs = configs[:1]
 
         def grid_fn(cfg):

--- a/src/tilegym/suites/liger/cutile/grpo_loss.py
+++ b/src/tilegym/suites/liger/cutile/grpo_loss.py
@@ -32,6 +32,7 @@ from cuda.tile.tune import exhaustive_search
 
 LOG2E = 1.4426950408889634
 
+from tilegym.autotune import is_autotune_disabled
 from tilegym.backend import register_impl
 
 _LOSS_TYPE_GRPO = 0
@@ -361,7 +362,7 @@ _fwd_autotune_cache: dict = {}
 
 
 def _tuned_fwd_kernel(stream, cache_key, grid, fwd_args):
-    if os.environ.get("DISABLE_AUTOTUNE") == "1":
+    if is_autotune_disabled():
         return _grpo_loss_fwd_ct.replace_hints(occupancy=ByTarget(sm_100=_FWD_FALLBACK_OCC, default=_FWD_FALLBACK_OCC))
     if cache_key not in _fwd_autotune_cache:
         result = exhaustive_search(

--- a/src/tilegym/suites/liger/cutile/qwen2vl_mrope.py
+++ b/src/tilegym/suites/liger/cutile/qwen2vl_mrope.py
@@ -8,7 +8,22 @@ Qwen2VL Multimodal Rotary Position Embedding (M-RoPE) kernel (CuTile backend).
 Half-split layout: left half of head_dim = real part, right half = imaginary part.
 Three RoPE sections: temporal [0, t_end), height [t_end, h_end), width [h_end, hd//2).
 cos/sin shape: (3, bsz, seq_len, head_dim).
-Grid: (bsz, seq_len) — one program per token (2D grid avoids divmod on pid).
+
+Two kernel variants selected at runtime via the ALIGNED flag (mirrors rope.py):
+
+  ALIGNED case (power-of-2 head_dim AND all head counts match tile sizes AND
+  contiguous Q/K):
+    _qwen2vl_mrope_4d_ct -- operates on Q/K in original
+    (bsz, n_heads, seq_len, head_dim) layout using ct.load block loads (block index
+    0/1 in the last dim selects the real/imag half). No host-side transpose or
+    contiguous copy is needed, and Q/K traffic is a coalesced TMA load instead of a
+    per-element gather. Grid: (bsz * seq_len,).
+
+  Non-ALIGNED case (e.g. non-power-of-2 head_dim):
+    _qwen2vl_mrope_kernel -- gather/scatter kernel operating on a host-side
+    transposed+contiguous (bsz, seq_len, n_heads, head_dim) copy with column masking
+    to head_dim//2 so non-power-of-2 head_dim stays out-of-bounds safe.
+    Grid: (bsz, seq_len).
 """
 
 import cuda.tile as ct
@@ -19,6 +34,66 @@ from tilegym.backend import register_impl
 from .utils import next_power_of_2
 
 ConstInt = ct.Constant[int]
+
+
+@ct.kernel
+def _qwen2vl_mrope_4d_ct(
+    Q,  # (bsz, n_q_heads, seq_len, head_dim) -- original layout, head_dim = 2*TILE_HD
+    K,  # (bsz, n_k_heads, seq_len, head_dim)
+    COS,  # (3, bsz, seq_len, head_dim) -- first TILE_HD elements per section are the cos values
+    SIN,  # (3, bsz, seq_len, head_dim)
+    seq_len: ConstInt,
+    MROPE_SECTION_T: ConstInt,
+    MROPE_SECTION_H: ConstInt,
+    sin_sign: ct.Constant[float],
+    TILE_QH: ConstInt,
+    TILE_KH: ConstInt,
+    TILE_HD: ConstInt,
+):
+    """ALIGNED fast path: no host-side transpose/contiguous, coalesced TMA loads."""
+    pid = ct.bid(0)
+    batch_idx = pid // seq_len
+    seq_idx = pid % seq_len
+
+    t_end = MROPE_SECTION_T
+    h_end = t_end + MROPE_SECTION_H
+
+    # Select the M-RoPE section per column along head_dim//2: temporal [0, t_end),
+    # height [t_end, h_end), width [h_end, hd//2). COS/SIN are (3, bsz, seq, hd);
+    # block index (section, batch, seq, 0) grabs [0, TILE_HD) = the rotation values.
+    col = ct.arange(TILE_HD, dtype=ct.int32)[None, :]  # (1, TILE_HD)
+    in_t = col < t_end
+    in_h = col < h_end
+    t_cos = ct.load(COS, index=(0, batch_idx, seq_idx, 0), shape=(1, 1, 1, TILE_HD)).reshape((1, TILE_HD))
+    h_cos = ct.load(COS, index=(1, batch_idx, seq_idx, 0), shape=(1, 1, 1, TILE_HD)).reshape((1, TILE_HD))
+    w_cos = ct.load(COS, index=(2, batch_idx, seq_idx, 0), shape=(1, 1, 1, TILE_HD)).reshape((1, TILE_HD))
+    t_sin = ct.load(SIN, index=(0, batch_idx, seq_idx, 0), shape=(1, 1, 1, TILE_HD)).reshape((1, TILE_HD))
+    h_sin = ct.load(SIN, index=(1, batch_idx, seq_idx, 0), shape=(1, 1, 1, TILE_HD)).reshape((1, TILE_HD))
+    w_sin = ct.load(SIN, index=(2, batch_idx, seq_idx, 0), shape=(1, 1, 1, TILE_HD)).reshape((1, TILE_HD))
+    cos_row = ct.where(in_t, t_cos, ct.where(in_h, h_cos, w_cos))
+    sin_row = ct.where(in_t, t_sin, ct.where(in_h, h_sin, w_sin)) * sin_sign
+
+    # Q in (bsz, n_q_heads, seq_len, head_dim): index (b, 0, s, 0) = real half,
+    # index (b, 0, s, 1) = imag half (block 1 starts at element TILE_HD = head_dim//2).
+    q_r = ct.load(Q, index=(batch_idx, 0, seq_idx, 0), shape=(1, TILE_QH, 1, TILE_HD)).reshape((TILE_QH, TILE_HD))
+    q_i = ct.load(Q, index=(batch_idx, 0, seq_idx, 1), shape=(1, TILE_QH, 1, TILE_HD)).reshape((TILE_QH, TILE_HD))
+    # Rotate in fp32 (cos_row/sin_row are fp32), round only the final result.
+    q_r_f = q_r.astype(ct.float32)
+    q_i_f = q_i.astype(ct.float32)
+    new_q_r = (q_r_f * cos_row - q_i_f * sin_row).astype(Q.dtype)
+    new_q_i = (q_i_f * cos_row + q_r_f * sin_row).astype(Q.dtype)
+    ct.store(Q, index=(batch_idx, 0, seq_idx, 0), tile=new_q_r.reshape((1, TILE_QH, 1, TILE_HD)))
+    ct.store(Q, index=(batch_idx, 0, seq_idx, 1), tile=new_q_i.reshape((1, TILE_QH, 1, TILE_HD)))
+
+    # K in (bsz, n_k_heads, seq_len, head_dim)
+    k_r = ct.load(K, index=(batch_idx, 0, seq_idx, 0), shape=(1, TILE_KH, 1, TILE_HD)).reshape((TILE_KH, TILE_HD))
+    k_i = ct.load(K, index=(batch_idx, 0, seq_idx, 1), shape=(1, TILE_KH, 1, TILE_HD)).reshape((TILE_KH, TILE_HD))
+    k_r_f = k_r.astype(ct.float32)
+    k_i_f = k_i.astype(ct.float32)
+    new_k_r = (k_r_f * cos_row - k_i_f * sin_row).astype(K.dtype)
+    new_k_i = (k_i_f * cos_row + k_r_f * sin_row).astype(K.dtype)
+    ct.store(K, index=(batch_idx, 0, seq_idx, 0), tile=new_k_r.reshape((1, TILE_KH, 1, TILE_HD)))
+    ct.store(K, index=(batch_idx, 0, seq_idx, 1), tile=new_k_i.reshape((1, TILE_KH, 1, TILE_HD)))
 
 
 @ct.kernel
@@ -139,7 +214,51 @@ def _qwen2vl_mrope_kernel(
     ct.scatter(key, k_i_idx, new_k_i, mask=k_mask, check_bounds=False, latency=1)
 
 
+def _is_aligned(q, k, n_q_head, n_kv_head, head_dim_half, TILE_HD, TILE_QH, TILE_KH):
+    """ALIGNED fast path: power-of-2 head_dim / head counts and contiguous Q/K, so the
+    4D block-load kernel can run in-place on the original (bsz, n_heads, seq, hd) layout
+    without any host transpose+contiguous copy."""
+    return (
+        (TILE_HD == head_dim_half)
+        and (TILE_QH == n_q_head)
+        and (TILE_KH == n_kv_head)
+        and q.is_contiguous()
+        and k.is_contiguous()
+    )
+
+
 def _qwen2vl_mrope_forward(q, k, cos, sin, mrope_section):
+    # q/k in: (bsz, n_heads, seq_len, head_dim)
+    batch_size, n_q_head, seq_len, head_dim = q.shape
+    n_kv_head = k.shape[1]
+    head_dim_half = head_dim // 2
+    TILE_HD = next_power_of_2(head_dim_half)
+    TILE_QH = next_power_of_2(n_q_head)
+    TILE_KH = next_power_of_2(n_kv_head)
+
+    if _is_aligned(q, k, n_q_head, n_kv_head, head_dim_half, TILE_HD, TILE_QH, TILE_KH):
+        cos_c = cos.contiguous()
+        sin_c = sin.contiguous()
+        ct.launch(
+            torch.cuda.current_stream(),
+            (batch_size * seq_len,),
+            _qwen2vl_mrope_4d_ct,
+            (
+                q,
+                k,
+                cos_c,
+                sin_c,
+                int(seq_len),
+                int(mrope_section[0]),
+                int(mrope_section[1]),
+                1.0,
+                int(TILE_QH),
+                int(TILE_KH),
+                int(TILE_HD),
+            ),
+        )
+        return q, k, cos, sin
+
     q = q.transpose(1, 2).contiguous()
     k = k.transpose(1, 2).contiguous()
 
@@ -184,6 +303,37 @@ def _qwen2vl_mrope_forward(q, k, cos, sin, mrope_section):
 
 
 def _qwen2vl_mrope_backward(dq, dk, cos, sin, mrope_section):
+    # dq/dk in: (bsz, n_heads, seq_len, head_dim)
+    batch_size, n_q_head, seq_len, head_dim = dq.shape
+    n_kv_head = dk.shape[1]
+    head_dim_half = head_dim // 2
+    TILE_HD = next_power_of_2(head_dim_half)
+    TILE_QH = next_power_of_2(n_q_head)
+    TILE_KH = next_power_of_2(n_kv_head)
+
+    if _is_aligned(dq, dk, n_q_head, n_kv_head, head_dim_half, TILE_HD, TILE_QH, TILE_KH):
+        cos_c = cos.contiguous()
+        sin_c = sin.contiguous()
+        ct.launch(
+            torch.cuda.current_stream(),
+            (batch_size * seq_len,),
+            _qwen2vl_mrope_4d_ct,
+            (
+                dq,
+                dk,
+                cos_c,
+                sin_c,
+                int(seq_len),
+                int(mrope_section[0]),
+                int(mrope_section[1]),
+                -1.0,  # backward negates sin
+                int(TILE_QH),
+                int(TILE_KH),
+                int(TILE_HD),
+            ),
+        )
+        return dq, dk
+
     dq = dq.transpose(1, 2).contiguous()
     dk = dk.transpose(1, 2).contiguous()
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -88,6 +88,38 @@ def get_tensor_alignment(tensor):
     return alignment
 
 
+# Consumer-Blackwell arches (sm120/sm121) have less device memory than the
+# data-center GPUs the liger ``test_perf`` shapes were sized for.
+_MEMORY_CONSTRAINED_ARCHS = ("sm120", "sm121")
+
+
+def skip_perf_shape_on_oom(test_fn):
+    r"""Convert a genuine OOM on memory-constrained arches into a skip.
+
+    Wraps a liger ``test_perf`` method. If executing the perf shape raises a
+    ``torch.cuda.OutOfMemoryError`` and ``--arch`` is a memory-constrained
+    consumer-Blackwell arch (sm120/sm121), reclaim memory and ``pytest.skip``.
+    On every other arch (b200/sm100, h100/sm90, a100/sm80) the error is
+    re-raised so the perf-tracking platforms still fail loudly. Only
+    ``torch.cuda.OutOfMemoryError`` is intercepted -- correctness assertions and
+    all other exceptions propagate unchanged.
+    """
+
+    @wraps(test_fn)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return test_fn(self, *args, **kwargs)
+        except torch.cuda.OutOfMemoryError:
+            gc.collect()
+            torch.cuda.empty_cache()
+            arch = self.request.config.getoption("--arch")
+            if arch in _MEMORY_CONSTRAINED_ARCHS:
+                pytest.skip(f"perf shape exceeds device memory on {arch}")
+            raise
+
+    return wrapper
+
+
 class PyTestCase:
     r"""
     Base class for TileGym unit tests.

--- a/tests/ops/test_bmm.py
+++ b/tests/ops/test_bmm.py
@@ -71,6 +71,9 @@ class Test_BMM_FWD(common.PyTestCase):
         else:
             pytest.skip(f"Backend {backend} is not available")
 
+        if backend == "tilecpp" and static_persistent:
+            pytest.skip("tilecpp static_persistent is under investigation")
+
         if backend == "cutile" and not static_persistent and (transpose_a or transpose_b):
             pytest.skip("CuTile non-persistent kernel doesn't support transpose")
         if backend == "cutile-rs" and not static_persistent and (transpose_a or transpose_b):

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -58,8 +58,8 @@ class Test_RMSNorm(common.PyTestCase):
         else:
             pytest.skip(f"Backend {backend} is not available")
 
-        # multi_wave_cached is only implemented in the cutile backend
-        if backend != "cutile" and mode == "multi_wave_cached":
+        # multi_wave_cached is only implemented in the cutile and tilecpp backends
+        if backend not in ("cutile", "tilecpp") and mode == "multi_wave_cached":
             pytest.skip(f"multi_wave_cached mode is not implemented for backend {backend}")
 
         if backend == "tilecpp" and mode == "static_persistent":

--- a/tests/ops/test_rms_norm.py
+++ b/tests/ops/test_rms_norm.py
@@ -62,6 +62,9 @@ class Test_RMSNorm(common.PyTestCase):
         if backend != "cutile" and mode == "multi_wave_cached":
             pytest.skip(f"multi_wave_cached mode is not implemented for backend {backend}")
 
+        if backend == "tilecpp" and mode == "static_persistent":
+            pytest.skip("tilecpp static_persistent is under investigation")
+
         # skip static_persistent tests when n > 16384 to avoid excessive memory usage
         # Avoid tileiras hangs on RTX PRO 6000 which has 100 KB shared memory per SM
         # mode=None can also select static_persistent via heuristic when M > NUM_SMS * 2

--- a/tests/ops/test_silu_and_mul.py
+++ b/tests/ops/test_silu_and_mul.py
@@ -56,11 +56,6 @@ class Test_SiLUAndMul(common.PyTestCase):
         else:
             pytest.skip(f"Backend {backend} is not available")
 
-        if backend == "tilecpp":
-            pytest.skip(
-                "tilecpp silu_and_mul does not implement backward; the gradient check would raise NotImplementedError"
-            )
-
         self.setUp()
         device = torch.device("cuda")
 
@@ -108,11 +103,6 @@ class Test_SiLUAndMul(common.PyTestCase):
             tilegym.set_backend(backend)
         else:
             pytest.skip(f"Backend {backend} is not available")
-
-        if backend == "tilecpp":
-            pytest.skip(
-                "tilecpp silu_and_mul does not implement backward; the gradient check would raise NotImplementedError"
-            )
 
         self.setUp()
         device = torch.device("cuda")

--- a/tests/ops/test_swiglu.py
+++ b/tests/ops/test_swiglu.py
@@ -86,12 +86,6 @@ class Test_SwiGLU(common.PyTestCase):
         except Exception as e:
             pytest.skip(f"Backend is not supported: {e}")
 
-        if backend == "tilecpp" and (hidden_size % 8 != 0 or hidden_size % 16 != 0):
-            pytest.skip(
-                "tilecpp swiglu_forward gather kernel requires hidden_size divisible by 8 "
-                "(and contiguous-row stride divisible by 16) for vectorised loads/stores."
-            )
-
         a = torch.randn(batch_size, seq_len, hidden_size, device="cuda")
         b = torch.randn(batch_size, seq_len, hidden_size, device="cuda")
 
@@ -180,12 +174,6 @@ class Test_SwiGLU(common.PyTestCase):
             set_backend(backend)
         except Exception as e:
             pytest.skip(f"Backend is not supported: {e}")
-
-        if backend == "tilecpp" and (hidden_size % 8 != 0 or hidden_size % 16 != 0):
-            pytest.skip(
-                "tilecpp swiglu_forward gather kernel requires hidden_size divisible by 8 "
-                "(and contiguous-row stride divisible by 16) for vectorised loads/stores."
-            )
 
         device = torch.device("cuda")
         dtype = torch.float32

--- a/tests/suites/liger/test_group_norm.py
+++ b/tests/suites/liger/test_group_norm.py
@@ -37,7 +37,6 @@ class Test_Liger_GroupNorm(common.PyTestCase):
     @pytest.mark.parametrize("backend", _backends)
     def test_op_forward(self, batch_size, num_channels, hidden_size, num_groups, dtype, backend, monkeypatch):
         """Test forward output matches PyTorch F.group_norm reference."""
-        monkeypatch.setenv("DISABLE_AUTOTUNE", "1")
         self.setUp()
         if tilegym.is_backend_available(backend):
             tilegym.set_backend(backend)
@@ -72,7 +71,6 @@ class Test_Liger_GroupNorm(common.PyTestCase):
     @pytest.mark.parametrize("backend", _backends)
     def test_op_backward(self, batch_size, num_channels, hidden_size, num_groups, dtype, backend, monkeypatch):
         """Test backward gradients (dX, dW, dB) match PyTorch reference."""
-        monkeypatch.setenv("DISABLE_AUTOTUNE", "1")
         self.setUp()
         if tilegym.is_backend_available(backend):
             tilegym.set_backend(backend)


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->

Update codes.

This PR contains **7** new commit(s).

### Commits included:

```
f8c6082 tilecpp: align op behavior with the cuTile Python reference implementations
61e9055 Widened the cuTile rope_quantize_fp8 no_rope copy-quantize sub-tile from rope_dim (64) to 128
a74f6c7 Rewrote the cuTile Qwen2VL M-RoPE kernel to mirror rope.py's ALIGNED 4D block-load path
8bee3fc Added num_worker_warps to the cuTile persistent_layer_norm autotune configs
3d39f66 add skip_perf_shape_on_oom decorator
292c845 refactor: unify autotune-disable env var to TILEGYM_DISABLE_AUTOTUNE
6144146 test(tilecpp): skip the two tilecpp cases ToT nvcc cannot build correctly
```

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: ["ops", "benchmark"]
```

## Checklist
- [ ] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

