### PR TITLE
test(perf): tilecpp perf parity with cutile & other updates

### DIFF
--- a/README.tilecpp.md
+++ b/README.tilecpp.md
@@ -50,10 +50,13 @@ python tests/benchmark/bench_swiglu.py
 ### Autotuning
 
 
-| Variable                   | Default | Description                                                                                             |
-| -------------------------- | ------- | ------------------------------------------------------------------------------------------------------- |
-| `TILECPP_AUTOTUNE`         | `0`     | Set to `1` to enable autotuning for kernel configurations. When disabled, uses default configurations.  |
-| `TILECPP_VERBOSE_AUTOTUNE` | `0`     | Set to `1` to enable verbose output during autotuning, showing configuration trials and timing results. |
+Autotuning follows `TILEGYM_DISABLE_AUTOTUNE`, the switch shared by every
+backend, and so is on unless that variable disables it.
+
+| Variable                   | Default                      | Description                                                                                             |
+| -------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `TILECPP_AUTOTUNE`         | unset                        | Overrides the shared switch for this backend alone: `0` pins the default configurations, anything else searches. |
+| `TILECPP_VERBOSE_AUTOTUNE` | `0`                          | Set to `1` to enable verbose output during autotuning, showing configuration trials and timing results. |
 
 
 ## Adding a New CUDA Tile C++ Kernel to TileGym

--- a/modeling/transformers/pyproject.toml
+++ b/modeling/transformers/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
   "flashinfer-bench==0.1.2",
   "pytest-html",
   "pytest-split",
+  "pytest-timeout",
   "pytest-xdist",
   "ruff",
 ]

--- a/modeling/transformers/uv.lock
+++ b/modeling/transformers/uv.lock
@@ -3401,6 +3401,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4278,6 +4290,7 @@ dev = [
     { name = "flashinfer-bench" },
     { name = "pytest-html" },
     { name = "pytest-split" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -4309,6 +4322,7 @@ requires-dist = [
     { name = "protobuf" },
     { name = "pytest-html", marker = "extra == 'dev'" },
     { name = "pytest-split", marker = "extra == 'dev'" },
+    { name = "pytest-timeout", marker = "extra == 'dev'" },
     { name = "pytest-xdist", marker = "extra == 'dev'" },
     { name = "pyyaml" },
     { name = "ruff", marker = "extra == 'dev'" },

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,8 +2,19 @@
 #
 # SPDX-License-Identifier: MIT
 
-[tool:pytest]
+# [tool:pytest] is the setup.cfg spelling; pytest.ini needs [pytest] or the whole
+# section is ignored. The four keys below match pytest's defaults, so activating
+# them changes nothing -- the timeout settings are what this enables.
+[pytest]
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
+# The slowest legitimate test is ~440s and runners vary by ~1.3x, so 1200s leaves
+# ample headroom while still bounding a hang well inside the job's own timeout.
+# thread method because signal cannot interrupt a blocked CUDA/nvcc call, which is
+# where hangs actually happen -- but that also kills the worker before xdist can
+# relay its output, so faulthandler dumps every thread's stack first.
+faulthandler_timeout = 900
+timeout = 1200
+timeout_method = thread

--- a/src/tilegym/ops/cutile/activation/gelu.py
+++ b/src/tilegym/ops/cutile/activation/gelu.py
@@ -73,22 +73,13 @@ def standard_normal_pdf_ct(x_val, BLOCK_SIZE: ct.Constant[int]):
 
 def gelu_tanh_forward_ct(x_val, BLOCK_SIZE: ct.Constant[int]):
     # f(x) = 0.5 * x * (1 + tanh(√(2/π) * (x + 0.044715 * x³)))
+    # ct.tanh uses the default (precise) rounding mode; the APPROX mode is not
+    # used because its 2-4 ULP deviation breaks cross-backend numeric parity.
     sqrt_2_div_pi = 0.7978845608028654
     coeff_044715 = 0.044715
-    half = ct.full((BLOCK_SIZE,), 0.5, dtype=x_val.dtype)
-    one = ct.ones((BLOCK_SIZE,), dtype=x_val.dtype)
-    sqrt_2_div_pi_tensor = ct.full((BLOCK_SIZE,), sqrt_2_div_pi, dtype=x_val.dtype)
-    coeff_tensor = ct.full((BLOCK_SIZE,), coeff_044715, dtype=x_val.dtype)
 
-    x_cubed = x_val * x_val * x_val
-    coeff_x_cubed = coeff_tensor * x_cubed
-    inner_sum = x_val + coeff_x_cubed
-    scaled_inner = sqrt_2_div_pi_tensor * inner_sum
-    tanh_val = _tanh_ct(scaled_inner, BLOCK_SIZE)
-    one_plus_tanh = one + tanh_val
-    half_x = half * x_val
-
-    return half_x * one_plus_tanh
+    inner = sqrt_2_div_pi * (x_val + coeff_044715 * x_val * x_val * x_val)
+    return 0.5 * x_val * (1.0 + ct.tanh(inner))
 
 
 def gelu_forward_ct(x_val, BLOCK_SIZE: ct.Constant[int]):
@@ -149,7 +140,9 @@ class _GeluCuTileFunction(torch.autograd.Function):
         approx_mode = GELU_TANH if approximate == "tanh" else GELU_EXACT
         y = torch.empty_like(x)
         n_elements = y.numel()
-        BLOCK_SIZE = 1024
+        # Wider tile for large (memory-bound) launches; 1024 for small
+        # (latency-bound) launches.
+        BLOCK_SIZE = 4096 if n_elements >= (1 << 24) else 1024
         grid = (math.ceil(n_elements / BLOCK_SIZE), 1, 1)
         x_flat = x.view(-1)
         y_flat = y.view(-1)

--- a/src/tilegym/ops/cutile/attention_variant.py
+++ b/src/tilegym/ops/cutile/attention_variant.py
@@ -152,6 +152,11 @@ def _fmha_variant_kernel_bnsd(
     if WINDOW_SIZE > 0:
         kv_start = max(0, (prefix_kvlen + start_m - WINDOW_SIZE) // TILE_N * TILE_N)
         kv_end = min(kv_len_val, prefix_kvlen + (bid_x + 1) * TILE_M + WINDOW_SIZE)
+    elif CAUSAL:
+        # Causal: KV positions past this query tile's last causal key are fully
+        # masked, so the loop is bounded at the diagonal rather than all of S_kv.
+        kv_start = 0
+        kv_end = min(kv_len_val, prefix_kvlen + (bid_x + 1) * TILE_M)
     else:
         kv_start = 0
         kv_end = kv_len_val
@@ -203,11 +208,13 @@ def _fmha_variant_kernel_bnsd(
             rmask = rmask.reshape((TILE_M, TILE_N))
             qk = ct.where(rmask != 0, ct.full((TILE_M, TILE_N), NEG_INF, dtype=ct.float32), qk)
 
-        # Apply causal mask
+        # Tiles whose last key is at or before this query tile's first causal
+        # position are entirely visible, so the causal mask is skipped for them.
         if CAUSAL:
-            offs_n_full = kv_pos + offs_n_tile
-            causal_mask = (offs_m + prefix_kvlen) >= offs_n_full
-            qk = ct.where(causal_mask, qk, ct.full((TILE_M, TILE_N), NEG_INF, dtype=ct.float32))
+            if kv_pos + TILE_N > start_m + prefix_kvlen + 1:
+                offs_n_full = kv_pos + offs_n_tile
+                causal_mask = (offs_m + prefix_kvlen) >= offs_n_full
+                qk = ct.where(causal_mask, qk, ct.full((TILE_M, TILE_N), NEG_INF, dtype=ct.float32))
 
         # Apply window mask
         if WINDOW_SIZE > 0:
@@ -334,6 +341,11 @@ def _fmha_variant_kernel_nsbd(
     if WINDOW_SIZE > 0:
         kv_start = max(0, (prefix_kvlen + start_m - WINDOW_SIZE) // TILE_N * TILE_N)
         kv_end = min(kv_len_val, prefix_kvlen + (bid_x + 1) * TILE_M + WINDOW_SIZE)
+    elif CAUSAL:
+        # Causal: KV positions past this query tile's last causal key are fully
+        # masked, so the loop is bounded at the diagonal rather than all of S_kv.
+        kv_start = 0
+        kv_end = min(kv_len_val, prefix_kvlen + (bid_x + 1) * TILE_M)
     else:
         kv_start = 0
         kv_end = kv_len_val
@@ -380,9 +392,10 @@ def _fmha_variant_kernel_nsbd(
             qk = ct.where(rmask != 0, ct.full((TILE_M, TILE_N), NEG_INF, dtype=ct.float32), qk)
 
         if CAUSAL:
-            offs_n_full = kv_pos + offs_n_tile
-            causal_mask = (offs_m + prefix_kvlen) >= offs_n_full
-            qk = ct.where(causal_mask, qk, ct.full((TILE_M, TILE_N), NEG_INF, dtype=ct.float32))
+            if kv_pos + TILE_N > start_m + prefix_kvlen + 1:
+                offs_n_full = kv_pos + offs_n_tile
+                causal_mask = (offs_m + prefix_kvlen) >= offs_n_full
+                qk = ct.where(causal_mask, qk, ct.full((TILE_M, TILE_N), NEG_INF, dtype=ct.float32))
 
         if WINDOW_SIZE > 0:
             offs_n_full = kv_pos + offs_n_tile

--- a/src/tilegym/ops/cutile/bmm.py
+++ b/src/tilegym/ops/cutile/bmm.py
@@ -49,13 +49,20 @@ def _bmm_autotune_configs():
                             TILE_M=TILE_M, TILE_N=TILE_N, TILE_K=TILE_K, GROUP_SIZE_M=8, occupancy=occupancy, num_ctas=2
                         )
     else:
-        # Other GPUs (e.g., GB100): Larger tiles with num_ctas=2
         for TILE_M in [128, 256]:
             for TILE_N in [256]:
-                for TILE_K in [64]:
-                    yield SimpleNamespace(
-                        TILE_M=TILE_M, TILE_N=TILE_N, TILE_K=TILE_K, GROUP_SIZE_M=8, occupancy=1, num_ctas=2
-                    )
+                for TILE_K in [32, 64]:
+                    for occupancy in [1, 2]:
+                        for LATENCY in [3, 4, 5]:
+                            yield SimpleNamespace(
+                                TILE_M=TILE_M,
+                                TILE_N=TILE_N,
+                                TILE_K=TILE_K,
+                                GROUP_SIZE_M=8,
+                                occupancy=occupancy,
+                                num_ctas=2,
+                                LATENCY=LATENCY,
+                            )
 
 
 # CuTile implementation of BMM kernel
@@ -108,6 +115,7 @@ def _static_persistent_bmm_kernel(
     TILE_N: ct.Constant[int],
     TILE_K: ct.Constant[int],
     GROUP_SIZE_M: ct.Constant[int],
+    LATENCY: ct.Constant[int],
     TRANSPOSE_A: ct.Constant[bool],
     TRANSPOSE_B: ct.Constant[bool],
 ):
@@ -159,7 +167,7 @@ def _static_persistent_bmm_kernel(
                     shape=(1, TILE_K, TILE_M),
                     order=(0, 1, 2),
                     padding_mode=zero_pad,
-                    latency=3,
+                    latency=LATENCY,
                 )
                 # Transpose to get (1, TILE_M, TILE_K)
                 a_tile_3d = ct.permute(a_tile_3d, (0, 2, 1))
@@ -171,7 +179,7 @@ def _static_persistent_bmm_kernel(
                     shape=(1, TILE_M, TILE_K),
                     order=(0, 1, 2),
                     padding_mode=zero_pad,
-                    latency=3,
+                    latency=LATENCY,
                 )
             # Reshape to 2D for MMA
             a_tile = ct.reshape(a_tile_3d, (TILE_M, TILE_K))
@@ -185,7 +193,7 @@ def _static_persistent_bmm_kernel(
                     shape=(1, TILE_N, TILE_K),
                     order=(0, 1, 2),
                     padding_mode=zero_pad,
-                    latency=3,
+                    latency=LATENCY,
                 )
                 # Transpose to get (1, TILE_K, TILE_N)
                 b_tile_3d = ct.permute(b_tile_3d, (0, 2, 1))
@@ -197,7 +205,7 @@ def _static_persistent_bmm_kernel(
                     shape=(1, TILE_K, TILE_N),
                     order=(0, 1, 2),
                     padding_mode=zero_pad,
-                    latency=3,
+                    latency=LATENCY,
                 )
             # Reshape to 2D for MMA
             b_tile = ct.reshape(b_tile_3d, (TILE_K, TILE_N))
@@ -209,7 +217,7 @@ def _static_persistent_bmm_kernel(
         result = ct.astype(accumulator, C.dtype)
         # Reshape to 3D for store
         result_3d = ct.reshape(result, (1, TILE_M, TILE_N))
-        ct.store(C, index=(bid_q, bid_m, bid_n), tile=result_3d, order=(0, 1, 2), latency=3)
+        ct.store(C, index=(bid_q, bid_m, bid_n), tile=result_3d, order=(0, 1, 2), latency=LATENCY)
 
 
 def _persistent_bmm_autotune_base(stream, a, b, output, batch_size, M, N, K, transpose_a, transpose_b):
@@ -246,6 +254,7 @@ def _persistent_bmm_autotune_base(stream, a, b, output, batch_size, M, N, K, tra
             cfg.TILE_N,
             cfg.TILE_K,
             cfg.GROUP_SIZE_M,
+            getattr(cfg, "LATENCY", 3),
             transpose_a,
             transpose_b,
         )

--- a/src/tilegym/ops/cutile/matmul.py
+++ b/src/tilegym/ops/cutile/matmul.py
@@ -142,6 +142,12 @@ def _static_persistent_matmul_autotune_configs():
         yield SimpleNamespace(
             TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=128, GROUP_SIZE_M=8, num_ctas=2, occupancy=1, LOAD_LATENCY=-1
         )
+        # Narrow-K tile for extreme-skinny float32 shapes: fp32 doubles per-tile shared
+        # memory, so the K=64 tiles above exceed the smem budget and are unrealizable,
+        # leaving no wide/large-tile candidate for the skinny fp32 case without this one.
+        yield SimpleNamespace(
+            TILE_SIZE_M=256, TILE_SIZE_N=128, TILE_SIZE_K=32, GROUP_SIZE_M=8, num_ctas=2, occupancy=1, LOAD_LATENCY=-1
+        )
         # Small-tile candidate for small/rectangular GEMMs, where the entries above cap
         # the persistent grid at 16-32 tile-jobs and strand most SMs.
         yield SimpleNamespace(

--- a/src/tilegym/ops/cutile/matmul.py
+++ b/src/tilegym/ops/cutile/matmul.py
@@ -128,6 +128,14 @@ def _static_persistent_matmul_autotune_configs():
         yield SimpleNamespace(
             TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=2, occupancy=1, LOAD_LATENCY=-1
         )
+        # Wide-N and load-cost-tuned tiles for extreme-skinny shapes (large M, small
+        # N/K), where the square tiles above leave the persistent grid underutilized.
+        yield SimpleNamespace(
+            TILE_SIZE_M=256, TILE_SIZE_N=512, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=2, occupancy=1, LOAD_LATENCY=-1
+        )
+        yield SimpleNamespace(
+            TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=2, occupancy=1, LOAD_LATENCY=4
+        )
         yield SimpleNamespace(
             TILE_SIZE_M=256, TILE_SIZE_N=256, TILE_SIZE_K=64, GROUP_SIZE_M=8, num_ctas=1, occupancy=1, LOAD_LATENCY=-1
         )

--- a/src/tilegym/ops/cutile/mla_decoding.py
+++ b/src/tilegym/ops/cutile/mla_decoding.py
@@ -15,6 +15,8 @@ ConstBool = ct.Constant[bool]
 
 INV_LOG_2 = 1.0 / math.log(2)
 
+_MLA_LOAD_LATENCY = 2
+
 
 @ct.kernel
 def _naive_absorb_mla_transpose_kernel(
@@ -73,6 +75,7 @@ def _naive_absorb_mla_transpose_kernel(
             index=(batch_idx, cnt, 0),
             shape=(1, TILE_N, TILE_D),
             allow_tma=True,
+            latency=_MLA_LOAD_LATENCY,
         )
         k = ct.reshape(k, (TILE_N, TILE_D))
         qk = ct.full((TILE_N, TILE_H), 0.0, dtype=ct.float32)
@@ -84,6 +87,7 @@ def _naive_absorb_mla_transpose_kernel(
             index=(batch_idx, cnt, 0),
             shape=(1, TILE_N, TILE_KPE),
             allow_tma=True,
+            latency=_MLA_LOAD_LATENCY,
         )
         kpe = ct.reshape(kpe, (TILE_N, TILE_KPE))
         qk = ct.mma(kpe, qpe, qk)
@@ -110,6 +114,7 @@ def _naive_absorb_mla_transpose_kernel(
             shape=(TILE_N, 1, TILE_D),
             order=(1, 0, 2),
             allow_tma=True,
+            latency=_MLA_LOAD_LATENCY,
         )
         v = ct.reshape(v, (TILE_N, TILE_D))
         v = ct.transpose(v, axis0=1, axis1=0)
@@ -129,6 +134,21 @@ def _naive_absorb_mla_transpose_kernel(
     acc = ct.transpose(acc, axis0=1, axis1=0)
     acc = ct.reshape(acc, (1, TILE_H, TILE_D))
     ct.store(Out, index=(batch_idx, bid_x, 0), tile=acc, allow_tma=True)
+
+
+def _select_tile_config() -> tuple[int, int]:
+    """Pick (TILE_H, TILE_N) for the current GPU architecture.
+
+    The kernel streams the whole KV cache through a (TILE_N, TILE_D=512) tile.
+    A TILE_N=128 tile throttles occupancy outside datacenter Blackwell, so those
+    architectures use the narrower TILE_N=64 tile while the datacenter parts the
+    wide tile was tuned for keep it. TILE_H stays 16 for all.
+    """
+    major, _ = torch.cuda.get_device_capability()
+    # sm_100: datacenter Blackwell keeps the wider KV tile.
+    if major == 10:
+        return 16, 128
+    return 16, 64
 
 
 class _MlaDecodingFunction(torch.autograd.Function):
@@ -191,10 +211,9 @@ def mla_decoding(
     transpose: bool = True,
     **kwargs,
 ) -> torch.Tensor:
-    TILE_H = 16
-    TILE_N = 128
-    num_ctas = None  # Let compiler auto-pick
     assert transpose == True, "CuTile MLA Decoding only supports transpose=True"
+    TILE_H, TILE_N = _select_tile_config()
+    num_ctas = None  # Let compiler auto-pick
     if sm_scale is None:
         sm_scale = 1.0 / (math.sqrt(q.size(-1) + qpe.size(-1)))
     return _MlaDecodingFunction.apply(q, qpe, kv, kpe, sm_scale, TILE_H, TILE_N, num_ctas)

--- a/src/tilegym/ops/cutile/moe_align_block.py
+++ b/src/tilegym/ops/cutile/moe_align_block.py
@@ -17,25 +17,29 @@ def _moe_align_block_size_stage1_kernel(
     NUM_EXPERTS: ct.Constant[int],
     NUMEL: ct.Constant[int],
     TOKENS_PER_THREAD: ct.Constant[int],
+    SUB_CHUNK: ct.Constant[int],
+    NUM_EXPERTS_POW2: ct.Constant[int],
 ):
     bid = ct.bid(0)
 
     start_idx = bid * TOKENS_PER_THREAD
     off_c = (bid + 1) * NUM_EXPERTS
-    token_cnt = ct.zeros((1,), dtype=ct.int32)
 
-    limit = max(0, min(TOKENS_PER_THREAD, NUMEL - start_idx))
-    for i in range(limit):
-        current_idx = start_idx + i
-        current_idx_tile = ct.full((1,), current_idx, dtype=ct.int32)
-        idx = ct.gather(topk_ids, current_idx_tile, padding_value=0)
+    # Vectorized histogram: process this program's token chunk in sub-chunks of
+    # SUB_CHUNK tokens.
+    expert_idx = ct.arange(NUM_EXPERTS_POW2, dtype=ct.int32)
+    expert_mask = expert_idx < NUM_EXPERTS
+    counts = ct.zeros((NUM_EXPERTS_POW2,), dtype=ct.int32)
 
-        off_c_tile = ct.full((1,), off_c, dtype=ct.int32)
-        cnt_offset = off_c_tile + idx
-        token_cnt = ct.gather(tokens_cnts, cnt_offset, padding_value=0)
+    sub_arange = ct.arange(SUB_CHUNK, dtype=ct.int32)
+    for sub_start in range(0, TOKENS_PER_THREAD, SUB_CHUNK):
+        tok_offs = start_idx + sub_start + sub_arange
+        tok_mask = (tok_offs < NUMEL) & ((sub_start + sub_arange) < TOKENS_PER_THREAD)
+        ids = ct.gather(topk_ids, tok_offs, mask=tok_mask, padding_value=NUM_EXPERTS)
+        match = (ids[:, None] == expert_idx[None, :]).astype(ct.int32)
+        counts = counts + ct.sum(match, axis=0)
 
-        new_cnt = token_cnt + ct.ones((1,), dtype=ct.int32)
-        ct.scatter(tokens_cnts, cnt_offset, new_cnt)
+    ct.scatter(tokens_cnts, off_c + expert_idx, counts, mask=expert_mask)
 
 
 @ct.kernel
@@ -61,9 +65,12 @@ def _moe_align_block_size_stage3_kernel(
     cumsum,
     NUM_EXPERTS: ct.Constant[int],
     BLOCK_SIZE: ct.Constant[int],
+    NUM_PROGRAMS: ct.Constant[int],
 ):
     last_cumsum = ct.zeros((1,), dtype=ct.int32)
-    off_cnt = NUM_EXPERTS * NUM_EXPERTS
+    # tokens_cnts has NUM_PROGRAMS + 1 rows; row NUM_PROGRAMS holds the total
+    # per-expert count (inclusive prefix over all token programs) after stage2.
+    off_cnt = NUM_PROGRAMS * NUM_EXPERTS
     max_cnt = ct.zeros((1,), dtype=ct.int32)
 
     for i in range(1, NUM_EXPERTS + 1):
@@ -86,7 +93,7 @@ def _moe_align_block_size_stage3_kernel(
 
 
 @ct.kernel
-def _moe_align_block_size_stage4_kernel(
+def _moe_align_block_size_stage4b_scatter_kernel(
     topk_ids,
     sorted_token_ids,
     expert_ids,
@@ -96,13 +103,18 @@ def _moe_align_block_size_stage4_kernel(
     BLOCK_SIZE: ct.Constant[int],
     NUMEL: ct.Constant[int],
     TOKENS_PER_THREAD: ct.Constant[int],
+    SUB_CHUNK: ct.Constant[int],
+    NUM_EXPERTS_POW2: ct.Constant[int],
 ):
+    # One program per token range: scatter its tokens into sorted positions.
     bid = ct.bid(0)
     off_t = bid * NUM_EXPERTS
 
+    # Stamp expert_ids. Programs 0..NUM_EXPERTS-1 own expert `bid`'s blocks;
+    # for programs with bid >= NUM_EXPERTS the cumsum gathers fall out of bounds
+    # (padding 0), so num_blocks == 0 and nothing is written.
     start_idx_cumsum = ct.gather(cumsum, bid, padding_value=0)
     end_idx_cumsum = ct.gather(cumsum, bid + 1, padding_value=0)
-
     start_block = start_idx_cumsum // BLOCK_SIZE
     end_block = (end_idx_cumsum + BLOCK_SIZE - 1) // BLOCK_SIZE
     num_blocks = max(0, end_block - start_block)
@@ -110,27 +122,45 @@ def _moe_align_block_size_stage4_kernel(
         block_idx = start_block + i
         ct.scatter(expert_ids, block_idx, bid)
 
+    expert_idx = ct.arange(NUM_EXPERTS_POW2, dtype=ct.int32)
+    expert_mask = expert_idx < NUM_EXPERTS
+    pre_cnt = ct.gather(tokens_cnts, off_t + expert_idx, mask=expert_mask, padding_value=0)
+    cum_off = ct.gather(cumsum, expert_idx, mask=expert_mask, padding_value=0)
+    running_off = pre_cnt + cum_off  # per-expert global write start for this program
+
     start_idx_tokens = bid * TOKENS_PER_THREAD
-    limit = max(0, min(TOKENS_PER_THREAD, NUMEL - start_idx_tokens))
-    for i in range(limit):
-        current_idx = start_idx_tokens + i
-        current_idx_tile = ct.full((1,), current_idx, dtype=ct.int32)
-        expert_id = ct.gather(topk_ids, current_idx_tile, padding_value=0)
+    sub_arange = ct.arange(SUB_CHUNK, dtype=ct.int32)
+    for sub_start in range(0, TOKENS_PER_THREAD, SUB_CHUNK):
+        tok_offs = start_idx_tokens + sub_start + sub_arange
+        in_range = (tok_offs < NUMEL) & ((sub_start + sub_arange) < TOKENS_PER_THREAD)
+        ids = ct.gather(topk_ids, tok_offs, mask=in_range, padding_value=NUM_EXPERTS)
 
-        off_t_tile = ct.full((1,), off_t, dtype=ct.int32)
-        cnt_offset = off_t_tile + expert_id
-        token_cnt = ct.gather(tokens_cnts, cnt_offset, padding_value=0)
+        match = (ids[:, None] == expert_idx[None, :]).astype(ct.int32)
+        rank_2d = ct.cumsum(match, axis=0) - match  # exclusive prefix per expert column
+        rank_per_token = ct.sum(rank_2d * match, axis=1)  # [SUB_CHUNK]
+        base_per_token = ct.sum(running_off[None, :] * match, axis=1)  # [SUB_CHUNK]
+        rank_post_pad = base_per_token + rank_per_token
 
-        cumsum_val = ct.gather(cumsum, expert_id, padding_value=0)
-        rank_post_pad = token_cnt + cumsum_val
+        ct.scatter(sorted_token_ids, rank_post_pad, tok_offs, mask=in_range)
 
-        ct.scatter(sorted_token_ids, rank_post_pad, current_idx_tile)
-        new_token_cnt = token_cnt + ct.ones((1,), dtype=ct.int32)
-        ct.scatter(tokens_cnts, cnt_offset, new_token_cnt)
+        running_off = running_off + ct.sum(match, axis=0)
 
 
 def _ceil_div(a, b):
     return (a + b - 1) // b
+
+
+# Cap on the vectorized sub-chunk width (tokens processed per inner iteration).
+# Bounds the [SUB_CHUNK, NUM_EXPERTS_POW2] match-matrix working set while still
+# vectorizing the histogram (stage1) and scatter (stage4b) hot loops.
+_SUB_CHUNK_CAP = 256
+
+# Target tokens processed per program. The launcher derives the number of
+# token-processing programs as ceil(numel / this), so large token counts spread
+# across more CTAs / SMs instead of being pinned to num_experts programs. 128
+# keeps each program to a single vectorized sub-chunk iteration (tokens_per_thread
+# <= this <= SUB_CHUNK) while maximizing CTA-level parallelism.
+_TARGET_TOKENS_PER_PROGRAM = 128
 
 
 def _moe_align_block_size(
@@ -146,46 +176,57 @@ def _moe_align_block_size(
     topk_ids_flat = topk_ids.reshape(-1)
 
     numel = topk_ids.numel()
-    grid = (num_experts,)
+
+    # Number of token-processing programs (stage1 / stage4b). Decoupled from
+    # num_experts so large token counts spread across more CTAs (more SMs, fewer
+    # serial sub-chunk iterations per program) instead of only num_experts CTAs.
+    num_programs = max(num_experts, _ceil_div(numel, _TARGET_TOKENS_PER_PROGRAM))
+    tokens_per_thread = _ceil_div(numel, num_programs)
+
     tokens_cnts = torch.zeros(
-        (num_experts + 1, num_experts),
+        (num_programs + 1, num_experts),
         dtype=torch.int32,
         device=topk_ids.device,
     )
     tokens_cnts_flat = tokens_cnts.reshape(-1)
     cumsum = torch.zeros((num_experts + 1,), dtype=torch.int32, device=topk_ids.device)
-    tokens_per_thread = _ceil_div(numel, num_experts)
 
-    # Launch stage 1
-    ct.launch(
-        torch.cuda.current_stream(),
-        grid,
-        _moe_align_block_size_stage1_kernel,
-        (topk_ids_flat, tokens_cnts_flat, num_experts, numel, tokens_per_thread),
-    )
-
-    # Launch stage 2
     num_experts_pow2 = next_power_of_2(num_experts)
+    num_programs_pow2 = next_power_of_2(num_programs)
+    # Vectorized sub-chunk width: power-of-two <= tokens_per_thread, capped so the
+    # match-matrix tile stays bounded for large chunks.
+    sub_chunk = min(next_power_of_2(tokens_per_thread), _SUB_CHUNK_CAP)
+
+    # Launch stage 1 (histogram): one program per token range.
     ct.launch(
         torch.cuda.current_stream(),
-        grid,
-        _moe_align_block_size_stage2_kernel,
-        (tokens_cnts_flat, num_experts, num_experts_pow2),
+        (num_programs,),
+        _moe_align_block_size_stage1_kernel,
+        (topk_ids_flat, tokens_cnts_flat, num_experts, numel, tokens_per_thread, sub_chunk, num_experts_pow2),
     )
 
-    # Launch stage 3
+    # Launch stage 2 (per-expert prefix over programs): one program per expert.
+    ct.launch(
+        torch.cuda.current_stream(),
+        (num_experts,),
+        _moe_align_block_size_stage2_kernel,
+        (tokens_cnts_flat, num_experts, num_programs_pow2),
+    )
+
+    # Launch stage 3 (per-expert padding + totals): single program.
     ct.launch(
         torch.cuda.current_stream(),
         (1,),
         _moe_align_block_size_stage3_kernel,
-        (num_tokens_post_pad, max_expert_cnt, tokens_cnts_flat, cumsum, num_experts, block_size),
+        (num_tokens_post_pad, max_expert_cnt, tokens_cnts_flat, cumsum, num_experts, block_size, num_programs),
     )
 
-    # Launch stage 4
+    # Launch stage 4 (expert_ids stamp + token scatter): one program per token
+    # range; programs 0..num_experts-1 additionally stamp their expert's blocks.
     ct.launch(
         torch.cuda.current_stream(),
-        grid,
-        _moe_align_block_size_stage4_kernel,
+        (num_programs,),
+        _moe_align_block_size_stage4b_scatter_kernel,
         (
             topk_ids_flat,
             sorted_token_ids,
@@ -196,6 +237,8 @@ def _moe_align_block_size(
             block_size,
             numel,
             tokens_per_thread,
+            sub_chunk,
+            num_experts_pow2,
         ),
     )
 

--- a/src/tilegym/ops/cutile/silu_and_mul.py
+++ b/src/tilegym/ops/cutile/silu_and_mul.py
@@ -3,17 +3,25 @@
 # SPDX-License-Identifier: MIT
 
 import functools
+from types import SimpleNamespace
 
 import cuda.tile as ct
 import torch
 from cuda.tile import RoundingMode as RMd
+from cuda.tile.tune import exhaustive_search
 
+from tilegym.autotune import is_autotune_disabled
 from tilegym.backend import register_impl
 from tilegym.experimental import experimental_kernel
 
+from .utils import cached_replace_hints
 from .utils import next_power_of_2
 
 ConstInt = ct.Constant[int]
+
+# Preserve the unhinted compiler default because explicit occupancy can regress some shapes.
+_SILU_OCCUPANCY_CONFIGS = tuple(SimpleNamespace(occupancy=occ) for occ in (None, 1, 2, 4, 8, 12, 16))
+_SILU_TUNE_CACHE: dict = {}
 
 
 # To be launched with grid = number of rows (batch_size)
@@ -119,6 +127,37 @@ def _ensure_contiguous(fn):
     return wrapper
 
 
+def _launch_silu_kernel(kernel, args, grid, cache_key):
+    stream = torch.cuda.current_stream()
+    if is_autotune_disabled():
+        tuned_kernel = kernel
+    else:
+        if cache_key not in _SILU_TUNE_CACHE:
+            result = exhaustive_search(
+                _SILU_OCCUPANCY_CONFIGS,
+                stream,
+                lambda _: grid,
+                kernel,
+                lambda _: args,
+                lambda cfg: {} if cfg.occupancy is None else {"occupancy": cfg.occupancy},
+            )
+            best_cfg = result.best.config
+            tuned_kernel = (
+                kernel if best_cfg.occupancy is None else cached_replace_hints(kernel, occupancy=best_cfg.occupancy)
+            )
+            _SILU_TUNE_CACHE[cache_key] = (best_cfg, tuned_kernel)
+        _, tuned_kernel = _SILU_TUNE_CACHE[cache_key]
+
+    ct.launch(stream, grid, tuned_kernel, args)
+
+
+def _silu_and_mul_forward(input_flat, output, hidden_size):
+    tile_size = next_power_of_2(hidden_size)
+    args = (input_flat, output, tile_size, hidden_size)
+    cache_key = ("fwd", hidden_size, input_flat.dtype, str(input_flat.device))
+    _launch_silu_kernel(_silu_and_mul_kernel_row_wise, args, (input_flat.shape[0],), cache_key)
+
+
 def _silu_and_mul_backward(
     grad_output: torch.Tensor,
     input: torch.Tensor,
@@ -143,14 +182,11 @@ def _silu_and_mul_backward(
     grad_a = torch.empty_like(grad_output_flat)
     grad_b = torch.empty_like(grad_output_flat)
 
-    TILE_SIZE = next_power_of_2(hidden_size)
+    tile_size = next_power_of_2(hidden_size)
     grid = (batch_size,)
-    ct.launch(
-        torch.cuda.current_stream(),
-        grid,
-        _silu_and_mul_backward_kernel_row_wise,
-        (grad_output_flat, input_flat, grad_a, grad_b, TILE_SIZE, hidden_size),
-    )
+    args = (grad_output_flat, input_flat, grad_a, grad_b, tile_size, hidden_size)
+    cache_key = ("bwd", hidden_size, grad_output_flat.dtype, str(grad_output_flat.device))
+    _launch_silu_kernel(_silu_and_mul_backward_kernel_row_wise, args, grid, cache_key)
 
     return grad_a.view(*original_output_shape), grad_b.view(*original_output_shape)
 
@@ -176,16 +212,7 @@ class _SiLUAndMulFunction(torch.autograd.Function):
             device=input.device,
         )
 
-        from .utils import next_power_of_2
-
-        TILE_SIZE = next_power_of_2(hidden_size)
-        grid = (batch_size,)
-        ct.launch(
-            torch.cuda.current_stream(),
-            grid,
-            _silu_and_mul_kernel_row_wise,
-            (input_flat, output, TILE_SIZE, hidden_size),
-        )
+        _silu_and_mul_forward(input_flat, output, hidden_size)
 
         # Reshape output
         output_shape = list(original_shape)
@@ -249,14 +276,5 @@ def silu_and_mul(
             device=input.device,
         )
 
-    from .utils import next_power_of_2
-
-    TILE_SIZE = next_power_of_2(hidden_size)
-    grid = (batch_size,)
-    ct.launch(
-        torch.cuda.current_stream(),
-        grid,
-        _silu_and_mul_kernel_row_wise,
-        (input_flat, output, TILE_SIZE, hidden_size),
-    )
+    _silu_and_mul_forward(input_flat, output, hidden_size)
     return output.reshape(*output_shape)

--- a/src/tilegym/ops/cutile/softmax.py
+++ b/src/tilegym/ops/cutile/softmax.py
@@ -3,17 +3,28 @@
 # SPDX-License-Identifier: MIT
 
 import math
+from types import SimpleNamespace
 
 import cuda.tile as ct
 import torch
 from cuda.tile import RoundingMode as RMd
+from cuda.tile.tune import exhaustive_search
 
+from tilegym.autotune import is_autotune_disabled
 from tilegym.backend import register_impl
 from tilegym.experimental import experimental_kernel
 
+from .utils import cached_replace_hints
 from .utils import next_power_of_2
 
 ConstInt = ct.Constant[int]
+
+_DEFAULT_TMA_OCCUPANCY = 2
+# Occupancy is tuned at first use per (device, dtype, shape) because the optimum
+# depends on the installed compiler and GPU. Each candidate costs one kernel
+# compile, so the grid is kept small.
+_TMA_OCCUPANCY_CANDIDATES = (2, 4, 6, 8)
+_softmax_tma_tune_cache: dict = {}
 
 
 @ct.kernel(occupancy=4)
@@ -79,7 +90,7 @@ def _softmax_kernel_multi_wave_full_row_reg_cached_ldg(
 
 
 # TMA version with static persistent scheduling
-@ct.kernel(occupancy=2)
+@ct.kernel(occupancy=_DEFAULT_TMA_OCCUPANCY)
 def _softmax_kernel_tma(
     output,
     input,
@@ -175,6 +186,35 @@ def _softmax_kernel_chunked(
 
 
 # Launch patterns for the kernels:
+def _softmax_tma_occupancy(input, output, n_rows, n_cols, tile_size, num_sms):
+    """Return the occupancy for the regular-TMA kernel, tuning once per shape."""
+    if is_autotune_disabled():
+        return _DEFAULT_TMA_OCCUPANCY
+
+    cache_key = (str(input.device), input.dtype, n_rows, n_cols)
+    if cache_key not in _softmax_tma_tune_cache:
+
+        def args_fn(cfg):
+            return (output, input, n_rows, n_cols, tile_size)
+
+        def grid_fn(cfg):
+            return (min(num_sms * cfg.occupancy, n_rows), 1, 1)
+
+        def hints_fn(cfg):
+            return {"occupancy": cfg.occupancy}
+
+        result = exhaustive_search(
+            [SimpleNamespace(occupancy=occupancy) for occupancy in _TMA_OCCUPANCY_CANDIDATES],
+            torch.cuda.current_stream(),
+            grid_fn,
+            _softmax_kernel_tma,
+            args_fn,
+            hints_fn,
+        )
+        _softmax_tma_tune_cache[cache_key] = result.best.config.occupancy
+    return _softmax_tma_tune_cache[cache_key]
+
+
 def _launch_softmax_kernel(input, output, TILE_SIZE=1024):
     """
     Launch the basic cuTile softmax kernel with static persistent scheduling
@@ -255,9 +295,10 @@ def _launch_softmax_kernel_tma(
     output = output.contiguous()
 
     NUM_SM = torch.cuda.get_device_properties(input.device).multi_processor_count
-    num_programs = min(NUM_SM * 2, n_rows)
+    occupancy = _softmax_tma_occupancy(input, output, n_rows, original_n_cols, TILE_SIZE, NUM_SM)
+    softmax_kernel_forward = cached_replace_hints(_softmax_kernel_tma, occupancy=occupancy)
+    num_programs = min(NUM_SM * occupancy, n_rows)
     grid = (num_programs, 1, 1)
-    softmax_kernel_forward = _softmax_kernel_tma
 
     ct.launch(
         torch.cuda.current_stream(),

--- a/src/tilegym/ops/cutile/swiglu.py
+++ b/src/tilegym/ops/cutile/swiglu.py
@@ -24,17 +24,17 @@ def _silu(x):
     return x * _sigmoid(x)
 
 
-@ct.kernel
-def _swiglu_forward_kernel(a, b, c, TILE_SIZE: ct.Constant[int]):
+@ct.kernel(occupancy=1, num_worker_warps=8)
+def _swiglu_forward_kernel(a, b, c, TILE_SIZE: ct.Constant[int], check_bounds: ct.Constant[bool]):
     row = ct.bid(0)
     offsets = ct.arange(TILE_SIZE, dtype=ct.int32)
 
-    a_tile = ct.gather(a, (row, offsets), check_bounds=True, padding_value=0.0)
-    b_tile = ct.gather(b, (row, offsets), check_bounds=True, padding_value=0.0)
+    a_tile = ct.gather(a, (row, offsets), check_bounds=check_bounds, padding_value=0.0)
+    b_tile = ct.gather(b, (row, offsets), check_bounds=check_bounds, padding_value=0.0)
 
     a_tile_f32 = a_tile.astype(ct.float32)
     c_tile = _silu(a_tile_f32).astype(a.dtype) * b_tile
-    ct.scatter(c, (row, offsets), c_tile, check_bounds=True)
+    ct.scatter(c, (row, offsets), c_tile, check_bounds=check_bounds)
 
 
 # Backward kernel for swiglu
@@ -88,6 +88,9 @@ def _swiglu_forward(a, b):
     n_rows = a.shape[0]
 
     TILE_SIZE = next_power_of_2(n_cols)
+    # Drop bounds checking only when the power-of-2 tile exactly covers n_cols
+    # (every lane in-bounds); irregular shapes keep masking on the partial tile.
+    check_bounds = TILE_SIZE != n_cols
     grid = (n_rows,)
     ct.launch(
         torch.cuda.current_stream(),
@@ -98,6 +101,7 @@ def _swiglu_forward(a, b):
             b,
             c,
             TILE_SIZE,
+            check_bounds,
         ),
     )
     return c.view(*ori_shape)

--- a/src/tilegym/ops/tilecpp/autotuner.py
+++ b/src/tilegym/ops/tilecpp/autotuner.py
@@ -7,9 +7,9 @@ CUDA Tile C++ Autotuner
 
 Provides autotuning infrastructure for CUDA Tile C++ kernels.
 
-The autotuner is controlled by the TILECPP_AUTOTUNE environment variable:
-- TILECPP_AUTOTUNE=0 (default): Use default configurations
-- TILECPP_AUTOTUNE=1: Enable autotuning to find optimal configurations
+Autotuning follows TILEGYM_DISABLE_AUTOTUNE, the project-wide switch, and so is
+on unless that variable disables it. TILECPP_AUTOTUNE overrides the decision for
+this backend alone: 0 pins the default configurations, anything else searches.
 """
 
 from __future__ import annotations
@@ -24,6 +24,8 @@ from typing import Callable
 from typing import Sequence
 
 import torch
+
+from tilegym.autotune import is_autotune_disabled
 
 logger = logging.getLogger(__name__)
 
@@ -371,5 +373,14 @@ def autotune(search_space):
 
 
 def is_autotuning_enabled() -> bool:
-    """Check if autotuning is enabled via TILECPP_AUTOTUNE environment variable."""
-    return os.environ.get("TILECPP_AUTOTUNE", "0") != "0"
+    """Report whether the search should run for this call.
+
+    TILECPP_AUTOTUNE, when set, decides on its own so that this backend can be
+    pinned to its default configurations while the others keep searching.
+    Otherwise the project-wide TILEGYM_DISABLE_AUTOTUNE switch decides, which
+    leaves autotuning on by default.
+    """
+    override = os.environ.get("TILECPP_AUTOTUNE")
+    if override is not None:
+        return override != "0"
+    return not is_autotune_disabled()

--- a/src/tilegym/ops/tilecpp/dropout.cuh
+++ b/src/tilegym/ops/tilecpp/dropout.cuh
@@ -19,21 +19,18 @@
  * Template Parameters:
  *   T: Element type (float, __half, __nv_bfloat16)
  *   BLOCK_SIZE: Number of elements processed per block (must be power of 2)
+ *   N_ELEMENTS: Number of elements in the tensor
+ *   P: Dropout probability
+ *   SEED: Pre-mixed random seed
  *
  * Parameters:
  *   x_ptr: Pointer to input tensor
  *   output_ptr: Pointer to output tensor
- *   p: Dropout probability (0.0 to 1.0)
- *   seed: Random seed for deterministic dropout mask
- *   n_elements: Number of elements in the tensor
  */
-template<typename T, int BLOCK_SIZE>
+template<typename T, int BLOCK_SIZE, int N_ELEMENTS, float P, uint32_t SEED>
 __tile_global__ void seeded_dropout_kernel(
     const T* __restrict__ x_ptr,
-    T* __restrict__ output_ptr,
-    float p,
-    uint64_t seed,
-    int n_elements
+    T* __restrict__ output_ptr
 ) {
     namespace ct = cuda::tiles;
 
@@ -42,48 +39,58 @@ __tile_global__ void seeded_dropout_kernel(
     output_ptr = ct::assume_aligned<16>(output_ptr);
 
     using TxN = ct::tile<T, ct::shape<BLOCK_SIZE>>;
-    using f32xN = ct::tile<float, ct::shape<BLOCK_SIZE>>;
     using i32xN = ct::tile<int, ct::shape<BLOCK_SIZE>>;
     using u32xN = ct::tile<uint32_t, ct::shape<BLOCK_SIZE>>;
 
     int bid = ct::bid().x;
 
     // p == 1 drops everything; 1/(1-p) would be inf and poison the kept lanes.
-    float scale = (p >= 1.0f) ? 0.0f : 1.0f / (1.0f - p);
+    constexpr float scale = (P >= 1.0f) ? 0.0f : 1.0f / (1.0f - P);
     // Python passes seed already mixed into a 32-bit space via _mix_seed; keep
     // the full 32 bits here. A modulo by a Mersenne prime would alias distinct
     // 32-bit seeds and shrink the effective seed space.
-    int seed_i32 = static_cast<int>(seed);
+    constexpr int seed_i32 = static_cast<int>(SEED);
 
     int tile_start = bid * BLOCK_SIZE;
     auto offsets = ct::iota<i32xN>() + tile_start;
 
-    auto mask = offsets < ct::full<i32xN>(n_elements);
-
-    TxN x_raw = ct::load_masked(x_ptr + offsets, mask, T(0));
-    auto x = ct::element_cast<float>(x_raw);
+    // gather_scatter_view is available starting with CUDA 13.4.
+#if __CUDACC_VER_MAJOR__ > 13 || (__CUDACC_VER_MAJOR__ == 13 && __CUDACC_VER_MINOR__ >= 4)
+    auto x_span = ct::tensor_span{x_ptr, ct::extents<uint32_t, N_ELEMENTS>{}};
+    auto x_view = ct::gather_scatter_view{
+        x_span, ct::shape<BLOCK_SIZE>{}, ct::integral_constant<0>{}};
+    auto x = x_view.load_masked(offsets);
+#else
+    auto mask = offsets < ct::full<i32xN>(N_ELEMENTS);
+    auto x = ct::load_masked(x_ptr + offsets, mask, T(0));
+#endif
 
     // combined = offsets * 1103515245 + seed, computed in uint32 so the
     // multiply wraps; signed overflow would be undefined behaviour.
-    auto combined = ct::element_cast<uint32_t>(offsets) * 1103515245u
-                  + ct::full<u32xN>(static_cast<uint32_t>(seed_i32));
+    auto combined_u32 = ct::element_cast<uint32_t>(offsets) * 1103515245u
+                      + ct::full<u32xN>(static_cast<uint32_t>(seed_i32));
+    auto combined = ct::element_cast<int>(combined_u32);
 
     auto hash_val = combined ^ (combined >> 16);
     hash_val = hash_val ^ (hash_val << 8);
     hash_val = hash_val ^ (hash_val >> 4);
 
     // Convert to float in [0, 1): clear sign bit, cast, normalize
-    auto hash_positive = hash_val & 0x7FFFFFFFu;
+    auto hash_positive = hash_val & 0x7FFFFFFF;
     auto hash_float = ct::element_cast<float>(hash_positive);
     auto random = hash_float / 2147483647.0f;
 
     // x_keep = random > p
-    auto x_keep = random > p;
+    auto x_keep = random > P;
 
-    auto scaled_x = x * scale;
-    auto output_f32 = ct::select(x_keep, scaled_x, ct::zeros<f32xN>());
-
-    // Convert back to T and store using pointer + scatter pattern
-    auto output = ct::element_cast<T>(output_f32);
+    auto scaled_x = x * ct::full<TxN>(scale);
+    auto output = ct::select(x_keep, scaled_x, ct::zeros<TxN>());
+#if __CUDACC_VER_MAJOR__ > 13 || (__CUDACC_VER_MAJOR__ == 13 && __CUDACC_VER_MINOR__ >= 4)
+    auto output_span = ct::tensor_span{output_ptr, ct::extents<uint32_t, N_ELEMENTS>{}};
+    auto output_view = ct::gather_scatter_view{
+        output_span, ct::shape<BLOCK_SIZE>{}, ct::integral_constant<0>{}};
+    output_view.store_masked(output, offsets);
+#else
     ct::store_masked(output_ptr + offsets, output, mask);
+#endif
 }

--- a/src/tilegym/ops/tilecpp/dropout.py
+++ b/src/tilegym/ops/tilecpp/dropout.py
@@ -50,11 +50,19 @@ def _launch_dropout_kernel(
     dtype = x.dtype
 
     num_blocks = (n_elements + block_size - 1) // block_size
+    p_literal = f"{np.float32(p):.9g}"
+    if "." not in p_literal and "e" not in p_literal:
+        p_literal += ".0"
 
     kernel, _, _ = _seeded_dropout_kernel.get_kernel(
         dtype=dtype,
-        template_params=[block_size],
-        signature="const {T}*, {T}*, float, uint64_t, int",
+        template_params=[
+            block_size,
+            n_elements,
+            f"{p_literal}f",
+            f"{_mix_seed(seed)}u",
+        ],
+        signature="const {T}*, {T}*",
     )
 
     _seeded_dropout_kernel.launch(
@@ -63,9 +71,6 @@ def _launch_dropout_kernel(
         args=[
             np.uint64(x.data_ptr()),
             np.uint64(output.data_ptr()),
-            np.float32(p),
-            np.uint64(_mix_seed(seed)),
-            np.int32(n_elements),
         ],
     )
 

--- a/src/tilegym/ops/tilecpp/mla.cuh
+++ b/src/tilegym/ops/tilecpp/mla.cuh
@@ -35,7 +35,11 @@ constexpr float MLA_NEG_INF = -1.0e6f;
  * Prefill MLA Forward Kernel
  */
 template<typename T, int B, int H, int H_KV, int S_QO, int S_KV,
-         int TILE_D, int TILE_KPE, int TILE_M, int TILE_N, int QUERY_GROUP_SIZE, bool IS_CAUSAL>
+         int TILE_D, int TILE_KPE, int TILE_M, int TILE_N, int QUERY_GROUP_SIZE, bool IS_CAUSAL,
+         int NUM_CTAS = 1, int OCCUPANCY = 1>
+[[ using cutile : hint(800,num_cta_in_cga=NUM_CTAS, occupancy=OCCUPANCY) ]]
+[[ using cutile : hint(900,num_cta_in_cga=NUM_CTAS, occupancy=OCCUPANCY) ]]
+[[ using cutile : hint(1000,num_cta_in_cga=NUM_CTAS, occupancy=OCCUPANCY) ]]
 __tile_global__ void prefill_mla_kernel(
     const T* __restrict__ _Q_ptr,
     const T* __restrict__ _QPE_ptr,

--- a/src/tilegym/ops/tilecpp/mla.py
+++ b/src/tilegym/ops/tilecpp/mla.py
@@ -20,8 +20,11 @@ import torch
 
 from tilegym.backend import register_impl
 from tilegym.logger import get_logger
+from tilegym.ops.tilecpp.autotuner import Config
+from tilegym.ops.tilecpp.autotuner import TileCppAutotuner
+from tilegym.ops.tilecpp.autotuner import autotune
+from tilegym.ops.tilecpp.autotuner import is_autotuning_enabled
 from tilegym.ops.tilecpp.utils._cuda_utils import TileCppKernel
-from tilegym.ops.tilecpp.utils._cuda_utils import get_dtype_info
 from tilegym.ops.tilecpp.utils._dump_types import dump_kernel_types
 
 logger = get_logger(__name__)
@@ -40,6 +43,30 @@ _prefill_mla_kernel = TileCppKernel(
     source_path=Path(__file__).parent / "mla.cuh",
     kernel_name="prefill_mla_kernel",
 )
+
+
+def _mla_sm80_autotune_configs():
+    configs = [Config(TILE_M=tm, TILE_N=tn, num_ctas=1, occupancy=2) for tm in [64, 128] for tn in [64, 128]]
+    configs.append(Config(TILE_M=64, TILE_N=64, num_ctas=1, occupancy=3))
+    return configs
+
+
+def _mla_sm90_autotune_configs():
+    configs = [Config(TILE_M=tm, TILE_N=tn, num_ctas=1, occupancy=1) for tm in [64, 128, 256] for tn in [64, 128]]
+    configs.extend(Config(TILE_M=tm, TILE_N=tn, num_ctas=1, occupancy=2) for tm in [64, 128] for tn in [64, 128])
+    return configs
+
+
+def _mla_autotune_configs():
+    gpu_capability = torch.cuda.get_device_capability()
+    return _mla_sm80_autotune_configs() if gpu_capability[0] < 9 else _mla_sm90_autotune_configs()
+
+
+def _default_mla_config():
+    gpu_capability = torch.cuda.get_device_capability()
+    if gpu_capability[0] < 9:
+        return Config(TILE_M=128, TILE_N=128, num_ctas=1, occupancy=2)
+    return Config(TILE_M=256, TILE_N=128, num_ctas=1, occupancy=1)
 
 
 def _get_cpp_type(dtype: torch.dtype) -> str:
@@ -75,6 +102,8 @@ def _launch_prefill_mla_kernel(
     TILE_N: int,
     QUERY_GROUP_SIZE: int,
     IS_CAUSAL: bool,
+    num_ctas: int = 1,
+    occupancy: int = 1,
 ):
     """Launch the prefill MLA kernel."""
     dtype = Q.dtype
@@ -82,8 +111,21 @@ def _launch_prefill_mla_kernel(
 
     dump_kernel_types("prefill_mla_kernel", Q, QPE, K, KPE, V)
 
-    # Template params: B, H, H_KV, S_QO, S_KV, TILE_D, TILE_KPE, TILE_M, TILE_N, QUERY_GROUP_SIZE, IS_CAUSAL
-    template_params = [B, H, H_KV, S_QO, S_KV, TILE_D, TILE_KPE, TILE_M, TILE_N, QUERY_GROUP_SIZE, IS_CAUSAL]
+    template_params = [
+        B,
+        H,
+        H_KV,
+        S_QO,
+        S_KV,
+        TILE_D,
+        TILE_KPE,
+        TILE_M,
+        TILE_N,
+        QUERY_GROUP_SIZE,
+        IS_CAUSAL,
+        num_ctas,
+        occupancy,
+    ]
 
     # Simplified signature: just pointers + scale (all dims are template params)
     kernel, _, _ = _prefill_mla_kernel.get_kernel(
@@ -107,6 +149,74 @@ def _launch_prefill_mla_kernel(
             np.uint64(Out.data_ptr()),
             np.float32(sm_scale),
         ],
+    )
+
+
+@autotune(search_space=_mla_autotune_configs())
+def _autotune_prefill_mla(
+    q,
+    qpe,
+    k,
+    kpe,
+    v,
+    out,
+    sm_scale,
+    is_causal,
+    query_group_size,
+    autotuner: TileCppAutotuner | None = None,
+):
+    B, H, S_qo, TILE_D = q.shape
+    H_kv = k.shape[1]
+    S_kv = k.shape[2]
+    TILE_KPE = qpe.shape[3]
+    key = (
+        "tilecpp_mla",
+        B,
+        H,
+        H_kv,
+        S_qo,
+        S_kv,
+        TILE_D,
+        TILE_KPE,
+        query_group_size,
+        is_causal,
+        q.dtype,
+        str(q.device),
+    )
+
+    def launch_fn(cfg: Config):
+        _launch_prefill_mla_kernel(
+            q,
+            qpe,
+            k,
+            kpe,
+            v,
+            out,
+            sm_scale,
+            B,
+            H,
+            H_kv,
+            S_qo,
+            S_kv,
+            TILE_D,
+            TILE_KPE,
+            cfg.TILE_M,
+            cfg.TILE_N,
+            query_group_size,
+            is_causal,
+            num_ctas=cfg.num_ctas,
+            occupancy=cfg.occupancy,
+        )
+
+    def grid_fn(_args: dict, cfg: Config) -> tuple:
+        return (cdiv(S_qo, cfg.TILE_M), B * H, 1)
+
+    autotuner(
+        torch.cuda.current_stream(),
+        key=key,
+        launch_fn=launch_fn,
+        grid_fn=grid_fn,
+        named_args={},
     )
 
 
@@ -149,31 +259,41 @@ class _attention(torch.autograd.Function):
             assert H % H_kv == 0
             query_group_size = int(H / H_kv)
 
-        TILE_M = kernel_configs.get("TILE_M", 256)
-        TILE_N = kernel_configs.get("TILE_N", 128)
-
-        dump_kernel_types("prefill_mla", q, qpe, k, kpe, v)
-
-        _launch_prefill_mla_kernel(
-            q,
-            qpe,
-            k,
-            kpe,
-            v,
-            o,
-            sm_scale,
-            B,
-            H,
-            H_kv,
-            S_qo,
-            S_kv,
-            TILE_D,
-            TILE_KPE,
-            TILE_M,
-            TILE_N,
-            query_group_size,
-            IS_CAUSAL,
-        )
+        if kernel_configs is None:
+            _autotune_prefill_mla(
+                q,
+                qpe,
+                k,
+                kpe,
+                v,
+                o,
+                sm_scale,
+                IS_CAUSAL,
+                query_group_size,
+            )
+        else:
+            _launch_prefill_mla_kernel(
+                q,
+                qpe,
+                k,
+                kpe,
+                v,
+                o,
+                sm_scale,
+                B,
+                H,
+                H_kv,
+                S_qo,
+                S_kv,
+                TILE_D,
+                TILE_KPE,
+                kernel_configs["TILE_M"],
+                kernel_configs["TILE_N"],
+                query_group_size,
+                IS_CAUSAL,
+                num_ctas=kernel_configs["num_ctas"],
+                occupancy=kernel_configs["occupancy"],
+            )
 
         ctx.save_for_backward(q, k, v, o)
         ctx.sm_scale = sm_scale
@@ -219,12 +339,18 @@ def tilecpp_mla(q, k, v, qpe, kpe, is_causal, scaling, **kwargs):
     if scaling is None:
         scaling = 1.0 / math.sqrt(q.size(-1) + qpe.size(-1))
 
-    defaults = {"TILE_M": 256, "TILE_N": 128}
     user_cfg = kwargs.get("kernel_configs")
-    if user_cfg is None:
-        kernel_configs = defaults
+    if user_cfg is None and is_autotuning_enabled():
+        kernel_configs = None
     else:
-        kernel_configs = {**defaults, **user_cfg}
+        default_cfg = _default_mla_config()
+        user_cfg = user_cfg or {}
+        kernel_configs = {
+            "TILE_M": user_cfg.get("TILE_M", user_cfg.get("BLOCK_M", default_cfg.TILE_M)),
+            "TILE_N": user_cfg.get("TILE_N", user_cfg.get("BLOCK_N", default_cfg.TILE_N)),
+            "num_ctas": user_cfg.get("num_ctas", default_cfg.num_ctas),
+            "occupancy": user_cfg.get("occupancy", default_cfg.occupancy),
+        }
 
     attention = Attention(is_causal, kernel_configs)
     o = attention(q, k, v, scaling, qpe, kpe)

--- a/src/tilegym/ops/tilecpp/mla_decoding.cuh
+++ b/src/tilegym/ops/tilecpp/mla_decoding.cuh
@@ -88,14 +88,12 @@ __tile_global__ void naive_absorb_mla(
     auto q_flat_offs = offs_h_2d * stride_qm + offs_d_2d;
     auto q_ptrs = Q_base + q_flat_offs;
     auto q_mask = ct::reshape(offs_h + ct::full<i32_H>(pid_x * BLOCK_H) < num_head, ct::shape<BLOCK_H, 1>{});
-    auto q_t = ct::load_masked(q_ptrs, q_mask, zero_tile<T>());
-    auto q = ct::element_cast<float>(q_t);
+    auto q = ct::load_masked(q_ptrs, q_mask, zero_tile<T>());
 
     // Load QPE: [BLOCK_H, BLOCK_KPE]
     auto qpe_flat_offs = offs_h_2d * stride_qpem + offs_kpe_2d;
     auto qpe_ptrs = QPE_base + qpe_flat_offs;
-    auto qpe_t = ct::load_masked(qpe_ptrs, q_mask, zero_tile<T>());
-    auto qpe = ct::element_cast<float>(qpe_t);
+    auto qpe = ct::load_masked(qpe_ptrs, q_mask, zero_tile<T>());
 
     // Initialize accumulators
     auto m_i = ct::full<f32_H>(-1e30f);
@@ -111,13 +109,11 @@ __tile_global__ void naive_absorb_mla(
         auto k_flat_offs = k_row_2d * stride_kvn + offs_d_2d;
         auto k_ptrs = KV_base + k_flat_offs;
         auto k_mask = ct::reshape(k_row_base < S_kv, ct::shape<BLOCK_N, 1>{});
-        auto k_t = ct::load_masked(k_ptrs, k_mask, zero_tile<T>());
-        auto k = ct::element_cast<float>(k_t);  // [BLOCK_N, BLOCK_D]
+        auto k = ct::load_masked(k_ptrs, k_mask, zero_tile<T>());  // [BLOCK_N, BLOCK_D]
 
         auto kpe_flat_offs = k_row_2d * stride_kpem + offs_kpe_2d;
         auto kpe_ptrs = KPE_base + kpe_flat_offs;
-        auto kpe_block_t = ct::load_masked(kpe_ptrs, k_mask, zero_tile<T>());
-        auto kpe_block = ct::element_cast<float>(kpe_block_t);  // [BLOCK_N, BLOCK_KPE]
+        auto kpe_block = ct::load_masked(kpe_ptrs, k_mask, zero_tile<T>());  // [BLOCK_N, BLOCK_KPE]
 
         // Compute QK = Q @ K^T: [BLOCK_H, BLOCK_D] @ [BLOCK_D, BLOCK_N] = [BLOCK_H, BLOCK_N]
         auto k_trans = ct::transpose(k);  // [BLOCK_D, BLOCK_N]
@@ -148,18 +144,16 @@ __tile_global__ void naive_absorb_mla(
         auto alpha_2d = ct::reshape(alpha, ct::shape<BLOCK_H, 1>{});
         acc = acc * alpha_2d;
 
-        auto v_t = ct::load_masked(k_ptrs, k_mask, zero_tile<T>());
-        auto v = ct::element_cast<float>(v_t);
+        auto v = ct::load_masked(k_ptrs, k_mask, zero_tile<T>());
 
-        // Accumulate: acc += P @ V: [BLOCK_H, BLOCK_N] @ [BLOCK_N, BLOCK_D]
-        acc = ct::mma(p, v, acc);
+        acc = ct::mma(ct::element_cast<T>(p), v, acc);
 
         m_i = m_ij;
     }
 
     // Finalize: output = acc / l_i
     auto l_i_2d = ct::reshape(l_i, ct::shape<BLOCK_H, 1>{});
-    auto output = acc / l_i_2d;
+    auto output = ct::div(acc, l_i_2d, ct::round_approximate_t{}, ct::round_subnormals_to_zero_t{});
 
     // Store output: [BLOCK_H, BLOCK_D]
     T* O_base = Out + batch_idx * stride_ob + pid_x * BLOCK_H * stride_om;
@@ -185,7 +179,7 @@ __tile_global__ void naive_absorb_mla(
  * Computes: QK = K @ Q^T + KPE @ QPE^T (in transposed [N, H] order)
  * Then transposes back for final output.
  */
-template<typename T, int BLOCK_D, int BLOCK_H, int BLOCK_N, int BLOCK_KPE>
+template<typename T, int BLOCK_D, int BLOCK_H, int BLOCK_N, int BLOCK_KPE, int EVEN_STRIDES>
 __tile_global__ void naive_absorb_mla_transpose(
     T* __restrict__ Q, T* __restrict__ QPE,
     T* __restrict__ KV, T* __restrict__ KPE_in,
@@ -202,6 +196,15 @@ __tile_global__ void naive_absorb_mla_transpose(
     KPE_in = ct::assume_aligned<16>(KPE_in);
     Out    = ct::assume_aligned<16>(Out);
     L      = ct::assume_aligned<16>(L);
+
+    if constexpr (EVEN_STRIDES) {
+        using tma_elems_t = ct::integral_constant<static_cast<int>(16 / sizeof(T))>;
+        stride_qm = ct::assume_divisible(stride_qm, tma_elems_t{});
+        stride_qpem = ct::assume_divisible(stride_qpem, tma_elems_t{});
+        stride_kvn = ct::assume_divisible(stride_kvn, tma_elems_t{});
+        stride_kpem = ct::assume_divisible(stride_kpem, tma_elems_t{});
+        stride_om = ct::assume_divisible(stride_om, tma_elems_t{});
+    }
 
     // Tile type definitions - use float for accumulation
     using f32_HxD = ct::tile<float, ct::shape<BLOCK_H, BLOCK_D>>;
@@ -226,37 +229,37 @@ __tile_global__ void naive_absorb_mla_transpose(
     int batch_idx = ct::bid().y;
     float qk_scale = sm_scale * INV_LOG_2;
 
-    // Base pointers
-    T* Q_base = Q + batch_idx * stride_qb + pid_x * BLOCK_H * stride_qm;
-    T* QPE_base = QPE + batch_idx * stride_qpeb + pid_x * BLOCK_H * stride_qpem;
-    T* KV_base = KV + batch_idx * stride_kvb;
-    T* KPE_base = KPE_in + batch_idx * stride_kpeb;
+    auto q_view = ct::partition_view{
+        ct::tensor_span{Q + batch_idx * stride_qb,
+                        ct::layout_strided_mapping{
+                            ct::extents{ct::integral_constant<BLOCK_D>{}, num_head},
+                            ct::extents{ct::integral_constant<1>{}, stride_qm}}},
+        ct::shape<BLOCK_D, BLOCK_H>{}};
+    auto qpe_view = ct::partition_view{
+        ct::tensor_span{QPE + batch_idx * stride_qpeb,
+                        ct::layout_strided_mapping{
+                            ct::extents{ct::integral_constant<BLOCK_KPE>{}, num_head},
+                            ct::extents{ct::integral_constant<1>{}, stride_qpem}}},
+        ct::shape<BLOCK_KPE, BLOCK_H>{}};
+    auto kv_view = ct::partition_view{
+        ct::tensor_span{KV + batch_idx * stride_kvb,
+                        ct::layout_strided_mapping{
+                            ct::extents{S_kv, ct::integral_constant<BLOCK_D>{}},
+                            ct::extents{stride_kvn, ct::integral_constant<1>{}}}},
+        ct::shape<BLOCK_N, BLOCK_D>{}};
+    auto kpe_view = ct::partition_view{
+        ct::tensor_span{KPE_in + batch_idx * stride_kpeb,
+                        ct::layout_strided_mapping{
+                            ct::extents{S_kv, ct::integral_constant<BLOCK_KPE>{}},
+                            ct::extents{stride_kpem, ct::integral_constant<1>{}}}},
+        ct::shape<BLOCK_N, BLOCK_KPE>{}};
 
-    // Generate 1D offset tiles
     auto offs_h = ct::iota<i32_H>();
-    auto offs_d = ct::iota<i32_D>();
-    auto offs_kpe = ct::iota<i32_KPE>();
     auto offs_n = ct::iota<i32_N>();
 
-    // Reshape to 2D for broadcasting
-    auto offs_h_2d = ct::reshape(offs_h, ct::shape<BLOCK_H, 1>{});
-    auto offs_d_2d = ct::reshape(offs_d, ct::shape<1, BLOCK_D>{});
-    auto offs_kpe_2d = ct::reshape(offs_kpe, ct::shape<1, BLOCK_KPE>{});
+    auto q = q_view.load_masked(0, pid_x);
 
-    // Load Q: [BLOCK_H, BLOCK_D] and transpose to [BLOCK_D, BLOCK_H]
-    auto q_flat_offs = offs_h_2d * stride_qm + offs_d_2d;
-    auto q_ptrs = Q_base + q_flat_offs;
-    auto q_mask = ct::reshape(offs_h + ct::full<i32_H>(pid_x * BLOCK_H) < num_head, ct::shape<BLOCK_H, 1>{});
-    auto q_hd_t = ct::load_masked(q_ptrs, q_mask, zero_tile<T>());
-    auto q_hd = ct::element_cast<float>(q_hd_t);  // [BLOCK_H, BLOCK_D]
-    auto q = ct::transpose(q_hd);  // [BLOCK_D, BLOCK_H]
-
-    // Load QPE: [BLOCK_H, BLOCK_KPE] and transpose to [BLOCK_KPE, BLOCK_H]
-    auto qpe_flat_offs = offs_h_2d * stride_qpem + offs_kpe_2d;
-    auto qpe_ptrs = QPE_base + qpe_flat_offs;
-    auto qpe_hk_t = ct::load_masked(qpe_ptrs, q_mask, zero_tile<T>());
-    auto qpe_hk = ct::element_cast<float>(qpe_hk_t);  // [BLOCK_H, BLOCK_KPE]
-    auto qpe = ct::transpose(qpe_hk);  // [BLOCK_KPE, BLOCK_H]
+    auto qpe = qpe_view.load_masked(0, pid_x);
 
     // Initialize accumulators in transposed layout [BLOCK_D, BLOCK_H]
     auto m_i = ct::full<f32_H>(-1e30f);
@@ -270,17 +273,8 @@ __tile_global__ void naive_absorb_mla_transpose(
         int curr_n = block_idx * BLOCK_N;
 
         auto k_row_base = ct::full<i32_N>(curr_n) + offs_n;
-        auto k_row_2d = ct::reshape(k_row_base, ct::shape<BLOCK_N, 1>{});
-        auto k_flat_offs = k_row_2d * stride_kvn + offs_d_2d;
-        auto k_ptrs = KV_base + k_flat_offs;
-        auto k_mask = ct::reshape(k_row_base < S_kv, ct::shape<BLOCK_N, 1>{});
-        auto k_t = ct::load_masked(k_ptrs, k_mask, zero_tile<T>());
-        auto k = ct::element_cast<float>(k_t);  // [BLOCK_N, BLOCK_D]
-
-        auto kpe_flat_offs = k_row_2d * stride_kpem + offs_kpe_2d;
-        auto kpe_ptrs = KPE_base + kpe_flat_offs;
-        auto kpe_block_t = ct::load_masked(kpe_ptrs, k_mask, zero_tile<T>());
-        auto kpe_block = ct::element_cast<float>(kpe_block_t);  // [BLOCK_N, BLOCK_KPE]
+        auto k = kv_view.load_masked(block_idx, 0);  // [BLOCK_N, BLOCK_D]
+        auto kpe_block = kpe_view.load_masked(block_idx, 0);  // [BLOCK_N, BLOCK_KPE]
 
         // Compute QK = K @ Q^T: [BLOCK_N, BLOCK_D] @ [BLOCK_D, BLOCK_H] = [BLOCK_N, BLOCK_H]
         auto qk = ct::mma(k, q, ct::zeros<f32_NxH>());  // [BLOCK_N, BLOCK_H]
@@ -313,12 +307,10 @@ __tile_global__ void naive_absorb_mla_transpose(
         acc = acc * alpha_bcast;
 
         // Load V: [BLOCK_N, BLOCK_D] and transpose to [BLOCK_D, BLOCK_N]
-        auto v_t = ct::load_masked(k_ptrs, k_mask, zero_tile<T>());
-        auto v = ct::element_cast<float>(v_t);  // [BLOCK_N, BLOCK_D]
+        auto v = kv_view.load_masked(block_idx, 0);  // [BLOCK_N, BLOCK_D]
         auto v_trans = ct::transpose(v);  // [BLOCK_D, BLOCK_N]
 
-        // Accumulate: acc += V^T @ P: [BLOCK_D, BLOCK_N] @ [BLOCK_N, BLOCK_H] = [BLOCK_D, BLOCK_H]
-        acc = ct::mma(v_trans, p, acc);
+        acc = ct::mma(v_trans, ct::element_cast<T>(p), acc);
 
         m_i = m_ij;
     }
@@ -329,19 +321,22 @@ __tile_global__ void naive_absorb_mla_transpose(
 
     // Finalize: output = acc / l_sum, transposed back to [BLOCK_H, BLOCK_D]
     auto l_sum_bcast = ct::reshape(l_sum, ct::shape<1, BLOCK_H>{});
-    acc = acc / l_sum_bcast;  // [BLOCK_D, BLOCK_H]
-    auto output = ct::transpose(acc);  // [BLOCK_H, BLOCK_D]
+    acc = ct::div(acc, l_sum_bcast, ct::round_approximate_t{},
+                  ct::round_subnormals_to_zero_t{});  // [BLOCK_D, BLOCK_H]
+    auto output = ct::transpose(ct::element_cast<T>(acc));  // [BLOCK_H, BLOCK_D]
 
     // Store output: [BLOCK_H, BLOCK_D]
-    T* O_base = Out + batch_idx * stride_ob + pid_x * BLOCK_H * stride_om;
-    auto o_flat_offs = offs_h_2d * stride_om + offs_d_2d;
-    auto o_ptrs = O_base + o_flat_offs;
-    ct::store_masked(o_ptrs, ct::element_cast<T>(output), q_mask);
+    auto o_view = ct::partition_view{
+        ct::tensor_span{Out + batch_idx * stride_ob,
+                        ct::layout_strided_mapping{
+                            ct::extents{num_head, ct::integral_constant<BLOCK_D>{}},
+                            ct::extents{stride_om, ct::integral_constant<1>{}}}},
+        ct::shape<BLOCK_H, BLOCK_D>{}};
+    o_view.store_masked(output, pid_x, 0);
 
     // Store L = m_i + log2(l_sum): [BLOCK_H]
-    float* L_base = L + batch_idx * num_head + pid_x * BLOCK_H;
-    auto l_result = m_i + ct::log2(l_sum);
-    auto l_ptrs = L_base + offs_h;
-    auto l_mask = offs_h + ct::full<i32_H>(pid_x * BLOCK_H) < num_head;
-    ct::store_masked(l_ptrs, l_result, l_mask);
+    auto l_view = ct::partition_view{
+        ct::tensor_span{L + batch_idx * num_head, ct::extents{num_head}},
+        ct::shape<BLOCK_H>{}};
+    l_view.store_masked(m_i + ct::log2(l_sum), pid_x);
 }

--- a/src/tilegym/ops/tilecpp/mla_decoding.py
+++ b/src/tilegym/ops/tilecpp/mla_decoding.py
@@ -72,10 +72,15 @@ def _launch_mla_decoding_kernel(
     # Select kernel
     kernel_wrapper = _naive_absorb_mla_transpose_kernel if transpose else _naive_absorb_mla_kernel
 
+    tma_elems = 16 // q.element_size()
+    even_strides = all(
+        s % tma_elems == 0 for s in (q.stride(1), qpe.stride(1), kv.stride(1), kpe.stride(1), out.stride(1))
+    )
+
     # Get kernel with template parameters
     kernel, _, _ = kernel_wrapper.get_kernel(
         dtype=dtype,
-        template_params=[BLOCK_D, BLOCK_H, BLOCK_N, BLOCK_KPE],
+        template_params=[BLOCK_D, BLOCK_H, BLOCK_N, BLOCK_KPE] + ([int(even_strides)] if transpose else []),
         signature="{T}*, {T}*, {T}*, {T}*, {T}*, float*, float, "
         "long long, int, long long, int, long long, int, long long, int, long long, int, int, int, int",
     )
@@ -136,7 +141,7 @@ class _mla_decoding(torch.autograd.Function):
         # BLOCK_D and BLOCK_KPE are determined by input dimensions
         # BLOCK_H and BLOCK_N are tuning parameters
         BLOCK_H = min(32, _next_power_of_2(num_head))
-        BLOCK_N = 64  # Default block size for sequence dimension
+        BLOCK_N = 64
 
         _launch_mla_decoding_kernel(
             q=q,

--- a/src/tilegym/ops/tilecpp/persistent_layer_norm.cuh
+++ b/src/tilegym/ops/tilecpp/persistent_layer_norm.cuh
@@ -84,9 +84,11 @@ __tile_global__ void persistent_layer_norm_fwd_kernel(
         ct::tensor_span{Rstd, ExtN{}},
         ct::shape<BLOCK_N>{});
 
-    // Load weights once (hoisted out of the grid-stride loop).
-    auto w = ct::element_cast<float>(pW.load(0));  // (BLOCK_D,)
-    auto b = ct::element_cast<float>(pB.load(0));  // (BLOCK_D,)
+    // Load weights once (hoisted out of the grid-stride loop). BLOCK_D is
+    // next_pow2(D), so the tile is wider than the tensor whenever D is not a
+    // power of two; the masked loads zero-fill the tail.
+    auto w = ct::element_cast<float>(pW.load_masked(0));  // (BLOCK_D,)
+    auto b = ct::element_cast<float>(pB.load_masked(0));  // (BLOCK_D,)
 
     // Broadcast weights into (BLOCK_N, BLOCK_D) by reshape to (1, BLOCK_D).
     auto w_bcast = ct::reshape<ct::shape<1, BLOCK_D>>(w);
@@ -101,7 +103,7 @@ __tile_global__ void persistent_layer_norm_fwd_kernel(
     for (auto current_pid : ct::irange(pid, upper_bound, NUM_SMS)) {
         TileXNxD x_tile;
         [[ using cutile : hint(1000, latency=4) ]]
-        x_tile = pX.load(current_pid, 0);
+        x_tile = pX.load_masked(current_pid, 0);
         auto x = ct::element_cast<float>(x_tile);
 
         f32_N mean;
@@ -122,13 +124,13 @@ __tile_global__ void persistent_layer_norm_fwd_kernel(
 
             if constexpr (TRAINING) {
                 [[ using cutile : hint(1000, allow_tma=false) ]]
-                pMean.store(mean, current_pid);
+                pMean.store_masked(mean, current_pid);
                 [[ using cutile : hint(1000, allow_tma=false) ]]
-                pRstd.store(rstd, current_pid);
+                pRstd.store_masked(rstd, current_pid);
             }
         } else {
-            mean = pMean.load(current_pid);
-            rstd = pRstd.load(current_pid);
+            mean = pMean.load_masked(current_pid);
+            rstd = pRstd.load_masked(current_pid);
         }
 
         // Broadcast mean/rstd to (BLOCK_N, 1) then rely on implicit broadcast
@@ -147,6 +149,6 @@ __tile_global__ void persistent_layer_norm_fwd_kernel(
 
         auto y_T = ct::element_cast<T>(y_f32);
         [[ using cutile : hint(1000, allow_tma=false) ]]
-        pY.store(y_T, current_pid, 0);
+        pY.store_masked(y_T, current_pid, 0);
     }
 }

--- a/src/tilegym/ops/tilecpp/persistent_layer_norm.py
+++ b/src/tilegym/ops/tilecpp/persistent_layer_norm.py
@@ -194,11 +194,6 @@ def _persistent_layer_norm_fwd(x, weight, bias, eps, mean=None, rstd=None):
         rstd = torch.empty((N,), dtype=torch.float32, device=x.device)
 
     BLOCK_D = _next_power_of_2(D)
-    if BLOCK_D != D:
-        raise ValueError(
-            f"persistent_layer_norm requires the last dimension D to be a power of two "
-            f"(got D={D}); the kernel does unmasked tile loads of size BLOCK_D=next_pow2(D)."
-        )
 
     gpu_capability = torch.cuda.get_device_capability(x.device)
     enable_autotune = is_autotuning_enabled() and gpu_capability[0] >= 9

--- a/src/tilegym/ops/tilecpp/rope.cuh
+++ b/src/tilegym/ops/tilecpp/rope.cuh
@@ -42,7 +42,9 @@
  */
 template<typename T, typename CT, typename ST, int BATCH, int Q_HEADS, int K_HEADS,
          int BLOCK_QH, int BLOCK_KH, int BLOCK_HD,
-         int HALF_ROPE_DIM, int HEAD_DIM, int COS_BS, int SEQ_LEN>
+         int HALF_ROPE_DIM, int HEAD_DIM, int COS_BS, int SEQ_LEN,
+         int Q_STRIDE_B, int Q_STRIDE_H, int Q_STRIDE_S,
+         int K_STRIDE_B, int K_STRIDE_H, int K_STRIDE_S>
 __tile_global__ void rope_kernel(
     T* __restrict__ q,    // [batch, n_q_heads, seq_len, head_dim]
     T* __restrict__ k,    // [batch, n_kv_heads, seq_len, head_dim]
@@ -78,8 +80,11 @@ __tile_global__ void rope_kernel(
     // Process Q tensor - 4D view over head_dim. Tile indices 0 and 1 along the
     // head_dim axis cover [0:2*BLOCK_HD) == [0:rope_dim); any elements at
     // [rope_dim:HEAD_DIM) are not accessed and pass through unchanged (in-place).
-    auto pQ = ct::partition_view(ct::tensor_span{q, ct::extents{BATCH, Q_HEADS, SEQ_LEN, HEAD_DIM}},
-                                 ct::shape<1, BLOCK_QH, 1, BLOCK_HD>{});
+    auto pQ = ct::partition_view(
+        ct::tensor_span{q, ct::layout_strided_mapping{
+            ct::extents<uint32_t, BATCH, Q_HEADS, SEQ_LEN, HEAD_DIM>{},
+            ct::extents<uint32_t, Q_STRIDE_B, Q_STRIDE_H, Q_STRIDE_S, 1>{}}},
+        ct::shape<1, BLOCK_QH, 1, BLOCK_HD>{});
     auto q_tile_1_loaded = pQ.load(batch_idx, 0, row_idx, 0);
     auto q_tile_1 = ct::element_cast<CompT>(ct::reshape<ct::shape<BLOCK_QH, BLOCK_HD>>(q_tile_1_loaded));
 
@@ -100,8 +105,11 @@ __tile_global__ void rope_kernel(
     pQ.store(new_q_tile_2_reshaped, batch_idx, 0, row_idx, 1);
 
     // Process K tensor
-    auto pK = ct::partition_view(ct::tensor_span{k, ct::extents{BATCH, K_HEADS, SEQ_LEN, HEAD_DIM}},
-                                 ct::shape<1, BLOCK_KH, 1, BLOCK_HD>{});
+    auto pK = ct::partition_view(
+        ct::tensor_span{k, ct::layout_strided_mapping{
+            ct::extents<uint32_t, BATCH, K_HEADS, SEQ_LEN, HEAD_DIM>{},
+            ct::extents<uint32_t, K_STRIDE_B, K_STRIDE_H, K_STRIDE_S, 1>{}}},
+        ct::shape<1, BLOCK_KH, 1, BLOCK_HD>{});
     auto k_tile_1_loaded = pK.load(batch_idx, 0, row_idx, 0);
     auto k_tile_1 = ct::element_cast<CompT>(ct::reshape<ct::shape<BLOCK_KH, BLOCK_HD>>(k_tile_1_loaded));
 

--- a/src/tilegym/ops/tilecpp/rope.py
+++ b/src/tilegym/ops/tilecpp/rope.py
@@ -95,8 +95,6 @@ def rope_forward(q, k, cos, sin, rope_dim=None):
 
     n_row = batch_size * seq_len
 
-    q = q.contiguous()
-    k = k.contiguous()
     cos = cos.contiguous()
     sin = sin.contiguous()
 
@@ -120,6 +118,12 @@ def rope_forward(q, k, cos, sin, rope_dim=None):
         head_dim,
         cos_bs,
         seq_len,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
     ]
 
     kernel, _, _ = _rope_forward_kernel.get_kernel(

--- a/src/tilegym/ops/tilecpp/softmax.cuh
+++ b/src/tilegym/ops/tilecpp/softmax.cuh
@@ -32,7 +32,7 @@
  *   n_cols: Number of columns (power of 2, must equal BLOCK_SIZE)
  *   num_programs: Total number of CTA programs for persistent scheduling
  */
-template<typename T, int BLOCK_SIZE>
+template<typename T, int BLOCK_SIZE, int TMA_ROWS>
 __tile_global__ void softmax_kernel(
     T* __restrict__ _output,
     const T* __restrict__ _input,
@@ -56,6 +56,34 @@ __tile_global__ void softmax_kernel(
     // Persistent scheduling: each program handles multiple rows
     int row_start = ct::bid().x;
     int row_step = num_programs;
+
+    if constexpr (TMA_ROWS) {
+        constexpr int TMA_ELEMS = static_cast<int>(16 / sizeof(T));
+        using tma_elems_t = ct::integral_constant<TMA_ELEMS>;
+        input_row_stride = ct::assume_divisible(input_row_stride, tma_elems_t{});
+        output_row_stride = ct::assume_divisible(output_row_stride, tma_elems_t{});
+
+        for (auto row_idx : ct::irange(row_start, n_rows, row_step)) {
+            auto pIn = ct::partition_view{
+                ct::tensor_span{input + row_idx * input_row_stride,
+                                ct::extents{ct::integral_constant<BLOCK_SIZE>{}}},
+                ct::shape<BLOCK_SIZE>{}};
+            auto pOut = ct::partition_view{
+                ct::tensor_span{output + row_idx * output_row_stride,
+                                ct::extents{ct::integral_constant<BLOCK_SIZE>{}}},
+                ct::shape<BLOCK_SIZE>{}};
+
+            auto row = ct::element_cast<float>(pIn.load(0));
+            float row_max = static_cast<float>(ct::reduce_max(row, 0_ic));
+            auto numerator = ct::exp(row - row_max);
+            float denominator = static_cast<float>(ct::sum(numerator, 0_ic));
+            auto softmax_output = ct::div(numerator, ct::full<f32xN>(denominator),
+                                         ct::round_approximate_t{},
+                                         ct::round_subnormals_to_zero_t{});
+            pOut.store(ct::element_cast<T>(softmax_output), 0);
+        }
+        return;
+    }
 
     for (auto row_idx : ct::irange(row_start, n_rows, row_step)) {
         // row_start_ptr = input + row_idx * input_row_stride
@@ -85,8 +113,9 @@ __tile_global__ void softmax_kernel(
 
         float denominator = static_cast<float>(ct::sum(numerator, 0_ic));
 
-        // softmax_output = numerator / denominator
-        auto softmax_output = numerator / denominator;
+        auto softmax_output = ct::div(numerator, ct::full<f32xN>(denominator),
+                                     ct::round_approximate_t{},
+                                     ct::round_subnormals_to_zero_t{});
 
         // Convert back to output type and store (only valid columns)
         auto softmax_output_T = ct::element_cast<T>(softmax_output);

--- a/src/tilegym/ops/tilecpp/softmax.py
+++ b/src/tilegym/ops/tilecpp/softmax.py
@@ -95,9 +95,18 @@ def _launch_softmax_forward(
     dump_kernel_types("softmax_kernel", input_tensor, output_tensor)
     dtype = input_tensor.dtype
 
+    TMA_MIN_ROW_BYTES = 32768
+    tma_elems = 16 // input_tensor.element_size()
+    tma_rows = int(
+        n_cols == block_size
+        and n_cols * input_tensor.element_size() >= TMA_MIN_ROW_BYTES
+        and input_tensor.stride(0) % tma_elems == 0
+        and output_tensor.stride(0) % tma_elems == 0
+    )
+
     kernel, _, _ = _softmax_kernel.get_kernel(
         dtype=dtype,
-        template_params=[block_size],
+        template_params=[block_size, tma_rows],
         signature="{T}*, const {T}*, int, int, int, int, int",
     )
 

--- a/src/tilegym/suites/flashinfer/cutile/fmha_prefill_bsr.py
+++ b/src/tilegym/suites/flashinfer/cutile/fmha_prefill_bsr.py
@@ -11,6 +11,9 @@ from cuda.tile import RoundingMode as RMd
 from cuda.tile.tune import exhaustive_search
 
 from tilegym.backend import register_impl
+from tilegym.logger import get_logger
+
+logger = get_logger(__name__)
 
 # Module-level tune caches for prefill kernels
 _prefill_paged_lpt_tune_cache: dict = {}
@@ -23,8 +26,6 @@ INV_LOG_2 = 1.0 / math.log(2)
 ConstInt = ct.Constant[int]
 ConstBool = ct.Constant[bool]
 ConstFloat = ct.Constant[float]
-
-_RAGGED_TWO_LOOP_MIN_SEQ = 4096
 
 
 def _get_prefill_autotune_configs(page_size=None):
@@ -56,6 +57,48 @@ def _get_prefill_autotune_configs(page_size=None):
                 yield cfg
         else:
             yield cfg
+
+
+def _autotune_ragged_two_loop(cache, cache_key, stream, kernel, grid_fn, args_fn, label):
+    """Tune the KV loop structure jointly with BLOCK_M/N/occupancy for ragged prefill.
+
+    Runs exhaustive_search once per USE_TWO_LOOP value and keeps the global best by
+    measured mean_us; a variant whose whole search space fails to build on an arch is
+    skipped. Memoizes (best_cfg, best_two_loop, hinted_kernel) in ``cache`` under
+    ``cache_key``. ``grid_fn(cfg)`` builds the launch grid; ``args_fn(cfg, two_loop)``
+    the kernel args.
+    """
+    if cache_key not in cache:
+        best = None
+        for two_loop in (True, False):
+            try:
+                result = exhaustive_search(
+                    list(_get_prefill_autotune_configs(None)),
+                    stream,
+                    grid_fn,
+                    kernel,
+                    lambda cfg, _tl=two_loop: args_fn(cfg, _tl),
+                    lambda cfg: {"occupancy": cfg.occupancy},
+                )
+            except ValueError as exc:
+                # exhaustive_search swallows per-config build/runtime failures and
+                # raises ValueError only when no config in the space is viable, i.e.
+                # this two_loop variant does not build on this arch -> skip it. Other
+                # error types (e.g. bugs in grid_fn/args_fn) propagate.
+                logger.debug("%s autotune skipped two_loop=%s: %s", label, two_loop, exc)
+                continue
+            if best is None or result.best.mean_us < best[0]:
+                best = (result.best.mean_us, two_loop, result.best.config)
+        if best is None:
+            raise RuntimeError(f"{label} autotune found no working configuration")
+        _, best_two_loop, best_cfg = best
+        logger.debug("%s chosen best_two_loop=%s key=%s", label, best_two_loop, cache_key)
+        cache[cache_key] = (
+            best_cfg,
+            best_two_loop,
+            kernel.replace_hints(occupancy=best_cfg.occupancy),
+        )
+    return cache[cache_key]
 
 
 def _load_page_prefill(
@@ -563,6 +606,8 @@ def _prefill_attention_ragged_body(
     offs_n_base = ct.arange(BLOCK_N, dtype=ct.int32)
     offs_m = start_m + ct.arange(BLOCK_M, dtype=ct.int32)
 
+    # USE_TWO_LOOP (compile-time const) picks two-loop causal split vs single
+    # fused loop; autotune measures both and keeps the faster per problem size.
     if USE_TWO_LOOP:
         if IS_CAUSAL:
             off_band_hi = ct.minimum(seq_len_kv, start_m)
@@ -795,9 +840,9 @@ def _prefill_attention_ragged_kernel(
 ):
     """
     Prefill attention kernel with ragged (contiguous) KV cache.
-    The KV loop structure is architecture-gated by USE_TWO_LOOP: a two-loop
-    causal split (unmasked off-band + masked diagonal) on consumer Blackwell, or
-    a unified single loop with an in-loop diagonal mask elsewhere.
+    The KV loop structure is selected by autotune via USE_TWO_LOOP: a two-loop
+    causal split (unmasked off-band + masked diagonal), or a unified single loop
+    with an in-loop diagonal mask.
     """
     seq_block_id = ct.bid(0)
     batch_id = ct.bid(1)
@@ -1173,15 +1218,7 @@ def prefill_attention_kv_ragged(
     BLOCK_R = head_dim_qk - head_dim_vo
     QUERY_GROUP_SIZE = num_qo_heads // num_kv_heads
 
-    # Two-loop causal split is the default (wins on consumer Blackwell, fp8, and
-    # long seq). Only datacenter Blackwell (sm10x) bf16/fp16 at short seq prefers
-    # the single fused loop — carve out exactly that niche.
-    _fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
-    is_fp8 = q.dtype in _fp8_dtypes or k_cache.dtype in _fp8_dtypes
-    use_two_loop = True
-    if torch.cuda.get_device_capability()[0] == 10 and not is_fp8 and max_seq_len < _RAGGED_TWO_LOOP_MIN_SEQ:
-        use_two_loop = False
-
+    # KV loop structure (USE_TWO_LOOP) is tuned below, not host-gated.
     outputs = (
         torch.empty(
             [q.shape[0], num_qo_heads, head_dim_vo],
@@ -1205,6 +1242,9 @@ def prefill_attention_kv_ragged(
         num_kv_heads,
         BLOCK_R,
         head_dim_vo,
+        q.dtype,
+        k_cache.dtype,
+        v_cache.dtype,
         k_scale,
         v_scale,
         max_seq_len,
@@ -1225,52 +1265,13 @@ def prefill_attention_kv_ragged(
         num_hb_remainder = (num_qo_heads * num_batch) % swizzle
 
         ragged_lpt_stream = torch.cuda.current_stream()
-        ragged_lpt_cache_key = (autotune_key, swizzle, str(q.device), use_two_loop)
-        if ragged_lpt_cache_key not in _prefill_ragged_lpt_tune_cache:
-            result = exhaustive_search(
-                list(_get_prefill_autotune_configs(None)),
-                ragged_lpt_stream,
-                lambda cfg: ((max_seq_len + cfg.BLOCK_M - 1) // cfg.BLOCK_M * num_qo_heads * num_batch, 1, 1),
-                _prefill_attention_ragged_lpt_kernel,
-                lambda cfg: (
-                    q,
-                    k_cache,
-                    v_cache,
-                    actual_seq_lens_q_flat,
-                    actual_seq_lens_kv_flat,
-                    batch_offsets_flat,
-                    outputs,
-                    out_lse,
-                    k_scale,
-                    v_scale,
-                    num_kv_heads,
-                    cfg.BLOCK_M,
-                    cfg.BLOCK_N,
-                    head_dim_vo,
-                    BLOCK_R,
-                    QUERY_GROUP_SIZE,
-                    is_causal,
-                    use_two_loop,
-                    num_qo_heads,
-                    num_batch,
-                    max_seq_len,
-                    swizzle,
-                    num_hb_quotient,
-                    max(num_hb_remainder, 1),
-                ),
-                lambda cfg: {"occupancy": cfg.occupancy},
-            )
-            best_cfg = result.best.config
-            _prefill_ragged_lpt_tune_cache[ragged_lpt_cache_key] = (
-                best_cfg,
-                _prefill_attention_ragged_lpt_kernel.replace_hints(occupancy=best_cfg.occupancy),
-            )
-        best_cfg, tuned_kernel = _prefill_ragged_lpt_tune_cache[ragged_lpt_cache_key]
-        ct.launch(
-            ragged_lpt_stream,
-            ((max_seq_len + best_cfg.BLOCK_M - 1) // best_cfg.BLOCK_M * num_qo_heads * num_batch, 1, 1),
-            tuned_kernel,
-            (
+        ragged_lpt_cache_key = (autotune_key, swizzle, str(q.device))
+
+        def _lpt_grid(cfg):
+            return ((max_seq_len + cfg.BLOCK_M - 1) // cfg.BLOCK_M * num_qo_heads * num_batch, 1, 1)
+
+        def _lpt_args(cfg, two_loop):
+            return (
                 q,
                 k_cache,
                 v_cache,
@@ -1282,63 +1283,40 @@ def prefill_attention_kv_ragged(
                 k_scale,
                 v_scale,
                 num_kv_heads,
-                best_cfg.BLOCK_M,
-                best_cfg.BLOCK_N,
+                cfg.BLOCK_M,
+                cfg.BLOCK_N,
                 head_dim_vo,
                 BLOCK_R,
                 QUERY_GROUP_SIZE,
                 is_causal,
-                use_two_loop,
+                two_loop,
                 num_qo_heads,
                 num_batch,
                 max_seq_len,
                 swizzle,
                 num_hb_quotient,
                 max(num_hb_remainder, 1),
-            ),
+            )
+
+        best_cfg, best_two_loop, tuned_kernel = _autotune_ragged_two_loop(
+            _prefill_ragged_lpt_tune_cache,
+            ragged_lpt_cache_key,
+            ragged_lpt_stream,
+            _prefill_attention_ragged_lpt_kernel,
+            _lpt_grid,
+            _lpt_args,
+            "prefill ragged lpt",
         )
+        ct.launch(ragged_lpt_stream, _lpt_grid(best_cfg), tuned_kernel, _lpt_args(best_cfg, best_two_loop))
     else:
         ragged_stream = torch.cuda.current_stream()
-        ragged_cache_key = (autotune_key, str(q.device), use_two_loop)
-        if ragged_cache_key not in _prefill_ragged_tune_cache:
-            result = exhaustive_search(
-                list(_get_prefill_autotune_configs(None)),
-                ragged_stream,
-                lambda cfg: ((max_seq_len + cfg.BLOCK_M - 1) // cfg.BLOCK_M, num_batch, num_qo_heads),
-                _prefill_attention_ragged_kernel,
-                lambda cfg: (
-                    q,
-                    k_cache,
-                    v_cache,
-                    actual_seq_lens_q_flat,
-                    actual_seq_lens_kv_flat,
-                    batch_offsets_flat,
-                    outputs,
-                    out_lse,
-                    k_scale,
-                    v_scale,
-                    num_kv_heads,
-                    cfg.BLOCK_M,
-                    cfg.BLOCK_N,
-                    head_dim_vo,
-                    BLOCK_R,
-                    QUERY_GROUP_SIZE,
-                    is_causal,
-                    use_two_loop,
-                ),
-                lambda cfg: {"occupancy": cfg.occupancy},
-            )
-            best_cfg = result.best.config
-            _prefill_ragged_tune_cache[ragged_cache_key] = (
-                best_cfg,
-                _prefill_attention_ragged_kernel.replace_hints(occupancy=best_cfg.occupancy),
-            )
-        best_cfg, tuned_kernel = _prefill_ragged_tune_cache[ragged_cache_key]
-        ct.launch(
-            ragged_stream,
-            ((max_seq_len + best_cfg.BLOCK_M - 1) // best_cfg.BLOCK_M, num_batch, num_qo_heads),
-            tuned_kernel,
-            (
+        ragged_cache_key = (autotune_key, str(q.device))
+
+        def _grid(cfg):
+            return ((max_seq_len + cfg.BLOCK_M - 1) // cfg.BLOCK_M, num_batch, num_qo_heads)
+
+        def _args(cfg, two_loop):
+            return (
                 q,
                 k_cache,
                 v_cache,
@@ -1350,14 +1328,24 @@ def prefill_attention_kv_ragged(
                 k_scale,
                 v_scale,
                 num_kv_heads,
-                best_cfg.BLOCK_M,
-                best_cfg.BLOCK_N,
+                cfg.BLOCK_M,
+                cfg.BLOCK_N,
                 head_dim_vo,
                 BLOCK_R,
                 QUERY_GROUP_SIZE,
                 is_causal,
-                use_two_loop,
-            ),
+                two_loop,
+            )
+
+        best_cfg, best_two_loop, tuned_kernel = _autotune_ragged_two_loop(
+            _prefill_ragged_tune_cache,
+            ragged_cache_key,
+            ragged_stream,
+            _prefill_attention_ragged_kernel,
+            _grid,
+            _args,
+            "prefill ragged",
         )
+        ct.launch(ragged_stream, _grid(best_cfg), tuned_kernel, _args(best_cfg, best_two_loop))
 
     return outputs, out_lse

--- a/src/tilegym/suites/flashinfer/cutile/fmha_prefill_bsr.py
+++ b/src/tilegym/suites/flashinfer/cutile/fmha_prefill_bsr.py
@@ -24,6 +24,8 @@ ConstInt = ct.Constant[int]
 ConstBool = ct.Constant[bool]
 ConstFloat = ct.Constant[float]
 
+_RAGGED_TWO_LOOP_MIN_SEQ = 4096
+
 
 def _get_prefill_autotune_configs(page_size=None):
     configs = [
@@ -495,6 +497,7 @@ def _prefill_attention_ragged_body(
     BLOCK_R: ConstInt,
     QUERY_GROUP_SIZE: ConstInt,
     IS_CAUSAL: ConstBool,
+    USE_TWO_LOOP: ConstBool,
 ):
     # Load sequence info
     seq_start_idx_tile = ct.gather(batch_offsets, (batch_id,), padding_value=0)
@@ -560,85 +563,23 @@ def _prefill_attention_ragged_body(
     offs_n_base = ct.arange(BLOCK_N, dtype=ct.int32)
     offs_m = start_m + ct.arange(BLOCK_M, dtype=ct.int32)
 
-    # Two-stage causal split: keep the masking machinery (offs_n / causal_mask /
-    # ct.where) out of the bulk off-band iterations. Only the single diagonal
-    # block needs masking, so the off-band loop body stays small — better
-    # software pipelining and lower register pressure than a merged loop that
-    # drags the mask through every iteration.
-    if IS_CAUSAL:
-        # Off-band: everything before the diagonal block (fully unmasked)
-        off_band_hi = ct.minimum(seq_len_kv, start_m)
-        # On-band: the diagonal block itself
-        on_band_lo = start_m
-        on_band_hi = ct.minimum(seq_len_kv, start_m + BLOCK_M)
-    else:
-        # Non-causal: process everything in off-band loop
-        off_band_hi = seq_len_kv
-        on_band_lo = 0
-        on_band_hi = 0
+    if USE_TWO_LOOP:
+        if IS_CAUSAL:
+            off_band_hi = ct.minimum(seq_len_kv, start_m)
+            on_band_lo = start_m
+            on_band_hi = ct.minimum(seq_len_kv, start_m + BLOCK_M)
+        else:
+            off_band_hi = seq_len_kv
+            on_band_lo = 0
+            on_band_hi = 0
 
-    off_band_iters = (off_band_hi + BLOCK_N - 1) // BLOCK_N
-    for iter_idx in range(off_band_iters):
-        curr_n = iter_idx * BLOCK_N
-
-        k_tile = ct.load(
-            k_seq,
-            index=(iter_idx, off_kv_h, 0),
-            shape=(BLOCK_N, 1, BLOCK_D),
-            order=(0, 1, 2),
-            allow_tma=True,
-            latency=2,
-            padding_mode=PAD_ZERO,
-        )
-        k = ct.reshape(k_tile, (BLOCK_N, BLOCK_D))
-
-        qk = ct.mma(q, ct.transpose(k), acc=qk_zeros)
-
-        if BLOCK_R > 0:
-            k_pe_tile = ct.load(
-                k_seq,
-                index=(iter_idx, off_kv_h, BLOCK_D // BLOCK_R),
-                shape=(BLOCK_N, 1, BLOCK_R),
-                order=(0, 1, 2),
-                allow_tma=True,
-                latency=2,
-                padding_mode=PAD_ZERO,
-            )
-            k_pe = ct.reshape(k_pe_tile, (BLOCK_N, BLOCK_R))
-            qk = ct.mma(q_pe, ct.transpose(k_pe), acc=qk)
-
-        qk_max = ct.max(qk, axis=1, keepdims=False)
-        m_ij = ct.maximum(m_i, (qk_max * qk_scale))
-        p = ct.exp2(qk * qk_scale - ct.reshape(m_ij, (BLOCK_M, 1)), flush_to_zero=True)
-
-        alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
-        l_i = l_i * alpha + ct.sum(p, axis=1, keepdims=False)
-        acc = acc * ct.reshape(alpha, (BLOCK_M, 1))
-
-        v_tile = ct.load(
-            v_seq,
-            index=(iter_idx, off_kv_h, 0),
-            shape=(BLOCK_N, 1, BLOCK_D),
-            order=(0, 1, 2),
-            allow_tma=True,
-            latency=2,
-            padding_mode=PAD_ZERO,
-        )
-        v = ct.reshape(v_tile, (BLOCK_N, BLOCK_D))
-
-        acc = ct.mma(ct.astype(p, q.dtype), v, acc=acc)
-        m_i = m_ij
-
-    if IS_CAUSAL:
-        on_band_iters = (on_band_hi - on_band_lo + BLOCK_N - 1) // BLOCK_N
-        on_band_block_start = on_band_lo // BLOCK_N
-        for iter_idx in range(on_band_iters):
-            curr_n = on_band_lo + iter_idx * BLOCK_N
-            block_idx = on_band_block_start + iter_idx
+        off_band_iters = (off_band_hi + BLOCK_N - 1) // BLOCK_N
+        for iter_idx in range(off_band_iters):
+            curr_n = iter_idx * BLOCK_N
 
             k_tile = ct.load(
                 k_seq,
-                index=(block_idx, off_kv_h, 0),
+                index=(iter_idx, off_kv_h, 0),
                 shape=(BLOCK_N, 1, BLOCK_D),
                 order=(0, 1, 2),
                 allow_tma=True,
@@ -652,7 +593,7 @@ def _prefill_attention_ragged_body(
             if BLOCK_R > 0:
                 k_pe_tile = ct.load(
                     k_seq,
-                    index=(block_idx, off_kv_h, BLOCK_D // BLOCK_R),
+                    index=(iter_idx, off_kv_h, BLOCK_D // BLOCK_R),
                     shape=(BLOCK_N, 1, BLOCK_R),
                     order=(0, 1, 2),
                     allow_tma=True,
@@ -661,10 +602,6 @@ def _prefill_attention_ragged_body(
                 )
                 k_pe = ct.reshape(k_pe_tile, (BLOCK_N, BLOCK_R))
                 qk = ct.mma(q_pe, ct.transpose(k_pe), acc=qk)
-
-            offs_n = curr_n + offs_n_base
-            causal_mask = ct.reshape(offs_m, (BLOCK_M, 1)) >= ct.reshape(offs_n, (1, BLOCK_N))
-            qk = ct.where(causal_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32))
 
             qk_max = ct.max(qk, axis=1, keepdims=False)
             m_ij = ct.maximum(m_i, (qk_max * qk_scale))
@@ -676,7 +613,129 @@ def _prefill_attention_ragged_body(
 
             v_tile = ct.load(
                 v_seq,
-                index=(block_idx, off_kv_h, 0),
+                index=(iter_idx, off_kv_h, 0),
+                shape=(BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2),
+                allow_tma=True,
+                latency=2,
+                padding_mode=PAD_ZERO,
+            )
+            v = ct.reshape(v_tile, (BLOCK_N, BLOCK_D))
+
+            acc = ct.mma(ct.astype(p, q.dtype), v, acc=acc)
+            m_i = m_ij
+
+        if IS_CAUSAL:
+            on_band_iters = (on_band_hi - on_band_lo + BLOCK_N - 1) // BLOCK_N
+            on_band_block_start = on_band_lo // BLOCK_N
+            for iter_idx in range(on_band_iters):
+                curr_n = on_band_lo + iter_idx * BLOCK_N
+                block_idx = on_band_block_start + iter_idx
+
+                k_tile = ct.load(
+                    k_seq,
+                    index=(block_idx, off_kv_h, 0),
+                    shape=(BLOCK_N, 1, BLOCK_D),
+                    order=(0, 1, 2),
+                    allow_tma=True,
+                    latency=2,
+                    padding_mode=PAD_ZERO,
+                )
+                k = ct.reshape(k_tile, (BLOCK_N, BLOCK_D))
+
+                qk = ct.mma(q, ct.transpose(k), acc=qk_zeros)
+
+                if BLOCK_R > 0:
+                    k_pe_tile = ct.load(
+                        k_seq,
+                        index=(block_idx, off_kv_h, BLOCK_D // BLOCK_R),
+                        shape=(BLOCK_N, 1, BLOCK_R),
+                        order=(0, 1, 2),
+                        allow_tma=True,
+                        latency=2,
+                        padding_mode=PAD_ZERO,
+                    )
+                    k_pe = ct.reshape(k_pe_tile, (BLOCK_N, BLOCK_R))
+                    qk = ct.mma(q_pe, ct.transpose(k_pe), acc=qk)
+
+                offs_n = curr_n + offs_n_base
+                causal_mask = ct.reshape(offs_m, (BLOCK_M, 1)) >= ct.reshape(offs_n, (1, BLOCK_N))
+                qk = ct.where(causal_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32))
+
+                qk_max = ct.max(qk, axis=1, keepdims=False)
+                m_ij = ct.maximum(m_i, (qk_max * qk_scale))
+                p = ct.exp2(qk * qk_scale - ct.reshape(m_ij, (BLOCK_M, 1)), flush_to_zero=True)
+
+                alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
+                l_i = l_i * alpha + ct.sum(p, axis=1, keepdims=False)
+                acc = acc * ct.reshape(alpha, (BLOCK_M, 1))
+
+                v_tile = ct.load(
+                    v_seq,
+                    index=(block_idx, off_kv_h, 0),
+                    shape=(BLOCK_N, 1, BLOCK_D),
+                    order=(0, 1, 2),
+                    allow_tma=True,
+                    latency=2,
+                    padding_mode=PAD_ZERO,
+                )
+                v = ct.reshape(v_tile, (BLOCK_N, BLOCK_D))
+
+                acc = ct.mma(ct.astype(p, q.dtype), v, acc=acc)
+                m_i = m_ij
+    else:
+        if IS_CAUSAL:
+            loop_hi = ct.minimum(seq_len_kv, start_m + BLOCK_M)
+        else:
+            loop_hi = seq_len_kv
+
+        total_iters = (loop_hi + BLOCK_N - 1) // BLOCK_N
+        for iter_idx in range(total_iters):
+            curr_n = iter_idx * BLOCK_N
+
+            k_tile = ct.load(
+                k_seq,
+                index=(iter_idx, off_kv_h, 0),
+                shape=(BLOCK_N, 1, BLOCK_D),
+                order=(0, 1, 2),
+                allow_tma=True,
+                latency=2,
+                padding_mode=PAD_ZERO,
+            )
+            k = ct.reshape(k_tile, (BLOCK_N, BLOCK_D))
+
+            qk = ct.mma(q, ct.transpose(k), acc=qk_zeros)
+
+            if BLOCK_R > 0:
+                k_pe_tile = ct.load(
+                    k_seq,
+                    index=(iter_idx, off_kv_h, BLOCK_D // BLOCK_R),
+                    shape=(BLOCK_N, 1, BLOCK_R),
+                    order=(0, 1, 2),
+                    allow_tma=True,
+                    latency=2,
+                    padding_mode=PAD_ZERO,
+                )
+                k_pe = ct.reshape(k_pe_tile, (BLOCK_N, BLOCK_R))
+                qk = ct.mma(q_pe, ct.transpose(k_pe), acc=qk)
+
+            if IS_CAUSAL:
+                if curr_n >= start_m:
+                    offs_n = curr_n + offs_n_base
+                    causal_mask = ct.reshape(offs_m, (BLOCK_M, 1)) >= ct.reshape(offs_n, (1, BLOCK_N))
+                    qk = ct.where(causal_mask, qk, ct.full((BLOCK_M, BLOCK_N), -1.0e6, dtype=ct.float32))
+
+            qk_max = ct.max(qk, axis=1, keepdims=False)
+            m_ij = ct.maximum(m_i, (qk_max * qk_scale))
+            p = ct.exp2(qk * qk_scale - ct.reshape(m_ij, (BLOCK_M, 1)), flush_to_zero=True)
+
+            alpha = ct.exp2((m_i - m_ij), flush_to_zero=True)
+            l_i = l_i * alpha + ct.sum(p, axis=1, keepdims=False)
+            acc = acc * ct.reshape(alpha, (BLOCK_M, 1))
+
+            v_tile = ct.load(
+                v_seq,
+                index=(iter_idx, off_kv_h, 0),
                 shape=(BLOCK_N, 1, BLOCK_D),
                 order=(0, 1, 2),
                 allow_tma=True,
@@ -732,12 +791,13 @@ def _prefill_attention_ragged_kernel(
     BLOCK_R: ConstInt,
     QUERY_GROUP_SIZE: ConstInt,
     IS_CAUSAL: ConstBool,
+    USE_TWO_LOOP: ConstBool,
 ):
     """
     Prefill attention kernel with ragged (contiguous) KV cache.
-    Uses a unified single loop over all KV positions; causal mask is applied
-    conditionally only in the diagonal region (curr_n >= start_m), eliminating
-    duplicated loop body and reducing register pressure.
+    The KV loop structure is architecture-gated by USE_TWO_LOOP: a two-loop
+    causal split (unmasked off-band + masked diagonal) on consumer Blackwell, or
+    a unified single loop with an in-loop diagonal mask elsewhere.
     """
     seq_block_id = ct.bid(0)
     batch_id = ct.bid(1)
@@ -764,6 +824,7 @@ def _prefill_attention_ragged_kernel(
         BLOCK_R,
         QUERY_GROUP_SIZE,
         IS_CAUSAL,
+        USE_TWO_LOOP,
     )
 
 
@@ -786,6 +847,7 @@ def _prefill_attention_ragged_lpt_kernel(
     BLOCK_R: ConstInt,
     QUERY_GROUP_SIZE: ConstInt,
     IS_CAUSAL: ConstBool,
+    USE_TWO_LOOP: ConstBool,
     NUM_HEADS: ConstInt,
     NUM_BATCH: ConstInt,
     MAX_SEQ_LEN: ConstInt,
@@ -833,6 +895,7 @@ def _prefill_attention_ragged_lpt_kernel(
         BLOCK_R,
         QUERY_GROUP_SIZE,
         IS_CAUSAL,
+        USE_TWO_LOOP,
     )
 
 
@@ -1110,6 +1173,15 @@ def prefill_attention_kv_ragged(
     BLOCK_R = head_dim_qk - head_dim_vo
     QUERY_GROUP_SIZE = num_qo_heads // num_kv_heads
 
+    # Two-loop causal split is the default (wins on consumer Blackwell, fp8, and
+    # long seq). Only datacenter Blackwell (sm10x) bf16/fp16 at short seq prefers
+    # the single fused loop — carve out exactly that niche.
+    _fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
+    is_fp8 = q.dtype in _fp8_dtypes or k_cache.dtype in _fp8_dtypes
+    use_two_loop = True
+    if torch.cuda.get_device_capability()[0] == 10 and not is_fp8 and max_seq_len < _RAGGED_TWO_LOOP_MIN_SEQ:
+        use_two_loop = False
+
     outputs = (
         torch.empty(
             [q.shape[0], num_qo_heads, head_dim_vo],
@@ -1153,7 +1225,7 @@ def prefill_attention_kv_ragged(
         num_hb_remainder = (num_qo_heads * num_batch) % swizzle
 
         ragged_lpt_stream = torch.cuda.current_stream()
-        ragged_lpt_cache_key = (autotune_key, swizzle, str(q.device))
+        ragged_lpt_cache_key = (autotune_key, swizzle, str(q.device), use_two_loop)
         if ragged_lpt_cache_key not in _prefill_ragged_lpt_tune_cache:
             result = exhaustive_search(
                 list(_get_prefill_autotune_configs(None)),
@@ -1178,6 +1250,7 @@ def prefill_attention_kv_ragged(
                     BLOCK_R,
                     QUERY_GROUP_SIZE,
                     is_causal,
+                    use_two_loop,
                     num_qo_heads,
                     num_batch,
                     max_seq_len,
@@ -1215,6 +1288,7 @@ def prefill_attention_kv_ragged(
                 BLOCK_R,
                 QUERY_GROUP_SIZE,
                 is_causal,
+                use_two_loop,
                 num_qo_heads,
                 num_batch,
                 max_seq_len,
@@ -1225,7 +1299,7 @@ def prefill_attention_kv_ragged(
         )
     else:
         ragged_stream = torch.cuda.current_stream()
-        ragged_cache_key = (autotune_key, str(q.device))
+        ragged_cache_key = (autotune_key, str(q.device), use_two_loop)
         if ragged_cache_key not in _prefill_ragged_tune_cache:
             result = exhaustive_search(
                 list(_get_prefill_autotune_configs(None)),
@@ -1250,6 +1324,7 @@ def prefill_attention_kv_ragged(
                     BLOCK_R,
                     QUERY_GROUP_SIZE,
                     is_causal,
+                    use_two_loop,
                 ),
                 lambda cfg: {"occupancy": cfg.occupancy},
             )
@@ -1281,6 +1356,7 @@ def prefill_attention_kv_ragged(
                 BLOCK_R,
                 QUERY_GROUP_SIZE,
                 is_causal,
+                use_two_loop,
             ),
         )
 

--- a/src/tilegym/suites/flashinfer/cutile/gemm/ragged_block_scaled_bmm.py
+++ b/src/tilegym/suites/flashinfer/cutile/gemm/ragged_block_scaled_bmm.py
@@ -6,10 +6,22 @@ from types import SimpleNamespace
 
 import cuda.tile as ct
 import torch
+from cuda.tile.tune import exhaustive_search
 
+from tilegym.autotune import is_autotune_enabled
 from tilegym.backend import register_impl
 from tilegym.kernel_utils import get_kernel_configs
+from tilegym.logger import get_logger
 from tilegym.ops.cutile.utils import cached_replace_hints
+
+logger = get_logger(__name__)
+
+# The tuned kernel is whichever of the per-expert / uniform / swap_ab variants
+# measured faster for a given shape. Keyed on the shape scalars.
+_ragged_block_scaled_bmm_tune_cache: dict = {}
+
+# Use per-expert scheduling when the uniform schedule processes over 25% extra rows.
+_PER_EXPERT_INFLATION_THRESHOLD = 1.25
 
 
 def _is_large_m(total_m, Q):
@@ -17,6 +29,118 @@ def _is_large_m(total_m, Q):
     average_m = total_m / Q
     is_large_m = average_m >= 256
     return is_large_m
+
+
+def _compute_and_store_tile(
+    a,  # Input matrix A [total_m, K] FP8
+    b,  # Input matrix B [Q, N, K] FP8
+    a_scale,  # Scale for A [total_m, k_tiles] FP32
+    b_scale,  # Scale for B [Q, n_tiles, k_tiles] FP32
+    c,  # Output matrix C [total_m, N]
+    m_start,  # Segment start row (expert pid_q)
+    m_end,  # Segment end row (expert pid_q)
+    pid_m,  # Row tile index within the segment
+    pid_n,  # Column tile index
+    pid_q,  # Batch/expert index
+    num_k_tiles,
+    HAS_A_SCALE: ct.Constant[int],
+    SWAP_AB: ct.Constant[int],
+    BLOCK_M: ct.Constant[int],
+    BLOCK_N: ct.Constant[int],
+    BLOCK_K: ct.Constant[int],
+):
+    """
+    Compute one output tile C[pid_m, pid_n] for expert pid_q and store it.
+
+    Shared K-loop body for all three scheduling variants (per-expert, uniform,
+    swap_ab). Slices A/C/a_scale for the segment, runs the scaled FP8 MMA over
+    the K dimension, and writes the result. SWAP_AB selects the (B @ A^T)^T path.
+    """
+    # Sliced views for A and C (and a_scale) using Array.slice
+    Ai = a.slice(axis=0, start=m_start, stop=m_end)
+    Ci = c.slice(axis=0, start=m_start, stop=m_end)
+    if HAS_A_SCALE == 1:
+        a_scale_i = a_scale.slice(axis=0, start=m_start, stop=m_end)
+
+    acc = ct.full((BLOCK_M, BLOCK_N), 0.0, dtype=ct.float32)
+
+    # N tile offset (element-level) for b_scale calculation
+    n_offset = pid_n * BLOCK_N
+    offs_bsn = n_offset // BLOCK_K
+
+    # Zero accumulator for per-K MMA (reused each iteration)
+    if SWAP_AB == 1:
+        mma_zeros = ct.full((BLOCK_N, BLOCK_M), 0.0, dtype=ct.float32)
+    else:
+        mma_zeros = ct.full((BLOCK_M, BLOCK_N), 0.0, dtype=ct.float32)
+
+    # K-loop for matrix multiplication
+    for k in range(num_k_tiles):
+        k_offset = k * BLOCK_K
+
+        # Load A block using TMA
+        a_block = ct.load(
+            Ai,
+            index=(pid_m, k),
+            shape=(BLOCK_M, BLOCK_K),
+            padding_mode=ct.PaddingMode.ZERO,
+        )
+
+        # Load B block - B is [Q, N, K], we need [BLOCK_N, BLOCK_K]
+        b_block_3d = ct.load(
+            b,
+            index=(pid_q, n_offset // BLOCK_N, k_offset // BLOCK_K),
+            shape=(1, BLOCK_N, BLOCK_K),
+            order=(0, 1, 2),
+            padding_mode=ct.PaddingMode.ZERO,
+        )
+        b_block_nk = ct.reshape(b_block_3d, (BLOCK_N, BLOCK_K))
+
+        if SWAP_AB == 1:
+            # swap_ab: compute (B @ A^T)^T
+            a_block_t = ct.permute(a_block, (1, 0))
+            c_swapped = ct.mma(b_block_nk, a_block_t, acc=mma_zeros)
+            c_mma = ct.permute(c_swapped, (1, 0))
+        else:
+            # Transpose B to [BLOCK_K, BLOCK_N] then A [BLOCK_M, BLOCK_K] @ B = [BLOCK_M, BLOCK_N]
+            b_block = ct.permute(b_block_nk, (1, 0))  # [BLOCK_K, BLOCK_N]
+            c_mma = ct.mma(a_block, b_block, acc=mma_zeros)
+
+        # Load and apply scales
+        if HAS_A_SCALE == 1:
+            a_scale_block = ct.load(
+                a_scale_i,
+                index=(pid_m, k),
+                shape=(BLOCK_M, 1),
+                padding_mode=ct.PaddingMode.ZERO,
+            )
+            b_scale_block = ct.load(
+                b_scale,
+                index=(pid_q, offs_bsn, k),
+                shape=(1, 1, 1),
+                order=(0, 1, 2),
+                padding_mode=ct.PaddingMode.ZERO,
+            )
+            b_scale_val = ct.reshape(b_scale_block, (1, 1))
+            scale_combined = a_scale_block * ct.broadcast_to(b_scale_val, (BLOCK_M, 1))
+            scale_ab = ct.broadcast_to(scale_combined, (BLOCK_M, BLOCK_N))
+        else:
+            b_scale_block = ct.load(
+                b_scale,
+                index=(pid_q, offs_bsn, k),
+                shape=(1, 1, 1),
+                order=(0, 1, 2),
+                padding_mode=ct.PaddingMode.ZERO,
+            )
+            b_scale_val = ct.reshape(b_scale_block, (1, 1))
+            scale_ab = ct.broadcast_to(b_scale_val, (BLOCK_M, BLOCK_N))
+
+        # Apply scale and accumulate
+        acc = acc + c_mma * scale_ab
+
+    # Convert to output dtype and store to C using TMA
+    c_block = ct.astype(acc, c.dtype)
+    ct.store(Ci, index=(pid_m, pid_n), tile=c_block)
 
 
 @ct.kernel
@@ -90,93 +214,24 @@ def _ragged_block_scaled_bmm_kernel(
             pid_m = first_pid_m + (pid_in_batch % group_size_m_actual)
             pid_n = (pid_in_batch % num_pid_in_group) // group_size_m_actual
 
-            # Create sliced views for A and C using Array.slice
-            Ai = a.slice(axis=0, start=m_start, stop=m_end)
-            Ci = c.slice(axis=0, start=m_start, stop=m_end)
-
-            if HAS_A_SCALE == 1:
-                a_scale_i = a_scale.slice(axis=0, start=m_start, stop=m_end)
-
-            # Initialize accumulator
-            acc = ct.full((BLOCK_M, BLOCK_N), 0.0, dtype=ct.float32)
-
-            # N tile offset (element-level) for b_scale calculation
-            n_offset = pid_n * BLOCK_N
-            offs_bsn = n_offset // BLOCK_K
-
-            # Zero accumulator for per-K MMA (reused each iteration)
-            mma_zeros = ct.full((BLOCK_M, BLOCK_N), 0.0, dtype=ct.float32)
-
-            # K-loop for matrix multiplication
-            for k in range(num_k_tiles):
-                k_offset = k * BLOCK_K
-
-                # Load A block using TMA
-                a_block = ct.load(
-                    Ai,
-                    index=(pid_m, k),
-                    shape=(BLOCK_M, BLOCK_K),
-                    padding_mode=ct.PaddingMode.ZERO,
-                )
-
-                # Load B block - B is [Q, N, K], we need [BLOCK_N, BLOCK_K]
-                b_block_3d = ct.load(
-                    b,
-                    index=(pid_q, n_offset // BLOCK_N, k_offset // BLOCK_K),
-                    shape=(1, BLOCK_N, BLOCK_K),
-                    order=(0, 1, 2),
-                    padding_mode=ct.PaddingMode.ZERO,
-                )
-                # Reshape to [BLOCK_N, BLOCK_K] then transpose to get [BLOCK_K, BLOCK_N]
-                b_block_nk = ct.reshape(b_block_3d, (BLOCK_N, BLOCK_K))
-                b_block = ct.permute(b_block_nk, (1, 0))  # [BLOCK_K, BLOCK_N]
-
-                # Matrix multiplication: A [BLOCK_M, BLOCK_K] @ B [BLOCK_K, BLOCK_N] = C [BLOCK_M, BLOCK_N]
-                c_mma = ct.mma(a_block, b_block, acc=mma_zeros)
-
-                # Load and apply scales
-                if HAS_A_SCALE == 1:
-                    # Load a_scale for this block using TMA
-                    a_scale_block = ct.load(
-                        a_scale_i,
-                        index=(pid_m, k),
-                        shape=(BLOCK_M, 1),
-                        padding_mode=ct.PaddingMode.ZERO,
-                    )
-
-                    # Load b_scale - scalar at [pid_q, offs_bsn, k]
-                    b_scale_block = ct.load(
-                        b_scale,
-                        index=(pid_q, offs_bsn, k),
-                        shape=(1, 1, 1),
-                        order=(0, 1, 2),
-                        padding_mode=ct.PaddingMode.ZERO,
-                    )
-                    b_scale_val = ct.reshape(b_scale_block, (1, 1))
-
-                    # Combined scale: a_scale [BLOCK_M, 1] * b_scale [1, 1] = [BLOCK_M, 1]
-                    scale_combined = a_scale_block * ct.broadcast_to(b_scale_val, (BLOCK_M, 1))
-                    scale_ab = ct.broadcast_to(scale_combined, (BLOCK_M, BLOCK_N))
-                else:
-                    # Only b_scale
-                    b_scale_block = ct.load(
-                        b_scale,
-                        index=(pid_q, offs_bsn, k),
-                        shape=(1, 1, 1),
-                        order=(0, 1, 2),
-                        padding_mode=ct.PaddingMode.ZERO,
-                    )
-                    b_scale_val = ct.reshape(b_scale_block, (1, 1))
-                    scale_ab = ct.broadcast_to(b_scale_val, (BLOCK_M, BLOCK_N))
-
-                # Apply scale and accumulate
-                acc = acc + c_mma * scale_ab
-
-            # Convert to output dtype
-            c_block = ct.astype(acc, c.dtype)
-
-            # Store to output C using TMA
-            ct.store(Ci, index=(pid_m, pid_n), tile=c_block)
+            _compute_and_store_tile(
+                a,
+                b,
+                a_scale,
+                b_scale,
+                c,
+                m_start,
+                m_end,
+                pid_m,
+                pid_n,
+                pid_q,
+                num_k_tiles,
+                HAS_A_SCALE,
+                0,  # SWAP_AB
+                BLOCK_M,
+                BLOCK_N,
+                BLOCK_K,
+            )
 
             # Advance to this CTA's next flat tile (persistent stride).
             tile_idx = tile_idx + num_programs
@@ -184,6 +239,85 @@ def _ragged_block_scaled_bmm_kernel(
         # Running prefix sum over experts; chain start = previous end.
         last_problem_end = last_problem_end + tiles_this_expert
         m_start = m_end
+
+
+@ct.kernel
+def _ragged_block_scaled_bmm_uniform_kernel(
+    a,  # Input matrix A [total_m, K] FP8
+    b,  # Input matrix B [Q, N, K] FP8
+    a_scale,  # Scale for A [total_m, k_tiles] FP32
+    b_scale,  # Scale for B [Q, n_tiles, k_tiles] FP32
+    c,  # Output matrix C [total_m, N]
+    m_indptr,  # Segment offsets [Q+1], flattened 1D
+    q,  # Number of batches
+    max_m,  # Host-side max segment size hint (kept for autotune cache key)
+    max_m_device,  # 1-element int32 tensor (shape (1,)) — device-side ground truth for max(valid_m)
+    n,  # Output N dimension
+    HAS_A_SCALE: ct.Constant[int],  # Whether a_scale is provided (0 or 1)
+    BLOCK_M: ct.Constant[int],
+    BLOCK_N: ct.Constant[int],
+    BLOCK_K: ct.Constant[int],
+    GROUP_SIZE_M: ct.Constant[int],
+):
+    """
+    Uniform (per-batch) tile scheduling for the non-swap path.
+
+    The flat tile space is sized to the per-batch bound max(valid_m); phantom
+    tiles past each expert's real rows are masked by `if pid_m*BLOCK_M < valid_m`.
+    For balanced routing (every expert ~= max_m) this emits the same real tiles
+    as the per-expert schedule but without its prefix-sum + nested control flow,
+    which the per-expert kernel pays as pure overhead. The host gates per-expert
+    vs uniform on measured imbalance. Reads the bound from device-side
+    `max_m_device` (defense-in-depth against a stale host `max_m` hint).
+    """
+    pid = ct.bid(0)
+
+    num_k_tiles = ct.num_tiles(a, axis=1, shape=(BLOCK_M, BLOCK_K))
+    max_m_runtime = ct.load(max_m_device, index=(0,), shape=(1,)).item()
+    num_pid_m = ct.cdiv(max_m_runtime, BLOCK_M)
+    num_pid_n = ct.cdiv(n, BLOCK_N)
+    tiles_per_batch = num_pid_m * num_pid_n
+    total_tiles = tiles_per_batch * q
+    num_programs = ct.num_blocks(0)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    # Persistent scheduling loop
+    for current_pid in range(pid, total_tiles, num_programs):
+        pid_q = current_pid // tiles_per_batch
+        pid_in_batch = current_pid % tiles_per_batch
+
+        group_id = pid_in_batch // num_pid_in_group
+        first_pid_m = group_id * GROUP_SIZE_M
+        group_size_m_actual = ct.minimum(num_pid_m - first_pid_m, GROUP_SIZE_M)
+
+        pid_m = first_pid_m + (pid_in_batch % group_size_m_actual)
+        pid_n = (pid_in_batch % num_pid_in_group) // group_size_m_actual
+
+        m_start_tile = ct.load(m_indptr, index=(pid_q,), shape=(1,))
+        m_start = m_start_tile.item()
+        m_end_tile = ct.load(m_indptr, index=(pid_q + 1,), shape=(1,))
+        m_end = m_end_tile.item()
+        valid_m = m_end - m_start
+
+        if pid_m * BLOCK_M < valid_m:
+            _compute_and_store_tile(
+                a,
+                b,
+                a_scale,
+                b_scale,
+                c,
+                m_start,
+                m_end,
+                pid_m,
+                pid_n,
+                pid_q,
+                num_k_tiles,
+                HAS_A_SCALE,
+                0,  # SWAP_AB
+                BLOCK_M,
+                BLOCK_N,
+                BLOCK_K,
+            )
 
 
 @ct.kernel
@@ -243,83 +377,24 @@ def _ragged_block_scaled_bmm_swap_ab_kernel(
         valid_m = m_end - m_start
 
         if pid_m * BLOCK_M < valid_m:
-            # Create sliced views for A and C using Array.slice
-            Ai = a.slice(axis=0, start=m_start, stop=m_end)
-            Ci = c.slice(axis=0, start=m_start, stop=m_end)
-
-            if HAS_A_SCALE == 1:
-                a_scale_i = a_scale.slice(axis=0, start=m_start, stop=m_end)
-
-            acc = ct.full((BLOCK_M, BLOCK_N), 0.0, dtype=ct.float32)
-
-            n_offset = pid_n * BLOCK_N
-            offs_bsn = n_offset // BLOCK_K
-
-            # Zero accumulator for per-K MMA (reused each iteration)
-            mma_zeros = ct.full((BLOCK_N, BLOCK_M), 0.0, dtype=ct.float32)
-
-            for k in range(num_k_tiles):
-                k_offset = k * BLOCK_K
-
-                # Load A block using TMA
-                a_block = ct.load(
-                    Ai,
-                    index=(pid_m, k),
-                    shape=(BLOCK_M, BLOCK_K),
-                    padding_mode=ct.PaddingMode.ZERO,
-                )
-
-                # Load B block
-                b_block_3d = ct.load(
-                    b,
-                    index=(pid_q, n_offset // BLOCK_N, k_offset // BLOCK_K),
-                    shape=(1, BLOCK_N, BLOCK_K),
-                    order=(0, 1, 2),
-                    padding_mode=ct.PaddingMode.ZERO,
-                )
-                b_block_nk = ct.reshape(b_block_3d, (BLOCK_N, BLOCK_K))
-
-                # swap_ab: compute (B @ A^T)^T
-                a_block_t = ct.permute(a_block, (1, 0))
-                c_swapped = ct.mma(b_block_nk, a_block_t, acc=mma_zeros)
-                c_mma = ct.permute(c_swapped, (1, 0))
-
-                # Load and apply scales
-                if HAS_A_SCALE == 1:
-                    a_scale_block = ct.load(
-                        a_scale_i,
-                        index=(pid_m, k),
-                        shape=(BLOCK_M, 1),
-                        padding_mode=ct.PaddingMode.ZERO,
-                    )
-
-                    b_scale_block = ct.load(
-                        b_scale,
-                        index=(pid_q, offs_bsn, k),
-                        shape=(1, 1, 1),
-                        order=(0, 1, 2),
-                        padding_mode=ct.PaddingMode.ZERO,
-                    )
-                    b_scale_val = ct.reshape(b_scale_block, (1, 1))
-                    scale_combined = a_scale_block * ct.broadcast_to(b_scale_val, (BLOCK_M, 1))
-                    scale_ab = ct.broadcast_to(scale_combined, (BLOCK_M, BLOCK_N))
-                else:
-                    b_scale_block = ct.load(
-                        b_scale,
-                        index=(pid_q, offs_bsn, k),
-                        shape=(1, 1, 1),
-                        order=(0, 1, 2),
-                        padding_mode=ct.PaddingMode.ZERO,
-                    )
-                    b_scale_val = ct.reshape(b_scale_block, (1, 1))
-                    scale_ab = ct.broadcast_to(b_scale_val, (BLOCK_M, BLOCK_N))
-
-                acc = acc + c_mma * scale_ab
-
-            c_block = ct.astype(acc, c.dtype)
-
-            # Store to output C using TMA
-            ct.store(Ci, index=(pid_m, pid_n), tile=c_block)
+            _compute_and_store_tile(
+                a,
+                b,
+                a_scale,
+                b_scale,
+                c,
+                m_start,
+                m_end,
+                pid_m,
+                pid_n,
+                pid_q,
+                num_k_tiles,
+                HAS_A_SCALE,
+                1,  # SWAP_AB
+                BLOCK_M,
+                BLOCK_N,
+                BLOCK_K,
+            )
 
 
 def _ragged_block_scaled_bmm_autotune_configs():
@@ -329,6 +404,7 @@ def _ragged_block_scaled_bmm_autotune_configs():
     gpu_capability = torch.cuda.get_device_capability()
 
     if gpu_capability in [(12, 0), (12, 1)]:
+        # SM120/SM121 (Blackwell RTX-Pro / consumer) tuning space.
         for BM, BN, swap_ab in [
             (128, 128, False),
             (64, 128, True),
@@ -375,6 +451,7 @@ def _ragged_block_scaled_bmm_autotune_configs():
                         occupancy=occupancy,
                     )
     elif gpu_capability == (9, 0):
+        # SM90 (Hopper) tuning space.
         for BM, BN, swap_ab in [
             (256, 128, False),
             (128, 128, False),
@@ -421,6 +498,7 @@ def _get_default_kernel_configs(total_m, Q, VEC_SIZE):
     is_large_m = _is_large_m(total_m, Q)
 
     if gpu_capability in [(12, 0), (12, 1)]:
+        # SM120/SM121 (Blackwell RTX-Pro / consumer) default.
         return {
             "BLOCK_M": 128,
             "BLOCK_N": 128,
@@ -462,6 +540,7 @@ def _get_default_kernel_configs(total_m, Q, VEC_SIZE):
                 "occupancy": 1,
             }
     elif gpu_capability == (9, 0):
+        # SM90 (Hopper) default.
         if is_large_m:
             return {
                 "BLOCK_M": 32,
@@ -492,6 +571,87 @@ def _get_default_kernel_configs(total_m, Q, VEC_SIZE):
             "num_ctas": 1,
             "occupancy": 1,
         }
+
+
+def _ragged_block_scaled_bmm_autotune(
+    stream, a, b, a_scale, b_scale, c, m_indptr, Q, max_m, max_m_device, N, K, total_m, has_a_scale
+):
+    """
+    Autotuned launch for ragged block-scaled BMM.
+
+    Tunes the per-expert, uniform and swap_ab kernels over their config spaces and
+    launches whichever measured faster. All three compute the same product, so the
+    choice only shifts fp8 accumulation grouping (results agree within tolerance).
+    Which one wins is not predictable from the shape alone (it is non-monotonic in
+    the per-batch M and differs per arch), so it is measured rather than guessed
+    with a host-side gate.
+    """
+    NUM_SMS = torch.cuda.get_device_properties(a.device).multi_processor_count
+
+    def args_fn(cfg):
+        return (
+            a,
+            b,
+            a_scale,
+            b_scale,
+            c,
+            m_indptr,
+            Q,
+            max_m,
+            max_m_device,
+            N,
+            has_a_scale,
+            cfg.BLOCK_M,
+            cfg.BLOCK_N,
+            cfg.BLOCK_K,
+            cfg.GROUP_SIZE_M,
+        )
+
+    def grid_fn(cfg):
+        num_pid_m = ct.cdiv(max_m, cfg.BLOCK_M)
+        num_pid_n = ct.cdiv(N, cfg.BLOCK_N)
+        total_tiles = num_pid_m * num_pid_n * Q
+        num_programs = min(NUM_SMS // cfg.num_ctas, total_tiles) * cfg.occupancy
+        # Never launch zero programs when there are rows to process, or the
+        # output would be left silently unwritten (max_m can be 0 only for a
+        # degenerate/empty batch, which correctly launches nothing).
+        return (max(num_programs, 1) if total_m > 0 else num_programs, 1, 1)
+
+    def hints_fn(cfg):
+        return {"num_ctas": cfg.num_ctas, "occupancy": cfg.occupancy}
+
+    all_configs = list(_ragged_block_scaled_bmm_autotune_configs())
+    nonswap_configs = [cfg for cfg in all_configs if not cfg.swap_ab]
+    swap_configs = [cfg for cfg in all_configs if cfg.swap_ab]
+
+    cache_key = (Q, max_m, total_m, N, K, has_a_scale, a.dtype, str(a.device))
+    if cache_key not in _ragged_block_scaled_bmm_tune_cache:
+        best = None
+        for kernel, configs in (
+            (_ragged_block_scaled_bmm_kernel, nonswap_configs),
+            (_ragged_block_scaled_bmm_uniform_kernel, nonswap_configs),
+            (_ragged_block_scaled_bmm_swap_ab_kernel, swap_configs),
+        ):
+            if not configs:
+                continue
+            try:
+                result = exhaustive_search(configs, stream, grid_fn, kernel, args_fn, hints_fn)
+            except Exception as exc:
+                # A whole config space can fail to build on a given arch (e.g. smem
+                # limits); fall back to whichever variant did tune successfully.
+                logger.debug("ragged_block_scaled_bmm autotune skipped %s: %s", kernel, exc)
+                continue
+            if best is None or result.best.mean_us < best[0]:
+                best = (result.best.mean_us, kernel, result.best.config)
+        if best is None:
+            raise RuntimeError("ragged_block_scaled_bmm autotune found no working configuration")
+        _, best_kernel, best_cfg = best
+        _ragged_block_scaled_bmm_tune_cache[cache_key] = (
+            best_cfg,
+            best_kernel.replace_hints(**hints_fn(best_cfg)),
+        )
+    best_cfg, tuned_kernel = _ragged_block_scaled_bmm_tune_cache[cache_key]
+    ct.launch(stream, grid_fn(best_cfg), tuned_kernel, args_fn(best_cfg))
 
 
 @register_impl("flashinfer.gemm.ragged_block_scaled_bmm", backend="cutile")
@@ -552,7 +712,34 @@ def ragged_block_scaled_bmm(
     if max_m_device is None:
         max_m_device = torch.tensor([max_m], dtype=torch.int32, device=a.device)
 
-    # Get kernel configs
+    has_a_scale = 1 if a_scale is not None else 0
+    if a_scale is None:
+        a_scale = torch.empty(1, device=a.device, dtype=torch.float32)
+
+    if is_autotune_enabled():
+        # The per-expert, uniform and swap_ab kernels are all tuned and the faster
+        # one wins. There is no host-side shape heuristic here on purpose: a
+        # threshold on the per-batch M mis-routes MoE GEMMs, because which variant
+        # is faster is not monotonic in M and differs per arch.
+        _ragged_block_scaled_bmm_autotune(
+            torch.cuda.current_stream(),
+            a,
+            b,
+            a_scale,
+            b_scale,
+            c,
+            m_indptr,
+            Q,
+            max_m,
+            max_m_device,
+            N,
+            K_A,
+            total_m,
+            has_a_scale,
+        )
+        return c
+
+    # Fixed default configs; the ratio gate selects per-expert vs uniform.
     default_configs = _get_default_kernel_configs(total_m, Q, VEC_SIZE)
     kernel_configs = get_kernel_configs(default_configs, kwargs.get("kernel_configs"))
 
@@ -571,17 +758,19 @@ def ragged_block_scaled_bmm(
     tiles_per_batch = num_pid_m * num_pid_n
     total_tiles = tiles_per_batch * Q
     num_programs = min(NUM_SMS // num_ctas, total_tiles) * occupancy
+    # Never launch zero programs when there are rows to process, or the output
+    # would be left silently unwritten (max_m is 0 only for an empty batch).
+    if total_m > 0:
+        num_programs = max(num_programs, 1)
 
     grid = (num_programs, 1, 1)
 
-    has_a_scale = 1 if a_scale is not None else 0
-
-    if a_scale is None:
-        a_scale = torch.empty(1, device=a.device, dtype=torch.float32)
+    if swap_ab:
+        kernel_fn = _ragged_block_scaled_bmm_swap_ab_kernel
     else:
-        a_scale = a_scale
-
-    kernel_fn = _ragged_block_scaled_bmm_swap_ab_kernel if swap_ab else _ragged_block_scaled_bmm_kernel
+        # Balanced routing -> uniform (cheaper); clearly imbalanced -> per-expert.
+        use_per_expert = Q * max_m > total_m * _PER_EXPERT_INFLATION_THRESHOLD
+        kernel_fn = _ragged_block_scaled_bmm_kernel if use_per_expert else _ragged_block_scaled_bmm_uniform_kernel
 
     hints = {}
     if num_ctas is not None:

--- a/src/tilegym/suites/liger/cutile/fused_add_rms_norm.py
+++ b/src/tilegym/suites/liger/cutile/fused_add_rms_norm.py
@@ -221,6 +221,55 @@ def _autotune_fwd_kernel(base_kernel, args, n_rows, cache_key, stream):
     return tuned
 
 
+_BWD_1CHUNK_NWW = 4
+
+
+def _bwd_autotune_configs():
+    for blocks_per_sm in (1, 2, 4, 8):
+        yield SimpleNamespace(blocks_per_sm=blocks_per_sm, num_worker_warps=_BWD_1CHUNK_NWW)
+
+
+_bwd_tune_cache: dict = {}
+
+
+def _autotune_bwd_kernel(
+    base_kernel, n_rows, n_cols, sm_count, device, cache_key, stream, args_fn_for_blocks, BLOCK_SIZE
+):
+    """Pick blocks_per_sm for the 1-chunk backward path via exhaustive_search.
+
+    ``args_fn_for_blocks(n_blocks)`` returns the full kernel-arg tuple (real dY/dS_out/
+    dX/S/W/RSTD buffers, a freshly-allocated dW_partial sized for n_blocks, and the
+    scalar constants) for a given block count. Returns a cached (blocks_per_sm,
+    tuned_kernel) tuple; the kernel is hint-specialized once here so the hot backward
+    path never re-runs replace_hints (which perturbs the launch).
+    """
+    if cache_key in _bwd_tune_cache:
+        return _bwd_tune_cache[cache_key]
+
+    kernel = base_kernel.replace_hints(num_worker_warps=_BWD_1CHUNK_NWW)
+
+    def _grid_fn(cfg):
+        n_blocks = min(sm_count * cfg.blocks_per_sm, n_rows)
+        return (n_blocks, 1, 1)
+
+    def _args_fn(cfg):
+        n_blocks = min(sm_count * cfg.blocks_per_sm, n_rows)
+        return args_fn_for_blocks(n_blocks)
+
+    result = exhaustive_search(
+        list(_bwd_autotune_configs()),
+        stream,
+        _grid_fn,
+        kernel,
+        _args_fn,
+        quiet=True,
+    )
+    best = result.best.config
+    tuned = (best.blocks_per_sm, kernel)
+    _bwd_tune_cache[cache_key] = tuned
+    return tuned
+
+
 @ct.kernel(occupancy=1)
 def _fused_add_rms_norm_bwd_persistent_ct(
     dY,  # (n_rows, n_cols) gradient of Y
@@ -462,7 +511,8 @@ def _fused_add_rms_norm_bwd_persistent_2c_ct(
     ct.scatter(dW_partial, (sm_id, col_idx_hi), dW_acc_hi, check_bounds=True)
 
 
-_fused_add_rms_norm_bwd_persistent_ct_nww8 = _fused_add_rms_norm_bwd_persistent_ct.replace_hints(num_worker_warps=8)
+# Large-shape 2-chunk path keeps its fixed nww=8 launch (already qualifies). The
+# 1-chunk small-shape path selects num_worker_warps per shape via _autotune_bwd_kernel.
 _fused_add_rms_norm_bwd_persistent_2c_ct_nww8 = _fused_add_rms_norm_bwd_persistent_2c_ct.replace_hints(
     num_worker_warps=8
 )
@@ -520,34 +570,38 @@ def _fused_add_rms_norm_backward_ct(dY, dS_out, S, W, RSTD, offset, casting_mode
     S2d = S.view(-1, dim)
     n_rows, n_cols = dY2d.shape
 
-    # Persistent kernel: one block per SM, each handles ceil(n_rows/sm_count) rows.
-    # Grid = (sm_count,) → exactly 1 block/SM → full 256KB register file available.
-    # When BLOCK_SIZE > _BWD_MAX_CHUNK_SIZE, use the 2-chunk kernel to reduce
-    # register pressure (CHUNK_SIZE/128 elements/thread vs BLOCK_SIZE/128).
+    # Persistent kernel: each block owns a contiguous slice of rows and loops over
+    # them, writing its dW partial once. When BLOCK_SIZE > _BWD_MAX_CHUNK_SIZE, use
+    # the 2-chunk kernel to reduce register pressure (CHUNK_SIZE/128 elements/thread
+    # vs BLOCK_SIZE/128).
     sm_count = torch.cuda.get_device_properties(W.device).multi_processor_count
-    num_iters = math.ceil(n_rows / sm_count)
 
     dX = torch.empty_like(dY2d)
-    # Per-SM partial dW: shape (sm_count, n_cols).
-    # Each SM accumulates dW in registers across its rows, writes once.
-    dW_partial = torch.empty(sm_count, n_cols, dtype=torch.float32, device=W.device)
+    stream = torch.cuda.current_stream()
 
-    grid = (sm_count, 1, 1)
+    dY_c = dY2d.contiguous()
+    dS_out_c = dS_out2d.contiguous()
+    S_c = S2d.contiguous()
+    W_c = W.contiguous()
+
     # gather+latency=3 gives explicit cp.async-style pipelining that outperforms TMA
-    # at every test shape on this kernel. 2-chunk variant caps per-thread register
-    # usage when BLOCK_SIZE > _BWD_MAX_CHUNK_SIZE (splits cols into lo/hi halves).
+    # at every test shape on this kernel.
     if BLOCK_SIZE > _BWD_MAX_CHUNK_SIZE:
+        # Large-shape 2-chunk path: one block per SM, splits cols into lo/hi halves.
+        # These shapes already saturate the SMs and qualify; keep the launch fixed.
         CHUNK_SIZE = BLOCK_SIZE // 2
+        num_iters = math.ceil(n_rows / sm_count)
+        dW_partial = torch.empty(sm_count, n_cols, dtype=torch.float32, device=W.device)
         ct.launch(
-            torch.cuda.current_stream(),
-            grid,
+            stream,
+            (sm_count, 1, 1),
             _fused_add_rms_norm_bwd_persistent_2c_ct_nww8,
             (
-                dY2d.contiguous(),
-                dS_out2d.contiguous(),
+                dY_c,
+                dS_out_c,
                 dX,
-                S2d.contiguous(),
-                W.contiguous(),
+                S_c,
+                W_c,
                 RSTD,
                 dW_partial,
                 int(n_cols),
@@ -559,31 +613,77 @@ def _fused_add_rms_norm_backward_ct(dY, dS_out, S, W, RSTD, offset, casting_mode
                 int(casting_mode),
             ),
         )
-    else:
+        dX = dX.view(*shape)
+        dW = dW_partial.sum(dim=0).to(W.dtype)
+        return dX, dX, dW  # dR == dX (gradient flows equally to X and R)
+
+    # Small-shape 1-chunk path: at small n_cols the one-block-per-SM grid leaves the
+    # SMs under-occupied (memory-latency bound). Tune the effective occupancy
+    # (blocks_per_sm) per shape; the persistent kernel is unchanged — each block just
+    # loops over a smaller slice of rows and writes its own dW partial row.
+    def _launch(kernel, n_blocks, dW_partial):
+        num_iters = math.ceil(n_rows / n_blocks)
         ct.launch(
-            torch.cuda.current_stream(),
-            grid,
-            _fused_add_rms_norm_bwd_persistent_ct_nww8,
+            stream,
+            (n_blocks, 1, 1),
+            kernel,
             (
-                dY2d.contiguous(),
-                dS_out2d.contiguous(),
+                dY_c,
+                dS_out_c,
                 dX,
-                S2d.contiguous(),
-                W.contiguous(),
+                S_c,
+                W_c,
                 RSTD,
                 dW_partial,
                 int(n_cols),
                 float(offset),
                 int(num_iters),
-                int(sm_count),
+                int(n_blocks),
                 int(n_rows),
                 int(BLOCK_SIZE),
                 int(casting_mode),
             ),
         )
 
-    dX = dX.view(*shape)
+    def _args_fn_for_blocks(n_blocks):
+        num_iters = math.ceil(n_rows / n_blocks)
+        dW_partial = torch.empty(n_blocks, n_cols, dtype=torch.float32, device=W.device)
+        return (
+            dY_c,
+            dS_out_c,
+            dX,
+            S_c,
+            W_c,
+            RSTD,
+            dW_partial,
+            int(n_cols),
+            float(offset),
+            int(num_iters),
+            int(n_blocks),
+            int(n_rows),
+            int(BLOCK_SIZE),
+            int(casting_mode),
+        )
+
+    cache_key = (n_cols, BLOCK_SIZE, casting_mode, S.dtype, str(W.device))
+    blocks_per_sm, tuned_kernel = _autotune_bwd_kernel(
+        _fused_add_rms_norm_bwd_persistent_ct,
+        n_rows,
+        n_cols,
+        sm_count,
+        W.device,
+        cache_key,
+        stream,
+        _args_fn_for_blocks,
+        BLOCK_SIZE,
+    )
+
+    n_blocks = min(sm_count * blocks_per_sm, n_rows)
+    dW_partial = torch.empty(n_blocks, n_cols, dtype=torch.float32, device=W.device)
+    _launch(tuned_kernel, n_blocks, dW_partial)
     dW = dW_partial.sum(dim=0).to(W.dtype)
+
+    dX = dX.view(*shape)
     return dX, dX, dW  # dR == dX (gradient flows equally to X and R)
 
 

--- a/src/tilegym/suites/liger/cutile/poly_norm.py
+++ b/src/tilegym/suites/liger/cutile/poly_norm.py
@@ -13,9 +13,13 @@ Reference:
 2. https://arxiv.org/pdf/2411.03884
 """
 
+from types import SimpleNamespace
+
 import cuda.tile as ct
 import torch
+from cuda.tile.tune import exhaustive_search
 
+from tilegym.autotune import is_autotune_disabled
 from tilegym.backend import register_impl
 
 from .utils import next_power_of_2
@@ -112,9 +116,6 @@ def _poly_norm_fwd_kernel(
             ct.scatter(y_output, (row_idx, col_indices), ct.astype(y_f32, x_tile.dtype), check_bounds=True)
 
 
-_poly_norm_fwd_kernel_occ8 = _poly_norm_fwd_kernel.replace_hints(occupancy=8)
-
-
 @ct.kernel(occupancy=4)
 def _poly_norm_fwd_kernel_sc_large(
     x_input,
@@ -170,11 +171,6 @@ def _poly_norm_fwd_kernel_sc_large(
         ct.scatter(y_output, (row_idx, col_indices), ct.astype(y_f32, x_tile2.dtype), check_bounds=False)
     else:
         ct.scatter(y_output, (row_idx, col_indices), ct.astype(y_f32, x_tile2.dtype), check_bounds=True)
-
-
-_poly_norm_fwd_kernel_sc_large_occ4 = _poly_norm_fwd_kernel_sc_large.replace_hints(occupancy=4)
-_poly_norm_fwd_kernel_sc_large_occ8 = _poly_norm_fwd_kernel_sc_large.replace_hints(occupancy=8)
-_poly_norm_fwd_kernel_sc_large_occ16 = _poly_norm_fwd_kernel_sc_large.replace_hints(occupancy=16)
 
 
 @ct.kernel(occupancy=2)
@@ -277,6 +273,86 @@ def _poly_norm_bwd_kernel(
 _poly_norm_bwd_kernel_large = _poly_norm_bwd_kernel.replace_hints(occupancy=4, num_worker_warps=8)
 
 
+# ---------------------------------------------------------------------------
+# Forward schedule autotune (tune-once / cache / launch)
+# ---------------------------------------------------------------------------
+# The best forward (kernel-variant, BLOCK_SIZE, occupancy) triple is
+# shape- and board-dependent, so it is selected by exhaustive_search once per
+# (n_rows, n_cols, dtype, device) and cached. Only forward schedule/config
+# selection depends on this; kernel math, the backward path, and dispatch
+# registration are unaffected.
+_fwd_tune_cache: dict = {}
+
+# Body key -> base @ct.kernel object. "mc" = fold-accumulator multi-chunk kernel
+# (BLOCK_SIZE may be < n_cols); "sc" = single-chunk re-gather kernel (one tile
+# covers the whole row, so BLOCK_SIZE >= n_cols).
+_FWD_BODY = {"mc": _poly_norm_fwd_kernel, "sc": _poly_norm_fwd_kernel_sc_large}
+
+
+def _fwd_configs(n_cols):
+    """Candidate (body_key, BLOCK_SIZE, occupancy) triples for this row width.
+
+    The first entry doubles as the fixed schedule used when autotune is
+    disabled, so is_autotune_disabled() never needs a separately maintained
+    default. Occupancy is higher for narrow tiles (to hide gather latency) and
+    lower for wide tiles (higher per-CTA tile pressure).
+    """
+    np2 = next_power_of_2(n_cols)
+    cfgs = []
+    # Single-chunk: one tile covers the whole row (BLOCK_SIZE >= n_cols).
+    sc_block = min(MAX_FUSED_SIZE, np2)
+    if sc_block >= n_cols:
+        if sc_block <= 2048:
+            sc_occ = (8, 16)
+        elif sc_block <= 4096:
+            sc_occ = (4, 8)
+        else:
+            sc_occ = (2, 4)
+        for occ in sc_occ:
+            cfgs.append(("sc", sc_block, occ))
+    # Multi-chunk fold-accumulator (BLOCK < n_cols): only competitive at wide
+    # rows, and the only usable body when next_pow2(n_cols) > MAX_FUSED_SIZE
+    # leaves no single-chunk tile.
+    mc_blocks = [2048, 4096] if n_cols >= 8192 else []
+    for blk in mc_blocks:
+        for occ in (4, 8):
+            cfgs.append(("mc", blk, occ))
+    return cfgs
+
+
+def _tune_forward(stream, grid, launch_args, n_cols):
+    """Search forward schedules and return (tuned_kernel, BLOCK_SIZE).
+
+    Runs one exhaustive_search per kernel body (each body is a distinct
+    @ct.kernel object, so it cannot share a single search), then keeps the
+    globally fastest measured config. _fwd_configs() always yields at least
+    one candidate per body that has any, so no separate fallback is needed
+    here — same as the other cuTile autotune sites (mla.py, attention_varlen.py).
+    """
+    configs = _fwd_configs(n_cols)
+    best = None  # (mean_us, body_key, BLOCK_SIZE, occupancy)
+    for body_key in ("sc", "mc"):
+        sub = [SimpleNamespace(BLOCK_SIZE=blk, occupancy=occ) for (k, blk, occ) in configs if k == body_key]
+        if not sub:
+            continue
+        base = _FWD_BODY[body_key]
+        with ct.compiler_timeout(60):
+            result = exhaustive_search(
+                sub,
+                stream,
+                lambda cfg: grid,
+                base,
+                lambda cfg: launch_args(cfg.BLOCK_SIZE),
+                lambda cfg: {"occupancy": cfg.occupancy},
+            )
+        m = result.best
+        if best is None or m.mean_us < best[0]:
+            best = (m.mean_us, body_key, m.config.BLOCK_SIZE, m.config.occupancy)
+
+    _, body_key, blk, occ = best
+    return _FWD_BODY[body_key].replace_hints(occupancy=occ), blk
+
+
 class PolyNormCuTileFunction(torch.autograd.Function):
     """
     PolyNorm autograd function with CuTile forward and backward kernels.
@@ -297,62 +373,49 @@ class PolyNormCuTileFunction(torch.autograd.Function):
         bias_shape = B.shape
         B = B.reshape(1)
 
-        # Per-shape BLOCK_SIZE & kernel variant. Single-chunk uses the SC kernel
-        # (re-gather, lower live-tile pressure); multi-chunk uses the fold-accumulator kernel.
-        # n_cols=2048 keeps BLOCK=1024 (multi-chunk) because BLOCK=2048 single-chunk
-        # spills the 3 fp32 accumulators (sum_sq_3/2/1).
-        if n_cols <= 1024:
-            BLOCK_SIZE = next_power_of_2(n_cols)
-        elif n_cols == 2048:
-            BLOCK_SIZE = 1024
-        elif n_cols <= 8192:
-            BLOCK_SIZE = 4096
-        else:
-            BLOCK_SIZE = min(MAX_FUSED_SIZE, next_power_of_2(n_cols))
-        aligned = (n_cols % BLOCK_SIZE) == 0
-        single_chunk = n_cols <= BLOCK_SIZE
-
-        if n_cols <= 1024:
-            fwd_kernel = _poly_norm_fwd_kernel_sc_large_occ16
-        elif n_cols == 2048:
-            fwd_kernel = _poly_norm_fwd_kernel
-        elif n_cols == 4096:
-            fwd_kernel = _poly_norm_fwd_kernel_sc_large_occ8
-        elif n_cols <= 8192:
-            fwd_kernel = _poly_norm_fwd_kernel_occ8
-        elif single_chunk:
-            fwd_kernel = _poly_norm_fwd_kernel_sc_large_occ4
-        else:
-            fwd_kernel = _poly_norm_fwd_kernel
-
         Y = torch.empty_like(X_2d)
         RSTD3 = torch.empty(n_rows, dtype=torch.float32, device=X.device)
         RSTD2 = torch.empty(n_rows, dtype=torch.float32, device=X.device)
         RSTD1 = torch.empty(n_rows, dtype=torch.float32, device=X.device)
 
+        stream = torch.cuda.current_stream()
         grid = (n_rows, 1, 1)
-        ct.launch(
-            torch.cuda.current_stream(),
-            grid,
-            fwd_kernel,
-            (
+        Wc = W.contiguous()
+        Bc = B.contiguous()
+
+        # launch_args(blk): full kernel-arg tuple for a given BLOCK_SIZE. Both
+        # forward bodies share this signature, so autotune and the final launch
+        # reuse it. aligned=True (hardware TMA path) whenever BLOCK_SIZE divides
+        # n_cols evenly.
+        def launch_args(blk):
+            return (
                 X_2d,
                 Y,
-                W.contiguous(),
-                B.contiguous(),
+                Wc,
+                Bc,
                 RSTD3,
                 RSTD2,
                 RSTD1,
                 int(n_cols),
                 float(eps),
-                int(BLOCK_SIZE),
-                bool(aligned),
-            ),
-        )
+                int(blk),
+                bool((n_cols % blk) == 0),
+            )
+
+        # Per-shape schedule autotune: tune once, cache the winning specialized
+        # kernel + BLOCK_SIZE, then launch directly on every later call.
+        if is_autotune_disabled():
+            body_key, BLOCK_SIZE, occ = _fwd_configs(n_cols)[0]
+            fwd_kernel = _FWD_BODY[body_key].replace_hints(occupancy=occ)
+        else:
+            cache_key = (n_rows, n_cols, X_2d.dtype, str(X_2d.device))
+            if cache_key not in _fwd_tune_cache:
+                _fwd_tune_cache[cache_key] = _tune_forward(stream, grid, launch_args, n_cols)
+            fwd_kernel, BLOCK_SIZE = _fwd_tune_cache[cache_key]
+
+        ct.launch(stream, grid, fwd_kernel, launch_args(BLOCK_SIZE))
 
         ctx.save_for_backward(X_2d, W, RSTD3, RSTD2, RSTD1)
-        ctx.BLOCK_SIZE = BLOCK_SIZE
-        ctx.aligned = aligned
         ctx.shape = shape
         ctx.bias_shape = bias_shape
 

--- a/tests/ops/test_attention_variant.py
+++ b/tests/ops/test_attention_variant.py
@@ -930,6 +930,34 @@ class Test_FMHA_variant(common.PyTestCase):
                 seed=seed,
                 window_size=window_size,
             )
+        elif backend == "tilecpp":
+            if not is_backend_available("tilecpp"):
+                pytest.skip("TileCpp backend not available")
+            if dtype == torch.float8_e5m2:
+                pytest.skip("Skip float8_e5m2 due to tilecpp not support float8")
+            if dropout > 0:
+                pytest.skip("TileCpp does not support dropout with deterministic random generation")
+            if seq_len >= 2**13 and (bias_type == "matrix" or use_random_mask):
+                # 8192-seqlen matrix bias and random-mask shapes are outside the
+                # shape set this backend is validated on.
+                pytest.skip("TileCpp: 8192-seqlen matrix bias / random mask is not covered")
+            set_backend("tilecpp")
+            backend_fn = lambda: fmha_variant(
+                q=q,
+                k=k,
+                v=v,
+                q_lens=q_lens,
+                kv_lens=kv_lens,
+                scaling=sm_scale,
+                dropout=dropout,
+                layout=layout,
+                random_mask=triton_mask,
+                is_causal=is_causal,
+                bias=triton_bias,
+                bias_type=bias_type,
+                seed=seed,
+                window_size=window_size,
+            )
         else:
             pytest.skip(f"Backend {backend} not supported")
 

--- a/tests/ops/test_layer_norm_legacy.py
+++ b/tests/ops/test_layer_norm_legacy.py
@@ -128,7 +128,9 @@ class Test_PersistentLayerNorm(common.PyTestCase):
         ],
     )
     @pytest.mark.parametrize("backend", _backends)
-    def test_op(self, m, n, dtype, backend):
+    def test_op(self, m, n, dtype, backend, arch):
+        if backend == "tilecpp" and arch in ["sm120", "sm121"] and n == 1024:
+            pytest.skip("Skip on sm120, sm121: tilecpp kernel compilation hangs at n=1024.")
         try:
             set_backend(backend)
         except Exception as e:

--- a/tests/suites/flashinfer/test_flashinfer_gemm_alpha_beta.py
+++ b/tests/suites/flashinfer/test_flashinfer_gemm_alpha_beta.py
@@ -41,7 +41,12 @@ class Test_FlashInfer_Matmul_Alpha_Beta(common.PyTestCase):
 
         return a, b
 
-    @pytest.mark.parametrize("framework", ["cutile"])  # cutile only; other backends OOM on all configs on this GPU
+    @pytest.mark.parametrize(
+        "framework",
+        [
+            "cutile",  # cutile only; other backends OOM on all configs on this GPU
+        ],
+    )
     @pytest.mark.parametrize("m, n, k", [(4096, 4096, 4096), (8192, 8192, 8192)])
     @pytest.mark.parametrize(
         "dtype, out_dtype",

--- a/wiki/cutile-knowledge-wiki/kernels/kernel-softmax.md
+++ b/wiki/cutile-knowledge-wiki/kernels/kernel-softmax.md
@@ -47,12 +47,13 @@ the narrow end; in between, fp32 `exp` throughput and the reduction dependency c
   statistic pass adds a full row read. Choosing the pass structure by row width is the
   single largest lever, worth more than any tuning knob once rows exceed register residency.
 - **Occupancy tiering by row width.** Wider rows mean bigger tiles, more registers/SMEM per CTA,
-  fewer resident CTAs. The cuTile kernels pin occupancy per variant — `occupancy=4` on the narrow
-  gather-persistent kernel, `occupancy=2` on the full-row TMA kernel — and hosts size
-  persistent grids to match (`min(NUM_SM * 4, n_rows)` for the narrow kernel, `NUM_SM * 2` for the
-  TMA path; all in `cutile/softmax.py`). The
-  invariant: the right occupancy falls as row width grows; one fixed setting either starves narrow
-  rows of parallelism or spills wide rows.
+  fewer resident CTAs. The cuTile kernels pin occupancy per variant. The narrow gather-persistent
+  kernel uses occupancy 4; the full-row TMA path searches a small set on first use and caches the
+  winner per device, dtype, and shape. The host uses the selected value for both the compiler hint
+  and persistent-grid multiplier (`min(NUM_SM * occupancy, n_rows)`; all in `cutile/softmax.py`).
+  Register and shared-memory pressure generally favor lower occupancy as row width grows, but the
+  winner can be non-monotonic because grid-wave and compiler effects also matter. Autotuning adapts
+  those effects to the installed compiler instead of encoding version-specific shape tiers.
 - **Routing between kernel variants.** The repo keeps several forward kernels alive simultaneously —
   gather-persistent, one-CTA-per-row register-cached, full-row TMA persistent, chunked
   three-pass — because each wins in a row-width band, and the host routes among them
@@ -73,9 +74,9 @@ the narrow end; in between, fp32 `exp` throughput and the reduction dependency c
 
 ## Applicable techniques
 - **Persistent grid-stride scheduling** (`tech-persistent-grid`) — decouples grid size from `n_rows`;
-  pair the grid multiple with the kernel's pinned occupancy.
-- **Occupancy pinning / tiering** (`tech-occupancy`) — set occupancy per row-width band instead of
-  accepting the compiler default; wide-row tiles at high occupancy spill.
+  pair the grid multiple with the kernel's selected occupancy.
+- **Occupancy autotuning** (`tech-occupancy`) — search a bounded set and cache the winner instead of
+  accepting the compiler default or encoding compiler-version-specific shape tiers.
 - **TMA vs gather loads** (`tech-tma-load`) — full-row `ct.load` with padding mode vs `ct.gather` with
   index tiles; both paths exist per variant and the winner is width-dependent.
 - **Compile-time bounds-check elision** — route exact power-of-two widths to a check-free


### PR DESCRIPTION
<!--- SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved. --->

<!--- SPDX-License-Identifier: MIT --->

## Description
<!-- Describe your changes here -->

Update codes.

This PR contains **20** new commit(s).

### Commits included:

```
20eae35 Unify cuTile SwiGLU forward kernel via check_bounds param
8ad1456 Arch-aware cuTile MLA decode tiling
8463f12 Bound cuTile fmha_variant causal KV loop and skip redundant masks
dbd1708 Tune cuTile FusedAddRMSNorm backward at small shapes
eca96a6 flashinfer prefill ragged: autotune the KV loop structure
9855756 perf(tilecpp): state the TMA shape facts for mla_decoding, rope and softmax
3e8058e Performance matching for several Tile C++ ops
1897c2e Vectorize and parallelize cuTile moe_align_block
66b7de2 cuTile: add narrow-K sm100 tile for skinny fp32 matmul
29ceba8 Autotune cuTile PolyNorm forward schedule selection
3b74f10 Speed up cuTile GeLU tanh with precise ct.tanh and adaptive tiling
ddb9075 cuTile: add skinny-GEMM sm100 autotune tiles
de2e51e Add silu occupancy tuning
6ea81bc Tune cuTile BMM pipelining depth and config space on sm100
c01bce5 fix(tilecpp): follow the project-wide autotune switch
906d4ae style(tests): reformat the gemm_alpha_beta framework parametrize list
0026bc3 perf(cutile): tune SM100 softmax occupancy
5d8a194 perf(flashinfer/cutile): gate per-expert ragged block-scaled BMM schedule on imbalance
75ced71 perf(flashinfer/cutile): arch-gate prefill-ragged two-loop causal split
32bbfb6 test(perf): tilecpp perf parity with cutile
```

## CI Configuration
<!-- Configure what to run in CI. Do not modify the structure below. -->
```yaml
config:
  build: true
  # valid options are "ops" and "benchmark"
  test: ["ops", "benchmark"]
```

## Checklist
- [ ] Code formatted and imports sorted via repo specifications (`./format.sh`)
- [ ] Documentation updated (if needed)
- [ ] CI configuration reviewed

